### PR TITLE
chore(deps): Zarf v0.31.0

### DIFF
--- a/.github/workflows/build-and-test-bundle.yaml
+++ b/.github/workflows/build-and-test-bundle.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: defenseunicorns/setup-zarf@main
         with:
           # renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=semver
-          version: v0.30.1
+          version: v0.31.0
           download-init-package: true
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: defenseunicorns/setup-zarf@main
         with:
           # renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=semver
-          version: v0.31.0-rc1
+          version: v0.31.0
           download-init-package: true
 
       - name: Use Node.js latest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The core applications are:
 
 | Dependency                                                     | Minimum Version |
 | -------------------------------------------------------------- | --------------- |
-| [Zarf](https://github.com/defenseunicorns/zarf/releases)       | 0.30.x          |
+| [Zarf](https://github.com/defenseunicorns/zarf/releases)       | 0.31.x          |
 | [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) | 0.7.x           |
 | [NodeJS](https://nodejs.org/en/download/)                      | LTS or Current  |
 

--- a/capabilities/istio/.github/zarf-runner/deploy/zarf.yaml
+++ b/capabilities/istio/.github/zarf-runner/deploy/zarf.yaml
@@ -18,7 +18,7 @@ components:
             cmd: |
               ARCH=$(uname -m)
               [ "$ARCH" = "x86_64" ] && ARCH="amd64"
-              ./zarf p d oci://ghcr.io/defenseunicorns/packages/init:v0.31.0-rc1-$ARCH --confirm
+              ./zarf p d oci://ghcr.io/defenseunicorns/packages/init:v0.31.0-$ARCH --confirm
           - description: Deploy the istio
             cmd: |
               ARCH=$(uname -m)

--- a/capabilities/neuvector/README.md
+++ b/capabilities/neuvector/README.md
@@ -16,7 +16,7 @@
 
 ## Prerequisites
 
-1. zarf >= 0.30.1
+1. zarf >= 0.31.x
 2. docker or alternative
 3. k3d
 


### PR DESCRIPTION
## Description

Sync zarf 0.30/0.31 rc -> 0.31.0. This introduces kubecontext fixes from Zarf as well as the `only.filter`