### PR TITLE
fix: correct incomplete deploy task

### DIFF
--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -16,7 +16,7 @@ tasks:
       - description: "Deploy the UDS Core Istio Only Example Bundle"
         cmd: |
           export ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          uds deploy examples/k3d-istio-only/ k3d-uds-core-istio-only- --confirm --no-progress"
+          uds deploy examples/k3d-istio-only/uds-bundle-k3d-uds-core-istio-only-${ARCH}-*.tar.zst --confirm --no-progress
 
       - task: out-of-band-tls-certs
 


### PR DESCRIPTION
## Description

The `example-bundle-k3d-istio-only` task in `tasks/deploy.yaml` was incomplete
...

## Related Issue

n/a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed