### PR TITLE
ci: add timeout limit for job so paid large runners dont accrue usage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   test:
     runs-on: "${{ inputs.capability == 'all' && 'uds-ubuntu-big-boy-4-core' || 'ubuntu-latest'}}"
+    timeout-minutes: 30
     name: Test
     env:
       CAPABILITY: ${{ inputs.capability }}


### PR DESCRIPTION
add timeout limit for job so paid large runners dont accrue usage when there is an issue

## Description

...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed