### PR TITLE
refactor: utilize uds task includes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,11 +41,11 @@ jobs:
 
       - name: Test a single source package
         if: ${{ inputs.package != 'all' }}
-        run: uds run -f tasks/test.yaml single-package
+        run: uds run test-single-package
 
       - name: Test UDS Core
         if: ${{ inputs.package == 'all' }}
-        run: uds run -f tasks/test.yaml uds-core
+        run: uds run test-uds-core
 
       - name: Save logs
         if: always()

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,11 @@
   },
   "yaml.schemas": {
     // renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.3.0/uds.schema.json": [
+      "uds-bundle.yaml"
+    ],
+
+    // renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
     "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.3.0/tasks.schema.json": [
       "tasks.yaml",
       "tasks/**/*.yaml",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The core applications are:
 
 ### Quickstart
 
-A common need is bootstrapping a new UDS Core environment for development or testing. The commands below will deploy the latest version of UDS Core. See the remaining sections for more details if the different bundles & packages available.
+A common need is bootstrapping a new UDS Core environment for development or testing. The commands below will deploy the latest version of UDS Core. See the remaining sections for more details on the different bundles and packages available.
 
 ```bash
 # ARM version

--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ The core applications are:
 
 ### Quickstart
 
-A common need is bootrapping a new UDS Core environment for development or testing. The command below will deploy a local K3d cluster with UDS Core on a Mac M1. See the remaining sections for more details if the different bundles & packages available.
+A common need is bootstrapping a new UDS Core environment for development or testing. The commands below will deploy the latest version of UDS Core. See the remaining sections for more details if the different bundles & packages available.
 
 ```bash
-uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core:0.1.3-arm64
+# ARM version
+uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core:arm64
+
+# AMD version
+uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core:amd64
 ```
 
 The bundle includes the uds.dev certs by default. To use custom certs, you can set the appropriate env variables and run
@@ -69,8 +73,10 @@ Thes bundles are intended for boostrapping common development & testing environm
 
 For complete testing, we test against a UDS Bundle that uses a locally-built Zarf package. Manually testing against the packages found under `/packages` is also possible using the `zarf` command.
 
+#### Create, build, and test the UDS Core Package
+
 ```bash
-uds run -f tasks/test.yaml uds-core
+uds run test-uds-core
 ```
 
 ## Working with an individual package
@@ -80,22 +86,22 @@ The individual packages that make up UDS Core are broken down in `src/`, the com
 #### Create, build, and test a single package (e.g. Neuvector)
 
 ```bash
-UDS_PKG=neuvector uds run -f tasks/test.yaml single-package
+UDS_PKG=neuvector uds run test-single-package
 ```
 
 #### To build a single package (e.g. Neuvector)
 
 ```bash
-UDS_PKG=neuvector uds run -f tasks/create.yaml single-package
+UDS_PKG=neuvector uds run create-single-package
 ```
 
 #### To deploy a single built package (e.g. Neuvector)
 
 ```bash
-UDS_PKG=neuvector uds run -f tasks/deploy.yaml single-package
+UDS_PKG=neuvector uds run deploy-single-package
 ```
 
-#### To test a single package (e.g. Neuvector)
+#### To test a single package already deployed (e.g. Neuvector)
 
 ```bash
 uds run -f src/neuvector/tasks/validate.yaml run

--- a/src/test/validate.yaml
+++ b/src/test/validate.yaml
@@ -23,13 +23,15 @@ tasks:
         wait:
           network:
             protocol: https
-            address: demo.admin.uds.dev
+            address: demo.admin.uds.dev/status/202
+            code: 202
 
       - description: Verify the tenant app is accessible
         wait:
           network:
             protocol: https
-            address: demo.uds.dev
+            address: demo.uds.dev/status/202
+            code: 202
 
       - description: Remove the test resources
         cmd: "kubectl delete -f 'src/test/app-*.yaml' --wait=false"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,0 +1,30 @@
+includes:
+  - create: ./tasks/create.yaml
+  - setup: ./tasks/setup.yaml
+  - deploy: ./tasks/deploy.yaml
+  - test: ./tasks/test.yaml
+
+tasks:
+  - name: setup-cluster
+    actions:
+      - task: setup:k3d-test-cluster
+
+  - name: create-single-package
+    actions:
+      - task: create:single-package
+
+  - name: create-standard-package
+    actions:
+      - task: create:standard-package
+
+  - name: deploy-single-package
+    actions:
+      - task: deploy:single-package
+
+  - name: test-single-package
+    actions:
+      - task: test:single-package
+
+  - name: test-uds-core
+    actions:
+      - task: test:uds-core

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -1,5 +1,6 @@
 tasks:
   - name: standard-package
+    description: "Create the UDS Core Zarf Package"
     actions:
       - task: pepr-build
 
@@ -7,11 +8,13 @@ tasks:
         cmd: "zarf package create packages/standard --confirm"
 
   - name: k3d-standard-bundle
+    description: "Create the K3d-UDS Core Bundle"
     actions:
       - description: "Create the UDS Core Standard Bundle"
         cmd: "uds create bundles/k3d-standard --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}"
 
   - name: istio-package
+    description: "Create the UDS Core (Istio Only) Zarf Package"
     actions:
       - task: pepr-build
 
@@ -19,11 +22,13 @@ tasks:
         cmd: "zarf package create packages/istio --confirm"
 
   - name: k3d-istio-bundle
+    description: "Create the K3d-UDS Core (Istio Only) Bundle"
     actions:
       - description: "Create the UDS Core Istio Only Bundle"
         cmd: "uds create bundles/k3d-istio --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}"
 
   - name: single-package
+    description: "Create a single Zarf Package, must set UDS_PKG environment variable"
     actions:
       - task: pepr-build
 
@@ -34,6 +39,7 @@ tasks:
         cmd: "zarf package create src/${UDS_PKG} --confirm"
 
   - name: pepr-build
+    description: "Build the UDS Core Pepr Module"
     actions:
       - description: "Build the UDS Core Pepr Module"
         cmd: |

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -26,9 +26,11 @@ tasks:
 
   - name: single-package
     actions:
-        # @todo (jeff): this pepr package versioning is still janky
+      # @todo (jeff): this pepr package versioning is still janky
       - description: "Deploy the requested Zarf Package (must set UDS_PKG environment variable)"
         cmd: |
           set -e
           zarf package deploy build/zarf-package-uds-core-${UDS_PKG}-${UDS_ARCH}.tar.zst --confirm
-          zarf package deploy build/zarf-package-pepr-uds-core-${UDS_ARCH}-0.2.0.tar.zst --confirm || true
+
+          peprBuild="build/zarf-package-pepr-uds-core-${UDS_ARCH}-0.2.0.tar.zst"
+          [ -f "${peprBuild}" ] && zarf package deploy "${peprBuild}" --confirm || echo "Pepr build not required"

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -54,3 +54,10 @@ tasks:
           uds publish bundles/k3d-standard/uds-bundle-k3d-core-arm64-${VERSION}.tar.zst ${TARGET_REPO}/bundles --no-progress
           uds publish bundles/k3d-istio/uds-bundle-k3d-core-istio-amd64-${VERSION}.tar.zst ${TARGET_REPO}/bundles --no-progress
           uds publish bundles/k3d-istio/uds-bundle-k3d-core-istio-arm64-${VERSION}.tar.zst ${TARGET_REPO}/bundles --no-progress
+
+      - description: "Tag the latest bundles"
+        cmd: |
+          set -e
+          pkgPath="ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core"
+          zarf tools registry copy ${pkgPath}:${VERSION}-arm64 ${pkgPath}:arm64
+          zarf tools registry copy ${pkgPath}:${VERSION}-amd64 ${pkgPath}:amd64

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -1,15 +1,15 @@
+includes:
+  - create: ./tasks/create.yaml
+  - setup: ./tasks/setup.yaml
+  - deploy: ./tasks/deploy.yaml
+
 tasks:
   - name: single-package
     description: "Build and test a single package, must set UDS_PKG environment variable"
     actions:
-      - description: "Create the package"
-        cmd: uds run -f tasks/create.yaml single-package --no-progress
-
-      - description: "Create the K3d cluster"
-        cmd: uds run -f tasks/setup.yaml k3d-test-cluster --no-progress
-
-      - description: "Deploy the package"
-        cmd: uds run -f tasks/deploy.yaml single-package --no-progress
+      - task: create:single-package
+      - task: setup:k3d-test-cluster
+      - task: deploy:single-package
 
       - description: "Validate the package"
         cmd: uds run -f src/${UDS_PKG}/validate.yaml run --no-progress
@@ -17,17 +17,10 @@ tasks:
   - name: uds-core
     description: "Build and test UDS Core"
     actions:
-      - description: "Create the UDS Core Standard Zarf Package"
-        cmd: uds run -f tasks/create.yaml standard-package --no-progress
-
-      - description: "Create the UDS Core Istio Only Zarf Package (create only to validate)"
-        cmd: uds run -f tasks/create.yaml istio-package --no-progress
-
-      - description: "Create the UDS Core Standard Bundle"
-        cmd: uds run -f tasks/create.yaml k3d-standard-bundle --no-progress
-
-      - description: "Deploy the UDS Core Standard Bundle"
-        cmd: uds run -f tasks/deploy.yaml k3d-standard-bundle --no-progress
+      - task: create:standard-package
+      - task: create:istio-package
+      - task: create:k3d-standard-bundle
+      - task: deploy:k3d-standard-bundle
 
       - description: "Validated all packages"
         # loop through each src/* package and run the validate.yaml task


### PR DESCRIPTION
## Description

Use task includes where possible (env vars cant be passed into includes inline so publish.yaml couldn't use it right now). Also provides a top-level task file to do clean commands such as:

```bash
uds run test-uds-core
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed