### PR TITLE
feat: expose tls certs as UDS bundle variables

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -27,4 +27,4 @@ runs:
     - name: Install UDS CLI
       shell: bash
       # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-      run: brew install defenseunicorns/tap/uds@0.3.0
+      run: brew install defenseunicorns/tap/uds@0.3.1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,12 +8,12 @@
   },
   "yaml.schemas": {
     // renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.3.0/uds.schema.json": [
+    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.3.1/uds.schema.json": [
       "uds-bundle.yaml"
     ],
 
     // renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.3.0/tasks.schema.json": [
+    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.3.1/tasks.schema.json": [
       "tasks.yaml",
       "tasks/**/*.yaml",
       "src/**/validate.yaml"

--- a/README.md
+++ b/README.md
@@ -47,10 +47,20 @@ uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core:arm64
 uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core:amd64
 ```
 
-The bundle includes the uds.dev certs by default. To use custom certs, you can set the appropriate env variables and run
+The bundle includes the uds.dev certs by default. You can use the bundle variables to override the default values. E.g. 
 
-```bash
-npx ts-node bundles/tls-certs.ts
+```yaml
+# uds-config.yaml
+bundle:
+  deploy:
+    zarf-packages:
+      core:
+        set:
+          # Be sure to pre-base64 encode the certs and keys
+          ADMIN_TLS_CERT: <base64 encoded cert>
+          ADMIN_TLS_KEY: <base64 encoded key>
+          TENANT_TLS_CERT: <base64 encoded cert>
+          TENANT_TLS_KEY: <base64 encoded key>
 ```
 
 ### UDS Core Packages

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The core applications are:
 | Dependency                                                     | Minimum Version |
 | -------------------------------------------------------------- | --------------- |
 | [Zarf](https://github.com/defenseunicorns/zarf/releases)       | 0.31.1          |
-| [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) | 0.3.0           |
+| [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) | 0.3.1           |
 | [NodeJS](https://nodejs.org/en/download/)                      | LTS or Current  |
 
 <!-- endtable -->

--- a/bundles/k3d-istio/uds-bundle.yaml
+++ b/bundles/k3d-istio/uds-bundle.yaml
@@ -22,3 +22,17 @@ zarf-packages:
     # x-release-please-start-version
     ref: 0.4.1
     # x-release-please-end
+    overrides:
+      variables:
+        - name: ADMIN_TLS_CERT
+          description: "The TLS cert for the admin gateway (must be base64 encoded)"
+          path: istio-admin-gateway/uds-istio-config/tls.cert
+        - name: ADMIN_TLS_KEY
+          description: "The TLS key for the admin gateway (must be base64 encoded)"
+          path: istio-admin-gateway/uds-istio-config/tls.key
+        - name: TENANT_TLS_CERT
+          description: "The TLS cert for the tenant gateway (must be base64 encoded)"
+          path: istio-tenant-gateway/uds-istio-config/tls.cert
+        - name: TENANT_TLS_KEY
+          description: "The TLS key for the tenant gateway (must be base64 encoded)"
+          path: istio-tenant-gateway/uds-istio-config/tls.key

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -22,3 +22,17 @@ zarf-packages:
     # x-release-please-start-version
     ref: 0.4.1
     # x-release-please-end
+    overrides:
+      variables:
+        - name: ADMIN_TLS_CERT
+          description: "The TLS cert for the admin gateway (must be base64 encoded)"
+          path: istio-admin-gateway/uds-istio-config/tls.cert
+        - name: ADMIN_TLS_KEY
+          description: "The TLS key for the admin gateway (must be base64 encoded)"
+          path: istio-admin-gateway/uds-istio-config/tls.key
+        - name: TENANT_TLS_CERT
+          description: "The TLS cert for the tenant gateway (must be base64 encoded)"
+          path: istio-tenant-gateway/uds-istio-config/tls.cert
+        - name: TENANT_TLS_KEY
+          description: "The TLS key for the tenant gateway (must be base64 encoded)"
+          path: istio-tenant-gateway/uds-istio-config/tls.key


### PR DESCRIPTION
## Description

This PR leverages the new UDS Helm Variables mapping introduce in [UDS CLI v0.3.0](https://github.com/defenseunicorns/uds-cli/releases/tag/v0.3.0). While this is currently at the bundle-level, this should eventually make it down to the Zarf level. However, for UDS deployers, the change will be transparent.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed