### PR TITLE
fix: resolve istio job termination container status logic issue

### DIFF
--- a/src/istio/pepr/istio-job-termination.ts
+++ b/src/istio/pepr/istio-job-termination.ts
@@ -15,10 +15,11 @@ When(a.Pod)
   .WithLabel("batch.kubernetes.io/job-name")
   .WithLabel("service.istio.io/canonical-name")
   .Watch(async pod => {
-    if (!pod.metadata?.name || !pod.metadata.namespace || !pod.status?.containerStatuses) {
+    if (!pod.metadata?.name || !pod.metadata.namespace ) {
       Log.error(pod, `Invalid Pod definition`);
       return;
     }
+
 
     const { name, namespace } = pod.metadata;
     const key = `${namespace}/${name}`;
@@ -29,8 +30,12 @@ When(a.Pod)
     }
 
     // Only terminate if the pod is running
-    if (pod.status.phase == "Running") {
+    if (pod.status?.phase == "Running") {
       // Check all container statuses
+      if (!pod.status.containerStatuses) {
+        Log.error(pod, `Invalid container status in Pod`);
+        return;
+      }
       const shouldTerminate = pod.status.containerStatuses
         // Ignore the istio-proxy container
         .filter(c => c.name != "istio-proxy")


### PR DESCRIPTION
## Description

Resolve logic bug where job termination was not functioning correctly because containerStatuses field doesnt exist when pod.status.phase is pending.

## Related Issue

Fixes [#54](https://github.com/defenseunicorns/uds-core/issues/54)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed