### PR TITLE
feat: update security policy to use provided user, group, and fsgroup

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -27,4 +27,4 @@ runs:
     - name: Install UDS CLI
       shell: bash
       # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-      run: brew install defenseunicorns/tap/uds@0.4.1
+      run: brew install defenseunicorns/tap/uds@0.5.2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,12 +8,12 @@
   },
   "yaml.schemas": {
     // renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.4.1/uds.schema.json": [
+    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.5.2/uds.schema.json": [
       "uds-bundle.yaml"
     ],
 
     // renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.4.1/tasks.schema.json": [
+    "https://raw.githubusercontent.com/defenseunicorns/uds-cli/v0.5.2/tasks.schema.json": [
       "tasks.yaml",
       "tasks/**/*.yaml",
       "src/**/validate.yaml"

--- a/bundles/k3d-istio/uds-bundle.yaml
+++ b/bundles/k3d-istio/uds-bundle.yaml
@@ -6,7 +6,7 @@ metadata:
   version: "0.6.2"
   # x-release-please-end
 
-zarf-packages:
+packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
     # renovate: datasource=github-tags depName=defenseunicorns/uds-k3d versioning=semver

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -6,7 +6,7 @@ metadata:
   version: "0.6.2"
   # x-release-please-end
 
-zarf-packages:
+packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
     # renovate: datasource=github-tags depName=defenseunicorns/uds-k3d versioning=semver

--- a/src/policies/security.ts
+++ b/src/policies/security.ts
@@ -78,7 +78,7 @@ When(a.Pod)
       pod.securityContext.runAsGroup = parseInt(runAsGroup)
     }
 
-    // Set the rsGroup field if it is defined in a label
+    // Set the fsGroup field if it is defined in a label
     const fsGroup = metadata.labels?.["uds/fsgroup"]
     if (fsGroup) {
       pod.securityContext.fsGroup = parseInt(fsGroup)

--- a/src/policies/security.ts
+++ b/src/policies/security.ts
@@ -83,15 +83,15 @@ When(a.Pod)
       pod.securityContext.runAsNonRoot = true;
     }
 
-    // Set the runAsUser field to 1000 if it is undefined
-    if (pod.securityContext.runAsUser === undefined) {
-      pod.securityContext.runAsUser = 1000;
-    }
+    // // Set the runAsUser field to 1000 if it is undefined
+    // if (pod.securityContext.runAsUser === undefined) {
+    //   pod.securityContext.runAsUser = 1000;
+    // }
 
-    // Set the runAsGroup field to 1000 if it is undefined
-    if (pod.securityContext.runAsGroup === undefined) {
-      pod.securityContext.runAsGroup = 1000;
-    }
+    // // Set the runAsGroup field to 1000 if it is undefined
+    // if (pod.securityContext.runAsGroup === undefined) {
+    //   pod.securityContext.runAsGroup = 1000;
+    // }
   })
   .Validate(request => {
     if (exemptPrivileged(request)) {

--- a/src/policies/security.ts
+++ b/src/policies/security.ts
@@ -72,7 +72,7 @@ When(a.Pod)
       pod.securityContext.runAsUser = parseInt(runAsUser)
     }
 
-    // Set the runAsUser field if it is defined in a label
+    // Set the runAsGroup field if it is defined in a label
     const runAsGroup = metadata.labels?.["uds/group"]
     if (runAsGroup) {
       pod.securityContext.runAsGroup = parseInt(runAsGroup)

--- a/src/policies/security.ts
+++ b/src/policies/security.ts
@@ -79,19 +79,19 @@ When(a.Pod)
     }
 
     // Set the runAsNonRoot field to true if it is undefined
-    // if (pod.securityContext.runAsNonRoot === undefined) {
-    //   pod.securityContext.runAsNonRoot = true;
-    // }
+    if (pod.securityContext.runAsNonRoot === undefined) {
+      pod.securityContext.runAsNonRoot = true;
+    }
 
-    // // Set the runAsUser field to 1000 if it is undefined
-    // if (pod.securityContext.runAsUser === undefined) {
-    //   pod.securityContext.runAsUser = 1000;
-    // }
+    // Set the runAsUser field to 1000 if it is undefined
+    if (pod.securityContext.runAsUser === undefined) {
+      pod.securityContext.runAsUser = 1000;
+    }
 
-    // // Set the runAsGroup field to 1000 if it is undefined
-    // if (pod.securityContext.runAsGroup === undefined) {
-    //   pod.securityContext.runAsGroup = 1000;
-    // }
+    // Set the runAsGroup field to 1000 if it is undefined
+    if (pod.securityContext.runAsGroup === undefined) {
+      pod.securityContext.runAsGroup = 1000;
+    }
   })
   .Validate(request => {
     if (exemptPrivileged(request)) {

--- a/src/policies/security.ts
+++ b/src/policies/security.ts
@@ -79,9 +79,9 @@ When(a.Pod)
     }
 
     // Set the runAsNonRoot field to true if it is undefined
-    if (pod.securityContext.runAsNonRoot === undefined) {
-      pod.securityContext.runAsNonRoot = true;
-    }
+    // if (pod.securityContext.runAsNonRoot === undefined) {
+    //   pod.securityContext.runAsNonRoot = true;
+    // }
 
     // // Set the runAsUser field to 1000 if it is undefined
     // if (pod.securityContext.runAsUser === undefined) {

--- a/src/policies/security.ts
+++ b/src/policies/security.ts
@@ -61,9 +61,22 @@ When(a.Pod)
     }
 
     const pod = request.Raw.spec!;
+    const metadata = request.Raw.metadata || {};
 
     // Ensure the securityContext field is defined
     pod.securityContext = pod.securityContext || {};
+
+    // Set the runAsUser field if it is defined in a label
+    const runAsUser = metadata.labels?.["uds/user"]
+    if (runAsUser) {
+      pod.securityContext.runAsUser = parseInt(runAsUser)
+    }
+
+    // Set the runAsUser field if it is defined in a label
+    const runAsGroup = metadata.labels?.["uds/group"]
+    if (runAsGroup) {
+      pod.securityContext.runAsGroup = parseInt(runAsGroup)
+    }
 
     // Set the runAsNonRoot field to true if it is undefined
     if (pod.securityContext.runAsNonRoot === undefined) {

--- a/src/policies/security.ts
+++ b/src/policies/security.ts
@@ -78,6 +78,12 @@ When(a.Pod)
       pod.securityContext.runAsGroup = parseInt(runAsGroup)
     }
 
+    // Set the rsGroup field if it is defined in a label
+    const fsGroup = metadata.labels?.["uds/fsgroup"]
+    if (fsGroup) {
+      pod.securityContext.fsGroup = parseInt(fsGroup)
+    }
+
     // Set the runAsNonRoot field to true if it is undefined
     if (pod.securityContext.runAsNonRoot === undefined) {
       pod.securityContext.runAsNonRoot = true;


### PR DESCRIPTION
## Description

When establishing the security context for a pod, Pepr security policy will look for labels to specify the runAsUser, runAsGroup, and/or fsGroup and use those values.

## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed