### PR TITLE
fix: wait on istio proxies

### DIFF
--- a/src/istio/values/values.yaml
+++ b/src/istio/values/values.yaml
@@ -2,3 +2,5 @@ global:
   variant: distroless
 meshConfig:
   accessLogFile: /dev/stdout
+  defaultConfig:
+    holdApplicationUntilProxyStarts: true


### PR DESCRIPTION
## Description

This seems to be a common default across most istio installs (including Big Bang). The effect is just to make sure that the main "app" containers don't start until proxies are up.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/69

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed