### PR TITLE
chore: simplify promtail values for scrape configs

### DIFF
--- a/src/promtail/values/values.yaml
+++ b/src/promtail/values/values.yaml
@@ -3,73 +3,7 @@ config:
     - url: 'http://loki-gateway.loki.svc.cluster.local:80/loki/api/v1/push'
 
   snippets:
-    scrapeConfigs: >
-      - job_name: kubernetes-pods
-        pipeline_stages:
-          - cri: {}
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          - source_labels:
-              - __meta_kubernetes_pod_node_name
-            target_label: __host__
-          - action: labelmap
-            regex: __meta_kubernetes_pod_label_(.+)
-          - action: replace
-            replacement: $1
-            separator: /
-            source_labels:
-              - __meta_kubernetes_namespace
-              - __meta_kubernetes_pod_name
-            target_label: job
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_namespace
-            target_label: namespace
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_pod_name
-            target_label: pod
-          - action: replace
-            source_labels:
-              - __meta_kubernetes_pod_container_name
-            target_label: container
-          - replacement: /var/log/pods/*$1/*.log
-            separator: /
-            source_labels:
-              - __meta_kubernetes_pod_uid
-              - __meta_kubernetes_pod_container_name
-            target_label: __path__
-          - action: replace
-            source_labels:
-            - __meta_kubernetes_pod_node_name
-            target_label: node_name
-          - action: replace
-            source_labels:
-            - __meta_kubernetes_namespace
-            target_label: namespace
-          - action: replace
-            replacement: $1
-            separator: /
-            source_labels:
-            - namespace
-            - app
-            target_label: job
-          - action: replace
-            source_labels:
-            - __meta_kubernetes_pod_name
-            target_label: pod
-          - action: replace
-            source_labels:
-            - __meta_kubernetes_pod_container_name
-            target_label: container
-          - action: replace
-            replacement: /var/log/pods/*$1/*.log
-            separator: /
-            source_labels:
-            - __meta_kubernetes_pod_uid
-            - __meta_kubernetes_pod_container_name
-            target_label: __path__
+    extraScrapeConfigs: >
       - job_name: systemd-messages
         static_configs:
           - targets: [localhost]
@@ -87,7 +21,6 @@ config:
           - source_labels:
             - __journal_syslog_identifier
             target_label: syslog_identifier
-  
 
 containerSecurityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
## Description

After reviewing [upstream defaults](https://github.com/grafana/helm-charts/blob/promtail-6.15.3/charts/promtail/values.yaml#L488-L528) the only additional piece we should need is the node specific scrape config to ensure node logs are available. If needed we can add/modify more labels/scrape configs based on any dashboards/other things we start using with Loki. For now this is sufficient for the explore tab to view logs by app/ns/etc and view node logs.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/38

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed