### PR TITLE
fix: change pepr error policy to reject

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "pepr": {
     "name": "UDS Core",
     "uuid": "uds-core",
-    "onError": "audit",
+    "onError": "reject",
     "alwaysIgnore": {
       "namespaces": [
         "uds-dev-stack",


### PR DESCRIPTION
## Description

Switches pepr webhook failure policies to Fail (via pepr reject config value).

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/98

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed