### PR TITLE
fix: remove loki gateway anti-affinity

### DIFF
--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -110,3 +110,5 @@ monitoring:
     enabled: false
 gateway:
   enabled: true
+  # Remove default anti-affinity since this is a 1-replica setup
+  affinity: ""

--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -112,3 +112,6 @@ gateway:
   enabled: true
   # Remove default anti-affinity since this is a 1-replica setup
   affinity: ""
+  # Temporary addition to handle upgrade scenarios removing affinity
+  deploymentStrategy:
+    type: Recreate


### PR DESCRIPTION
## Description

It was discovered in test that the anti-affinity set on the gateway is problematic during upgrades. This is partially because we are on a single node for k3d, but in general the anti-affinity does not make sense to have here since the gateway is a single replica setup.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed