### PR TITLE
fix: network policy to allow metrics-server ingress

### DIFF
--- a/src/metrics-server/chart/templates/uds-package.yaml
+++ b/src/metrics-server/chart/templates/uds-package.yaml
@@ -7,7 +7,18 @@ spec:
   network:
     allow:
       - direction: Egress
-        # todo: evaluate an "all nodes" generated rule
         podLabels:
           app.kubernetes.io/name: metrics-server
+        # todo: evaluate an "all nodes" generated rule
         remoteGenerated: Anywhere
+        port: 10250
+      - direction: Egress
+        podLabels:
+          app.kubernetes.io/name: metrics-server
+        remoteGenerated: KubeAPI
+      - direction: Ingress
+        podLabels:
+          app.kubernetes.io/name: metrics-server
+        # todo: evaluate a "KubeAPI" _ingress_ generated rule
+        remoteGenerated: Anywhere
+        port: 10250


### PR DESCRIPTION
## Description

Allows ingress from anywhere to the metrics-server endpoint. After investigation, calls to `kubectl top` are source-NAT-ed when they hit metric-server so the source IP ends up being an IP in the pod CIDR range, effectively the "gateway IP" for the node (on k3d typically `10.42.<server pod cidr, 0/1/2/...>.<0/1>`). This doesn't appear to be something we can consistently grab/calculate. One way we could lock this down would be by adding the CIDRs from all nodes `podCidr`s, but no sure of the value of that vs anywhere besides optics.

Effectively we need a "KubeAPI Ingress" generated rule that would handle the above scenario. I think this is also necessary for any webhooks, in some testing the prometheus webhook is failing as well, but has an Ignore policy that hides the issue.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/139

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed