### PR TITLE
fix: remove `tasks` from include paths to fix `uds run test-uds-core`

### DIFF
--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -1,7 +1,7 @@
 includes:
-  - create: ./tasks/create.yaml
-  - setup: ./tasks/setup.yaml
-  - deploy: ./tasks/deploy.yaml
+  - create: ./create.yaml
+  - setup: ./setup.yaml
+  - deploy: ./deploy.yaml
 
 tasks:
   - name: single-package


### PR DESCRIPTION
I have confirmed that with this change, `uds run test-uds-core` runs and passes locally "on my machine".