### PR TITLE
ci: fix debug to run on cancelled jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,9 +81,6 @@ jobs:
           kubectl get package -A
           echo "::endgroup::"
 
-      - name: Debug Events Output
-        if: ${{ failure() }}
-        run: |
           echo "::group::kubectl get events"
           kubectl get events -A --sort-by='.lastTimestamp'
           echo "::endgroup::"


### PR DESCRIPTION
## Description

Switched from `failure()` because that doesn't include cancelled jobs, which are the most common issue due to timeouts = cancellations.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed