### PR TITLE
chore: renovate labelling automation

### DIFF
--- a/.github/workflows/renovate-labels.yaml
+++ b/.github/workflows/renovate-labels.yaml
@@ -16,6 +16,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Remove Labels
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/renovate-labels.yaml
+++ b/.github/workflows/renovate-labels.yaml
@@ -1,0 +1,23 @@
+name: Renovate Labels
+
+on:
+  pull_request:
+    branches: [main]
+    types: [reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  remove_labels:
+    if: ${{ github.actor == 'renovate[bot]' }}
+    runs-on: ubuntu-latest
+    name: Remove Labels
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove Labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # If a Renovate PR is updated, remove the "waiting" labels so that it is re-evaluated
+        run: gh pr edit --add-label "renovate" --remove-label "waiting on ironbank,waiting on helm chart" ${{ github.event.pull_request.number }}

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "forkProcessing": "enabled",
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "branchConcurrentLimit": 0,
+  "labels": ["renovate"],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "rebaseStalePrs": true,


### PR DESCRIPTION
## Description

Adds a workflow on PR that uses the github CLI to remove `waiting` labels when a PR is updated, provided the PR author/committer is the renovate bot. Also adds a default `renovate` label to all renovate PRs.

## Related Issue

First pass / stop gap for https://github.com/defenseunicorns/uds-core/issues/168

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed