### PR TITLE
ci: add more debug outputs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,8 +89,8 @@ jobs:
           kubectl describe nodes
           echo "::endgroup::"
 
-          echo "::group::kubectl describe pending pods"
-          kubectl get pods -A | grep -i Pending | awk '{print "kubectl describe pod -n " $1 " " $2}' | bash
+          echo "::group::docker get node logs"
+          docker logs k3d-uds-server-0
           echo "::endgroup::"
 
       - name: Save logs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
           echo "::group::kubectl describe nodes"
           kubectl describe nodes
           echo "::endgroup::"
-          
+
           echo "::group::kubectl describe pending pods"
           kubectl get pods -A | grep -i Pending | awk '{print "kubectl describe pod -n " $1 " " $2}' | bash
           echo "::endgroup::"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,11 @@ jobs:
           kubectl get events -A --sort-by='.lastTimestamp'
           echo "::endgroup::"
 
-          echo "::group::kubectl get pending pods"
+          echo "::group::kubectl describe nodes"
+          kubectl describe nodes
+          echo "::endgroup::"
+          
+          echo "::group::kubectl describe pending pods"
           kubectl get pods -A | grep -i Pending | awk '{print "kubectl describe pod -n " $1 " " $2}' | bash
           echo "::endgroup::"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,6 +85,10 @@ jobs:
           kubectl get events -A --sort-by='.lastTimestamp'
           echo "::endgroup::"
 
+          echo "::group::kubectl get pending pods"
+          kubectl get pods -A | grep -i Pending | awk '{print "kubectl describe pod -n " $1 " " $2}' | bash
+          echo "::endgroup::"
+
       - name: Save logs
         if: always()
         uses: ./.github/actions/save-logs


### PR DESCRIPTION
## Description

CI debug is a tough nut to crack - events are not showing why some pods are pending so adding:
- describe nodes (hoping this may show resource metrics that would be useful or other node events)
- describe pending pods - this seems to be the main problem in failed runs, so hoping we can get the "why" for Pending pods from this

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed