### PR TITLE
fix: validating/mutating webhook networkpolicies and mtls

### DIFF
--- a/src/neuvector/chart/templates/peerauthentication/neuvector-controller-pa.yaml
+++ b/src/neuvector/chart/templates/peerauthentication/neuvector-controller-pa.yaml
@@ -13,4 +13,7 @@ spec:
   portLevelMtls:
     "18300":
       mode: PERMISSIVE
+    # Allow webhooks to operate permissive since ingress originates from the nodes
+    "30443":
+      mode: PERMISSIVE
 {{- end }}

--- a/src/neuvector/chart/templates/uds-package.yaml
+++ b/src/neuvector/chart/templates/uds-package.yaml
@@ -31,13 +31,13 @@ spec:
         selector:
           app: neuvector-updater-pod
 
-      # - direction: Ingress
-      #   # todo: evaluate a "KubeAPI" _ingress_ generated rule for webhook calls
-      #   remoteGenerated: Anywhere
-      #   selector:
-      #     app: neuvector-controller-pod
-      #   port: 30443
-      #   description: "Webhook"
+      - direction: Ingress
+        # todo: evaluate a "KubeAPI" _ingress_ generated rule for webhook calls
+        remoteGenerated: Anywhere
+        selector:
+          app: neuvector-controller-pod
+        port: 30443
+        description: "Webhook"
 
       - direction: Ingress
         remoteNamespace: monitoring

--- a/src/neuvector/chart/templates/uds-package.yaml
+++ b/src/neuvector/chart/templates/uds-package.yaml
@@ -31,6 +31,14 @@ spec:
         selector:
           app: neuvector-updater-pod
 
+      # - direction: Ingress
+      #   # todo: evaluate a "KubeAPI" _ingress_ generated rule for webhook calls
+      #   remoteGenerated: Anywhere
+      #   selector:
+      #     app: neuvector-controller-pod
+      #   port: 30443
+      #   description: "Webhook"
+
       - direction: Ingress
         remoteNamespace: monitoring
         remoteSelector:

--- a/src/prometheus-stack/chart/templates/peerauthentication/prometheus-operator-pa.yaml
+++ b/src/prometheus-stack/chart/templates/peerauthentication/prometheus-operator-pa.yaml
@@ -1,17 +1,17 @@
 {{- if .Capabilities.APIVersions.Has "security.istio.io/v1beta1" }}
-apiVersion: security.istio.io/v1beta1
+apiVersion: "security.istio.io/v1beta1"
 kind: PeerAuthentication
 metadata:
-  name: metrics-server-api-exception
+  name: prometheus-operator-webhook
   namespace: {{ .Release.Namespace }}
 spec:
-  mtls:
-    mode: STRICT
   selector:
     matchLabels:
-      app.kubernetes.io/name: metrics-server
+      app: kube-prometheus-stack-operator
+  mtls:
+    mode: STRICT
   portLevelMtls:
-    # Allow api service calls to operate permissive since ingress originates from the nodes
+    # Allow webhooks to operate permissive since ingress originates from the nodes
     "10250":
       mode: PERMISSIVE
 {{- end }}

--- a/src/prometheus-stack/chart/templates/uds-package.yaml
+++ b/src/prometheus-stack/chart/templates/uds-package.yaml
@@ -33,13 +33,13 @@ spec:
         selector:
           app: kube-prometheus-stack-admission-patch
 
-      # - direction: Ingress
-      #   # todo: evaluate a "KubeAPI" _ingress_ generated rule for webhook calls
-      #   remoteGenerated: Anywhere
-      #   selector:
-      #     app: kube-prometheus-stack-operator
-      #   port: 10250
-      #   description: "Webhook"
+      - direction: Ingress
+        # todo: evaluate a "KubeAPI" _ingress_ generated rule for webhook calls
+        remoteGenerated: Anywhere
+        selector:
+          app: kube-prometheus-stack-operator
+        port: 10250
+        description: "Webhook"
 
       # todo: lockdown egress to scrape targets
       - direction: Egress

--- a/src/prometheus-stack/chart/templates/uds-package.yaml
+++ b/src/prometheus-stack/chart/templates/uds-package.yaml
@@ -33,6 +33,14 @@ spec:
         selector:
           app: kube-prometheus-stack-admission-patch
 
+      # - direction: Ingress
+      #   # todo: evaluate a "KubeAPI" _ingress_ generated rule for webhook calls
+      #   remoteGenerated: Anywhere
+      #   selector:
+      #     app: kube-prometheus-stack-operator
+      #   port: 10250
+      #   description: "Webhook"
+
       # todo: lockdown egress to scrape targets
       - direction: Egress
         remoteNamespace: "" 


### PR DESCRIPTION
## Description

Adds the proper ingress rules to the webhooks and PERMISSIVE mTLS to allow calls to operate as expected. Validated by turning the webhook failure policies to Fail and applying CRs. The fix applied is similar to the approach taken with metrics-server, and can be re-evaluated as a generated rule instead of Anywhere in the future.

## Related Issue

Related to https://github.com/defenseunicorns/uds-core/issues/149 (not a solve for it, but would also be modified by that issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed