### PR TITLE
chore: support deselection of metrics-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ UDS Core establishes a secure baseline for cloud-native systems and ships with c
 - [Grafana](https://grafana.com/oss/grafana/) - Monitoring
 - [Istio](https://istio.io/) - Service Mesh
 - [Loki](https://grafana.com/oss/loki/) - Log Aggregation
-- [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) - Metrics
+- [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)* - Metrics
 - [Neuvector](https://open-docs.neuvector.com/) - Container Security
 - [Pepr](https://pepr.dev) - UDS policy engine & operator
 - [Prometheus Stack](https://github.com/prometheus-operator/kube-prometheus) - Monitoring
 - [Promtail](https://grafana.com/docs/loki/latest/send-data/promtail/) - Log Aggregation
+
+*Supports component deselection to use a Kubernetes distribution provided metrics-server.
 
 #### Future Applications
 

--- a/packages/standard/zarf.yaml
+++ b/packages/standard/zarf.yaml
@@ -44,7 +44,8 @@ components:
 
   # Metrics Server
   - name: metrics-server
-    required: true
+    # default instead of required to support deselection to use a distro-default metrics-server
+    default: true
     import:
       path: ../../src/metrics-server
 


### PR DESCRIPTION
## Description

Switches metrics-server from required to default to support deselecting it when you want to use a k8s distro default metrics-server.

## Related Issue

Related to https://github.com/defenseunicorns/uds-core/issues/176

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed