### PR TITLE
fix: hotfix for publishing workflows

### DIFF
--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -18,12 +18,16 @@ tasks:
       - description: "Create the UDS Core Standard Zarf Package"
         cmd: |
           ZARF_ARCHITECTURE=amd64 uds run -f tasks/create.yaml standard-package --no-progress --set FLAVOR=${FLAVOR}
-          ZARF_ARCHITECTURE=arm64 uds run -f tasks/create.yaml standard-package --no-progress --set FLAVOR=${FLAVOR}
+          if [ "${FLAVOR}" != "registry1" ]; then
+            ZARF_ARCHITECTURE=arm64 uds run -f tasks/create.yaml standard-package --no-progress --set FLAVOR=${FLAVOR}
+          fi
 
       - description: "Create the UDS Core Istio Only Zarf Package"
         cmd: |
           ZARF_ARCHITECTURE=amd64 uds run -f tasks/create.yaml istio-package --no-progress --set FLAVOR=${FLAVOR}
-          ZARF_ARCHITECTURE=arm64 uds run -f tasks/create.yaml istio-package --no-progress --set FLAVOR=${FLAVOR}
+          if [ "${FLAVOR}" != "registry1" ]; then
+            ZARF_ARCHITECTURE=arm64 uds run -f tasks/create.yaml istio-package --no-progress --set FLAVOR=${FLAVOR}
+          fi
 
       - description: "Publish the packages"
         cmd: |


### PR DESCRIPTION
## Description

Quick fix to filter out registry1 from any arm64 creates/publishes.

Noting that a longer term solution might be matrixing this workflow - started down that path and it felt a bit off with the bundle portion. Will revisit after cutting the current release.

## Related Issue

https://github.com/defenseunicorns/uds-core/actions/runs/8142199102/job/22251234250

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed