### PR TITLE
fix: kubeapi netpol generation now also includes the ip from the kubernetes service

### DIFF
--- a/src/pepr/operator/index.ts
+++ b/src/pepr/operator/index.ts
@@ -3,7 +3,11 @@ import { a } from "pepr";
 import { When } from "./common";
 import { cleanupNamespace } from "./controllers/istio/injection";
 import { purgeSSOClients } from "./controllers/keycloak/client-sync";
-import { initAPIServerCIDR, updateAPIServerCIDR } from "./controllers/network/generators/kubeAPI";
+import {
+  initAPIServerCIDR,
+  updateAPIServerCIDRFromEndpointSlice,
+  updateAPIServerCIDRFromService,
+} from "./controllers/network/generators/kubeAPI";
 import { UDSPackage } from "./crd";
 import { validator } from "./crd/validator";
 import { reconciler } from "./reconciler";
@@ -20,7 +24,14 @@ When(a.EndpointSlice)
   .IsCreatedOrUpdated()
   .InNamespace("default")
   .WithName("kubernetes")
-  .Watch(updateAPIServerCIDR);
+  .Watch(updateAPIServerCIDRFromEndpointSlice);
+
+// Watch for changes to the API server Service and update the API server CIDR
+When(a.Service)
+  .IsCreatedOrUpdated()
+  .InNamespace("default")
+  .WithName("kubernetes")
+  .Watch(updateAPIServerCIDRFromService);
 
 // Watch for changes to the UDSPackage CRD and cleanup the namespace mutations
 When(UDSPackage)


### PR DESCRIPTION
Fixes a bug in EKS vpc-cni for gitlab where the gitlab pods couldn't talk to the api server

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed