### PR TITLE
fix: keycloak volume permissions, UI update

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -24,6 +24,8 @@ spec:
         {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+      {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: uds-config
           image: "{{ .Values.configImage }}"

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.3.3
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.3.4
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"
@@ -41,6 +41,12 @@ fips: false
 
 #  Pod priority class name
 priorityClassName: ""
+
+# Pod level securityContext
+podSecurityContext: {}
+
+# Keycloak container securityContext
+securityContext: {}
 
 # Pod affinity
 affinity: |

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.3.2
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.3.3
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"

--- a/src/keycloak/tasks.yaml
+++ b/src/keycloak/tasks.yaml
@@ -1,5 +1,5 @@
 includes:
-  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.3.3/tasks.yaml
+  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.3.4/tasks.yaml
 
 tasks:
   # These tests break single capability test checks

--- a/src/keycloak/tasks.yaml
+++ b/src/keycloak/tasks.yaml
@@ -1,5 +1,5 @@
 includes:
-  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.3.2/tasks.yaml
+  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.3.3/tasks.yaml
 
 tasks:
   # These tests break single capability test checks

--- a/src/keycloak/values/registry1-values.yaml
+++ b/src/keycloak/values/registry1-values.yaml
@@ -1,6 +1,8 @@
 image:
   repository: registry1.dso.mil/ironbank/opensource/keycloak/keycloak
   tag: "23.0.4"
+podSecurityContext:
+  fsGroup: 2000
 securityContext:
   runAsUser: 2000
   runAsGroup: 2000

--- a/src/keycloak/values/upstream-values.yaml
+++ b/src/keycloak/values/upstream-values.yaml
@@ -1,3 +1,5 @@
+podSecurityContext:
+  fsGroup: 1000
 image:
   repository: quay.io/keycloak/keycloak
   tag: "23.0.4"

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -21,7 +21,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:23.0.4
-      - ghcr.io/defenseunicorns/uds/identity-config:0.3.3
+      - ghcr.io/defenseunicorns/uds/identity-config:0.3.4
 
   - name: keycloak
     required: true
@@ -37,4 +37,4 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:23.0.4
-      - ghcr.io/defenseunicorns/uds/identity-config:0.3.3
+      - ghcr.io/defenseunicorns/uds/identity-config:0.3.4

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -21,7 +21,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:23.0.4
-      - ghcr.io/defenseunicorns/uds/identity-config:0.3.2
+      - ghcr.io/defenseunicorns/uds/identity-config:0.3.3
 
   - name: keycloak
     required: true
@@ -37,4 +37,4 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:23.0.4
-      - ghcr.io/defenseunicorns/uds/identity-config:0.3.2
+      - ghcr.io/defenseunicorns/uds/identity-config:0.3.3


### PR DESCRIPTION
## Description

Updates to expose `podSecurityContext` and set defaults for registry1/upstream `fsGroup` + updates the config image to fix two issues in the theme - https://github.com/defenseunicorns/uds-identity-config/releases/tag/v0.3.3 and exiting on error - https://github.com/defenseunicorns/uds-identity-config/releases/tag/v0.3.4

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/220

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed