### PR TITLE
fix(keycloak): add missing postgres host and port secret keys

### DIFF
--- a/src/keycloak/chart/templates/secret-postgresql.yaml
+++ b/src/keycloak/chart/templates/secret-postgresql.yaml
@@ -12,4 +12,6 @@ spec:
     database: {{ .Values.postgresql.database | b64enc }}
     username: {{ .Values.postgresql.username | b64enc }}
     password: {{ .Values.postgresql.password | b64enc }}
+    host: {{ .Values.postgresql.host | b64enc }}
+    port: {{ .Values.postgresql.port | toString | b64enc }}
 {{- end }}

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -23,6 +23,10 @@ spec:
         {{- range $key, $value := .Values.podLabels }}
         {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 8 }}
         {{- end }}
+       {{- if not .Values.devMode }}
+      annotations:
+        postgres-hash: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}        
+      {{- end }}
     spec:
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -107,6 +107,10 @@ postgresql:
   password: keycloak
   # PostgreSQL Database to create
   database: keycloak
+  # PostgreSQL host
+  host: postgresql
+  # PostgreSQL port
+  port: 5432
 
 serviceMonitor:
   # If `true`, a ServiceMonitor resource for the prometheus-operator is created


### PR DESCRIPTION
This PR adds the postgres host/port entries missing from the secret along with a conditional secret sha256sum annotation to force a roll on secret update. Note this behavior is different than than the [Codecentric chart](https://github.com/codecentric/helm-charts/blob/58a318a16a5ed220601da39fcd4e82127c3f911a/charts/keycloak/templates/statefulset.yaml#L98) that only puts the password in the secret and the rest direct-injected into the `Statefulset`. 
