### PR TITLE
chore: annotate mutations in policies

### DIFF
--- a/src/pepr/policies/common.ts
+++ b/src/pepr/policies/common.ts
@@ -1,5 +1,6 @@
 import { KubernetesObject, V1Container, V1SecurityContext } from "@kubernetes/client-node";
 import { Capability, PeprMutateRequest, PeprValidateRequest, a } from "pepr";
+import { Policy } from "../operator/crd";
 
 export type Ctx = {
   name?: string;
@@ -91,9 +92,16 @@ export function isIstioInitContainer(
   return true;
 }
 
+function transform(policy: Policy) {
+  return policy
+    .split(/(?=[A-Z])/)
+    .join("-")
+    .toLowerCase();
+}
+
 export function annotateMutation<T extends KubernetesObject>(
   request: PeprMutateRequest<T>,
-  value: string,
+  policy: Policy,
 ) {
-  request.SetAnnotation(`policies.uds.core/mutated`, value);
+  request.SetAnnotation(`policies.uds.core/mutated`, transform(policy));
 }

--- a/src/pepr/policies/common.ts
+++ b/src/pepr/policies/common.ts
@@ -1,5 +1,6 @@
-import { V1SecurityContext, V1Container } from "@kubernetes/client-node";
+import { KubernetesObject, V1Container, V1SecurityContext } from "@kubernetes/client-node";
 import { Capability, PeprMutateRequest, PeprValidateRequest, a } from "pepr";
+import { Policy } from "../operator/crd";
 
 export type Ctx = {
   name?: string;
@@ -89,4 +90,12 @@ export function isIstioInitContainer(
 
   // If we get here, it's an istio init container
   return true;
+}
+
+export function annotateMutation<T extends KubernetesObject>(
+  request: PeprMutateRequest<T>,
+  policy: Policy,
+  value: string,
+) {
+  request.SetAnnotation(`uds-core-policies.${policy}.mutated`, value);
 }

--- a/src/pepr/policies/common.ts
+++ b/src/pepr/policies/common.ts
@@ -1,6 +1,5 @@
 import { KubernetesObject, V1Container, V1SecurityContext } from "@kubernetes/client-node";
 import { Capability, PeprMutateRequest, PeprValidateRequest, a } from "pepr";
-import { Policy } from "../operator/crd";
 
 export type Ctx = {
   name?: string;
@@ -94,8 +93,7 @@ export function isIstioInitContainer(
 
 export function annotateMutation<T extends KubernetesObject>(
   request: PeprMutateRequest<T>,
-  policy: Policy,
   value: string,
 ) {
-  request.SetAnnotation(`uds-core-policies.${policy}.mutated`, value);
+  request.SetAnnotation(`policies.uds.core/mutated`, value);
 }

--- a/src/pepr/policies/security.ts
+++ b/src/pepr/policies/security.ts
@@ -107,7 +107,7 @@ When(a.Pod)
     // Set the runAsGroup field to 1000 if it is undefined
     if (pod.securityContext.runAsGroup === undefined) {
       pod.securityContext.runAsGroup = 1000;
-      annotateMutation(request, Policy.RequireNonRootUser,"securityContext.runAsGroup");
+      annotateMutation(request, Policy.RequireNonRootUser, "securityContext.runAsGroup");
     }
   })
   .Validate(request => {
@@ -328,7 +328,11 @@ When(a.Pod)
       container.securityContext.capabilities = container.securityContext.capabilities || {};
       container.securityContext.capabilities.drop = ["ALL"];
     }
-    annotateMutation(request, Policy.DropAllCapabilities, "container.securityContext.capabilities.drop",);
+    annotateMutation(
+      request,
+      Policy.DropAllCapabilities,
+      "container.securityContext.capabilities.drop",
+    );
   })
   .Validate(request => {
     if (isExempt(request, Policy.DropAllCapabilities)) {

--- a/src/pepr/policies/security.ts
+++ b/src/pepr/policies/security.ts
@@ -75,39 +75,39 @@ When(a.Pod)
     const runAsUser = metadata.labels?.["uds/user"];
     if (runAsUser) {
       pod.securityContext.runAsUser = parseInt(runAsUser);
-      annotateMutation(request, Policy.RequireNonRootUser, "securityContext.runAsUser");
+      annotateMutation(request, "securityContext.runAsUser");
     }
 
     // Set the runAsGroup field if it is defined in a label
     const runAsGroup = metadata.labels?.["uds/group"];
     if (runAsGroup) {
       pod.securityContext.runAsGroup = parseInt(runAsGroup);
-      annotateMutation(request, Policy.RequireNonRootUser, "securityContext.runAsGroup");
+      annotateMutation(request, "securityContext.runAsGroup");
     }
 
     // Set the fsGroup field if it is defined in a label
     const fsGroup = metadata.labels?.["uds/fsgroup"];
     if (fsGroup) {
       pod.securityContext.fsGroup = parseInt(fsGroup);
-      annotateMutation(request, Policy.RequireNonRootUser, "securityContext.fsGroup");
+      annotateMutation(request, "securityContext.fsGroup");
     }
 
     // Set the runAsNonRoot field to true if it is undefined
     if (pod.securityContext.runAsNonRoot === undefined) {
       pod.securityContext.runAsNonRoot = true;
-      annotateMutation(request, Policy.RequireNonRootUser, "securityContext.runAsNonRoot");
+      annotateMutation(request, "securityContext.runAsNonRoot");
     }
 
     // Set the runAsUser field to 1000 if it is undefined
     if (pod.securityContext.runAsUser === undefined) {
       pod.securityContext.runAsUser = 1000;
-      annotateMutation(request, Policy.RequireNonRootUser, "securityContext.runAsUser");
+      annotateMutation(request, "securityContext.runAsUser");
     }
 
     // Set the runAsGroup field to 1000 if it is undefined
     if (pod.securityContext.runAsGroup === undefined) {
       pod.securityContext.runAsGroup = 1000;
-      annotateMutation(request, Policy.RequireNonRootUser, "securityContext.runAsGroup");
+      annotateMutation(request, "securityContext.runAsGroup");
     }
   })
   .Validate(request => {
@@ -330,7 +330,6 @@ When(a.Pod)
     }
     annotateMutation(
       request,
-      Policy.DropAllCapabilities,
       "container.securityContext.capabilities.drop",
     );
   })

--- a/src/pepr/policies/security.ts
+++ b/src/pepr/policies/security.ts
@@ -328,10 +328,7 @@ When(a.Pod)
       container.securityContext.capabilities = container.securityContext.capabilities || {};
       container.securityContext.capabilities.drop = ["ALL"];
     }
-    annotateMutation(
-      request,
-      "container.securityContext.capabilities.drop",
-    );
+    annotateMutation(request, "container.securityContext.capabilities.drop");
   })
   .Validate(request => {
     if (isExempt(request, Policy.DropAllCapabilities)) {

--- a/src/pepr/policies/security.ts
+++ b/src/pepr/policies/security.ts
@@ -75,40 +75,36 @@ When(a.Pod)
     const runAsUser = metadata.labels?.["uds/user"];
     if (runAsUser) {
       pod.securityContext.runAsUser = parseInt(runAsUser);
-      annotateMutation(request, "securityContext.runAsUser");
     }
 
     // Set the runAsGroup field if it is defined in a label
     const runAsGroup = metadata.labels?.["uds/group"];
     if (runAsGroup) {
       pod.securityContext.runAsGroup = parseInt(runAsGroup);
-      annotateMutation(request, "securityContext.runAsGroup");
     }
 
     // Set the fsGroup field if it is defined in a label
     const fsGroup = metadata.labels?.["uds/fsgroup"];
     if (fsGroup) {
       pod.securityContext.fsGroup = parseInt(fsGroup);
-      annotateMutation(request, "securityContext.fsGroup");
     }
 
     // Set the runAsNonRoot field to true if it is undefined
     if (pod.securityContext.runAsNonRoot === undefined) {
       pod.securityContext.runAsNonRoot = true;
-      annotateMutation(request, "securityContext.runAsNonRoot");
     }
 
     // Set the runAsUser field to 1000 if it is undefined
     if (pod.securityContext.runAsUser === undefined) {
       pod.securityContext.runAsUser = 1000;
-      annotateMutation(request, "securityContext.runAsUser");
     }
 
     // Set the runAsGroup field to 1000 if it is undefined
     if (pod.securityContext.runAsGroup === undefined) {
       pod.securityContext.runAsGroup = 1000;
-      annotateMutation(request, "securityContext.runAsGroup");
     }
+
+    annotateMutation(request, Policy.RequireNonRootUser);
   })
   .Validate(request => {
     if (isExempt(request, Policy.RequireNonRootUser)) {
@@ -328,7 +324,7 @@ When(a.Pod)
       container.securityContext.capabilities = container.securityContext.capabilities || {};
       container.securityContext.capabilities.drop = ["ALL"];
     }
-    annotateMutation(request, "container.securityContext.capabilities.drop");
+    annotateMutation(request, Policy.DropAllCapabilities);
   })
   .Validate(request => {
     if (isExempt(request, Policy.DropAllCapabilities)) {


### PR DESCRIPTION
## Description
Give users better information about when a resource is mutated by a policy (e.g. Require Non Root User mutates security contexts if undefined or `uds` labels are set).

## Related Issue

Resolves #212 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed