### PR TITLE
ci: add docs reviewer to PRs with 'needs-docs' label

### DIFF
--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -5,17 +5,16 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
 jobs:
-  add_reviewer:
+  reviewer:
+    name: Add Reviewer
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
 
       - name: Add reviewer if labeled
         if: ${{ contains( github.event.pull_request.labels.*.name, 'needs-docs' ) }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr edit --add-reviewer ${{ vars.DOCS_REVIEWER }}
-      # todo: add docs linting/formatting?
+  # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -4,14 +4,13 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
-permissions: write-all # temporary to test if this fixes permissions
-  # contents: write
-  # pull-requests: write
-
 jobs:
   reviewer:
     name: Add Reviewer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -20,12 +20,5 @@ jobs:
         if: ${{ contains( github.event.pull_request.labels.*.name, 'needs-docs' ) }}
         env:
           GH_TOKEN: ${{ github.token }}
-        # This has to be done via API call because of https://github.com/cli/cli/issues/4844
-        run: |
-            gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -f "team_reviewers[]=${{ vars.DOCS_REVIEWER }}"
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer= ${{ vars.DOCS_REVIEWER }}
   # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -1,0 +1,19 @@
+name: Validate Docs
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  add_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if labeled with needs-docs
+        id: check_label
+        run: echo "::set-output name=needs_docs::$(echo ${{ github.event.label.name == 'needs-docs' }})"
+      - name: Add reviewer if labeled
+        if: steps.check_label.outputs.needs_docs == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr edit --add-reviewer ${{ vars.DOCS_REVIEWER }}
+      # todo: add docs linting/formatting?

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -27,5 +27,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -f "team_reviewers[]=${{ vars.DOCS_REVIEWER }}" \
+            -f "team_reviewers[]=${{ vars.DOCS_REVIEWER }}"
   # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
     
 jobs:
   reviewer:

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -27,5 +27,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -f "reviewers=[${{ vars.DOCS_REVIEWER }}]" \
+            -f "team_reviewers=[${{ vars.DOCS_REVIEWER }}]" \
   # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -2,17 +2,19 @@ name: Validate Docs
 
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, synchronize, labeled]
 
 jobs:
   add_reviewer:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if labeled with needs-docs
-        id: check_label
-        run: echo "::set-output name=needs_docs::$(echo ${{ github.event.label.name == 'needs-docs' }})"
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
       - name: Add reviewer if labeled
-        if: steps.check_label.outputs.needs_docs == 'true'
+        if: ${{ contains( github.event.pull_request.labels.*.name, 'needs-docs' ) }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr edit --add-reviewer ${{ vars.DOCS_REVIEWER }}

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -27,5 +27,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -f "reviewers[]=${{ vars.DOCS_REVIEWER }}" \
+            -f "reviewers=[${{ vars.DOCS_REVIEWER }}]" \
   # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -16,5 +16,5 @@ jobs:
         if: ${{ contains( github.event.pull_request.labels.*.name, 'needs-docs' ) }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr edit --add-reviewer ${{ vars.DOCS_REVIEWER }}
+        run: gh pr edit --add-reviewer ${{ vars.DOCS_REVIEWER }} ${{ github.event.pull_request.number }}
   # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-    
+
 jobs:
   reviewer:
     name: Add Reviewer

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -20,5 +20,5 @@ jobs:
         if: ${{ contains( github.event.pull_request.labels.*.name, 'needs-docs' ) }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer= ${{ vars.DOCS_REVIEWER }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer ${{ vars.DOCS_REVIEWER }}
   # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -27,5 +27,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -f "team_reviewers=[${{ vars.DOCS_REVIEWER }}]" \
+            -f "team_reviewers[]=${{ vars.DOCS_REVIEWER }}" \
   # todo: add docs linting/formatting

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: write-all # temporary to test if this fixes permissions
+  # contents: write
+  # pull-requests: write
 
 jobs:
   reviewer:

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
+permissions:
+  contents: read
+    
 jobs:
   reviewer:
     name: Add Reviewer

--- a/.github/workflows/tag-docs-reviewer.yaml
+++ b/.github/workflows/tag-docs-reviewer.yaml
@@ -20,5 +20,12 @@ jobs:
         if: ${{ contains( github.event.pull_request.labels.*.name, 'needs-docs' ) }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr edit --add-reviewer ${{ vars.DOCS_REVIEWER }} ${{ github.event.pull_request.number }}
+        # This has to be done via API call because of https://github.com/cli/cli/issues/4844
+        run: |
+            gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -f "reviewers[]=${{ vars.DOCS_REVIEWER }}" \
   # todo: add docs linting/formatting


### PR DESCRIPTION
## Description

Adds the @defenseunicorns/uds-docs team to reviewers on PRs based on label `needs-docs` being present.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed