### PR TITLE
fix(keycloak): only use PVC for devMode

### DIFF
--- a/src/keycloak/chart/templates/pvc.yaml
+++ b/src/keycloak/chart/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.devMode }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -25,3 +26,4 @@ spec:
   resources:
     requests:
       storage: 512Mi
+{{- end }}

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -230,9 +230,16 @@ spec:
           emptyDir: {}
         - name: conf
           emptyDir: {}
+      {{- if .Values.devMode }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "keycloak.fullname" . }}-data
         - name: themes
           persistentVolumeClaim:
             claimName: {{ include "keycloak.fullname" . }}-themes
+      {{- else }}
+        - name: data
+          emptyDir: {}
+        - name: themes
+          emptyDir: {}
+      {{- end }}


### PR DESCRIPTION
Only use PVC for keycloak devMode to avoid issues in HA mode. 