### PR TITLE
chore: align mutation annotations

### DIFF
--- a/src/pepr/policies/common.ts
+++ b/src/pepr/policies/common.ts
@@ -103,5 +103,5 @@ export function annotateMutation<T extends KubernetesObject>(
   request: PeprMutateRequest<T>,
   policy: Policy,
 ) {
-  request.SetAnnotation(`policies.uds.core/mutated`, transform(policy));
+  request.SetAnnotation(`uds-core.pepr.dev/mutated`, transform(policy));
 }


### PR DESCRIPTION
## Description

This lines the annotation up with existing ones (`uds-core.pepr.dev/uds-core-policies`). I think it may make sense in the future for this to make its way into "pepr core" to enable customizing the default annotation that is added.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed