### PR TITLE
ci: fix ci backup status - use uds instead of zarf

### DIFF
--- a/src/velero/tasks.yaml
+++ b/src/velero/tasks.yaml
@@ -63,7 +63,7 @@ tasks:
 
               # get backup object
               uds zarf tools kubectl get backups -n velero ${BACKUP_NAME} -o yaml
-              zarf tools kubectl get backups -A -o yaml
+              uds zarf tools kubectl get backups -A -o yaml
               echo "::endgroup::"
 
               # get backupstoragelocations


### PR DESCRIPTION
## Description

fix the ci issue where backup check fails because it is using `zarf` instead of `uds zarf`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed