### PR TITLE
fix: sticky sessions for keycloak in ha

### DIFF
--- a/src/keycloak/chart/templates/destination-rule.yaml
+++ b/src/keycloak/chart/templates/destination-rule.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.devMode }}
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: {{ include "keycloak.fullname" . }}-sticky-session
+spec:
+  host: {{ include "keycloak.fullname" . }}-http.{{ .Release.Namespace }}.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpCookie:
+          name: {{ include "keycloak.fullname" . }}-session
+          ttl: 0s
+{{- end }}


### PR DESCRIPTION
## Description
Adds a destination rule to support sticky sessions for keycloak

/cc @brianrexrode 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed