### PR TITLE
fix: add kubeapi egress for neuvector enforcer

### DIFF
--- a/src/neuvector/chart/templates/uds-package.yaml
+++ b/src/neuvector/chart/templates/uds-package.yaml
@@ -31,6 +31,11 @@ spec:
         selector:
           app: neuvector-updater-pod
 
+      - direction: Egress
+        remoteGenerated: KubeAPI
+        selector:
+          app: neuvector-enforcer-pod
+
       - direction: Ingress
         # todo: evaluate a "KubeAPI" _ingress_ generated rule for webhook calls
         remoteGenerated: Anywhere


### PR DESCRIPTION
## Description
Give Neuvector enforcer kubeapi access.  I noticed enforcer logs indicating it was attempting to get the K8s version on startup. 

```
2024-03-26T14:03:31.003|ERRO|AGT|orchestration.GetK8sVersion: Get Version fail - error=Get "https://kubernetes.default/version": read tcp 10.42.0.36:36332->10.43.0.1:443: read: connection reset by peer
2024-03-26T14:03:31.005|ERRO|AGT|orchestration.GetK8sVersion: Get Version fail - error=Get "https://kubernetes.default/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver": read tcp 10.42.0.36:36354->10.43.0.1:443: read: connection reset by peer
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed