### PR TITLE
ci: set custom k3s image

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -4,7 +4,7 @@ variables:
 
   - name: PKG
 
-  - name: UDS_K3D_IMAGE
+  - name: K3D_IMAGE
     default: "ghcr.io/defenseunicorns/oss/uds-k3d-k3s:v1.28.7-k3s1"
 
 includes:

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -4,6 +4,9 @@ variables:
 
   - name: PKG
 
+  - name: UDS_K3D_IMAGE
+    default: "ghcr.io/defenseunicorns/oss/uds-k3d-k3s:v1.28.7-k3s1"
+
 includes:
   - create: ./tasks/create.yaml
   - setup: ./tasks/setup.yaml

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -11,12 +11,12 @@ tasks:
   - name: k3d-standard-bundle
     actions:
       - description: "Deploy the UDS Core Standard Bundle"
-        cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+        cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set=uds-k3d-dev.K3D_IMAGE=${K3D_IMAGE} --confirm --no-progress
 
   - name: k3d-slim-dev-bundle
     actions:
       - description: "Deploy the UDS Core Slim Dev Only Bundle"
-        cmd: uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+        cmd: uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --set=uds-k3d-dev.K3D_IMAGE=${K3D_IMAGE} --confirm --no-progress
 
   - name: single-package
     actions:

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -3,7 +3,7 @@ tasks:
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=github-tags depName=defenseunicorns/uds-k3d versioning=semver
-        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.5.0 --set=K3D_IMAGE=${UDS_K3D_IMAGE} --confirm"
+        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.5.0 --set=K3D_IMAGE=${K3D_IMAGE} --confirm"
 
   - name: k3d-test-cluster
     actions:

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -3,7 +3,7 @@ tasks:
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=github-tags depName=defenseunicorns/uds-k3d versioning=semver
-        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.5.0 --confirm"
+        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.5.0 --set=K3D_IMAGE=${UDS_K3D_IMAGE} --confirm"
 
   - name: k3d-test-cluster
     actions:


### PR DESCRIPTION
## Description
Takes advantage of custom k3s image to deploy more recent K3s releases.  

Relates to https://github.com/defenseunicorns/uds-k3d/pull/55

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed