### PR TITLE
chore: support headless keycloak admin user

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -57,3 +57,9 @@ packages:
             - name: TENANT_TLS_KEY
               description: "The TLS key for the tenant gateway (must be base64 encoded)"
               path: tls.key
+      keycloak:
+        keycloak:
+          variables:
+            - name: INSECURE_ADMIN_PASSWORD_GENERATION
+              description: "Generate an insecure admin password for dev/test"
+              path: insecureAdminPasswordGeneration.enabled

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -93,3 +93,9 @@ packages:
             - name: TENANT_TLS_KEY
               description: "The TLS key for the tenant gateway (must be base64 encoded)"
               path: tls.key
+      keycloak:
+        keycloak:
+          variables:
+            - name: INSECURE_ADMIN_PASSWORD_GENERATION
+              description: "Generate an insecure admin password for dev/test"
+              path: insecureAdminPasswordGeneration.enabled

--- a/src/keycloak/chart/README.md
+++ b/src/keycloak/chart/README.md
@@ -29,7 +29,7 @@ To be able to access the Keycloak administrative console you must create an init
 
 If you are unable to open a browser to create this user (i.e. a headless install), the chart provides values under `insecureAdminPasswordGeneration` which will generate the initial admin user for you and place the password in a secret (`keycloak-admin-password`) in cluster. To use this set `insecureAdminPasswordGeneration.enabled` to `true`, and (optionally) set `insecureAdminPasswordGeneration.username` to the desired username.
 
-Note that this is highly discouraged as it is often used as a shared admin account rather than a being tied to a specific user. If you do use this toggle, you must should immediately change the password after initial login so that your admin account information is not exposed in the cluster secret. This secret will only contain the initial password and will not be updated after you change the password during initial login.
+Note that this is highly discouraged as it is often used as a shared admin account rather than a being tied to a specific user. If you do use this toggle, you should immediately change the password after initial login so that your admin account information is not exposed in the cluster secret. This secret will only contain the initial password and will not be updated after you change the password during initial login.
 
 ## Why StatefulSet?
 

--- a/src/keycloak/chart/README.md
+++ b/src/keycloak/chart/README.md
@@ -12,7 +12,7 @@ For more information on Keycloak and its capabilities, see its [documentation](h
 
 When `devMode: true` is set, the chart will deploy a single Keycloak Pod with an in-memory database and scaling turned off.
 
-#### Autoscaling
+### Autoscaling
 
 The example autoscaling configuration in the values file scales from three up to a maximum of ten Pods using CPU utilization as the metric. Scaling up is done as quickly as required but scaling down is done at a maximum rate of one Pod per five minutes.
 
@@ -22,6 +22,14 @@ Autoscaling can be enabled as follows:
 autoscaling:
   enabled: true
 ```
+
+### Admin User Creation
+
+To be able to access the Keycloak administrative console you must create an initial admin user. You can do this using `zarf connect keycloak` which will launch a port-forward session to Keycloak. From there you will be prompted for the initial admin username and password.
+
+If you are unable to open a browser to create this user (i.e. a headless install), the chart provides values under `insecureAdminPasswordGeneration` which will generate the initial admin user for you and place the password in a secret (`keycloak-admin-password`) in cluster. To use this set `insecureAdminPasswordGeneration.enabled` to `true`, and (optionally) set `insecureAdminPasswordGeneration.username` to the desired username.
+
+Note that this is highly discouraged as it is often used as a shared admin account rather than a being tied to a specific user. If you do use this toggle, you must should immediately change the password after initial login so that your admin account information is not exposed in the cluster secret. This secret will only contain the initial password and will not be updated after you change the password during initial login.
 
 ## Why StatefulSet?
 

--- a/src/keycloak/chart/templates/secret-admin-password.yaml
+++ b/src/keycloak/chart/templates/secret-admin-password.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.insecureAdminPasswordGeneration.enabled }}
+{{- $kcPass := (randAlphaNum 32) | b64enc | quote }}
+{{- $secretName := (print (include "keycloak.fullname" .) "-admin-password") }}
+{{- if .Release.IsUpgrade }}
+  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+  {{- if $existingSecret }}
+    {{- $kcPass = (index $existingSecret.data "password" | b64dec) | quote }}
+  {{- end }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}  
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+type: Opaque
+data:
+  username: {{ .Values.insecureAdminPasswordGeneration.username | b64enc | quote }}
+  password: {{ $kcPass }}
+{{- end }}

--- a/src/keycloak/chart/templates/secret-admin-password.yaml
+++ b/src/keycloak/chart/templates/secret-admin-password.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.insecureAdminPasswordGeneration.enabled }}
 {{- $kcPass := (randAlphaNum 32) | b64enc | quote }}
+{{- $kcUser := .Values.insecureAdminPasswordGeneration.username | b64enc | quote }}
 {{- $secretName := (print (include "keycloak.fullname" .) "-admin-password") }}
 {{- if .Release.IsUpgrade }}
   {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
   {{- if $existingSecret }}
-    {{- $kcPass = (index $existingSecret.data "password" | b64dec) | quote }}
+    {{- $kcUser = (index $existingSecret.data "username") | quote }}
+    {{- $kcPass = (index $existingSecret.data "password") | quote }}
   {{- end }}
 {{- end }}
 apiVersion: v1
@@ -16,6 +18,6 @@ metadata:
     {{- include "keycloak.labels" . | nindent 4 }}
 type: Opaque
 data:
-  username: {{ .Values.insecureAdminPasswordGeneration.username | b64enc | quote }}
+  username: {{ $kcUser }}
   password: {{ $kcPass }}
 {{- end }}

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -170,6 +170,18 @@ spec:
               value: "-Dcom.redhat.fips=true"
             {{- end }}
           {{- end }}
+          {{- if .Values.insecureAdminPasswordGeneration.enabled }}
+            - name: KEYCLOAK_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keycloak.fullname" . }}-admin-password
+                  key: username
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "keycloak.fullname" . }}-admin-password
+                  key: password
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -15,6 +15,12 @@ domain: "###ZARF_VAR_DOMAIN###"
 # The primary Keycloak realm
 realm: uds
 
+# Generates an initial password for first admin user - only use if install is headless
+# (i.e. cannot hit keycloak UI with `zarf connect keycloak`), password should be changed after initial login
+insecureAdminPasswordGeneration:
+  enabled: false
+  username: admin
+
 # Indicates whether information about services should be injected into Pod's environment variables, matching the syntax of Docker links
 enableServiceLinks: true
 


### PR DESCRIPTION
## Description

Provides support for an initial admin user password to be generated. This is documented as the non-ideal path with instructions to change the password after initial login.

This toggle is exposed as a variable in the demo/dev bundles to support simpler CI/Dev testing workflows.

## Related Issue

Resolves https://github.com/defenseunicorns/uds-core/issues/293

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed