### PR TITLE
ci: adjust publish to not get debug output for snapshots

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,7 +69,7 @@ jobs:
           uds run -f tasks/test.yaml validate-packages --no-progress
 
       - name: Debug Output
-        if: ${{ always() }}
+        if: ${{ always() && !inputs.snapshot }}
         uses: ./.github/actions/debug-output
 
       - name: Publish Standard Package


### PR DESCRIPTION
## Description

update the publish ci so that testing debug output does not run for snapshots

## Related Issue

https://github.com/defenseunicorns/uds-core/actions/runs/8536885448

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed