### PR TITLE
ci: adjust save logs to handle k3d container not running

### DIFF
--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -12,7 +12,13 @@ runs:
   steps:
     - name: Pull logs from containerd
       run: |
-        docker cp k3d-uds-server-0:/var/log/ /tmp/uds-containerd-logs
+        CONTAINER_NAME="k3d-uds-server-0"
+        if docker ps | grep -q "$CONTAINER_NAME"; then
+          echo "Container $CONTAINER_NAME is running. Proceeding with log copy..."
+          docker cp ${CONTAINER_NAME}:/var/log/ /tmp/uds-containerd-logs
+        else
+          echo "Container $CONTAINER_NAME is not running. Skipping log copy."
+        fi
       shell: bash
 
     - name: Dump Node Logs


### PR DESCRIPTION
## Description

Adjust CI for the save-logs action to gracefully handle k3d container not running

## Related Issue

https://github.com/defenseunicorns/uds-core/actions/runs/8552847756/job/23453712516#step:15:19

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed