### PR TITLE
fix: loki bucket configuration service_account and namespace

### DIFF
--- a/.github/test-infra/buckets-iac/variables.tf
+++ b/.github/test-infra/buckets-iac/variables.tf
@@ -42,8 +42,8 @@ variable "bucket_configurations" {
   default = {
     loki = {
       name           = "loki"
-      service_account = "logging-loki"
-      namespace = "logging"
+      service_account = "loki"
+      namespace = "loki"
     }
     velero = {
       name           = "velero"


### PR DESCRIPTION
## Description
The loki service_account and namespace for the eks nightly testing match with what DUBBD deployed not uds-core. Updating those values to match the resources in core.

## Related Issue

Fixes #331 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed