### PR TITLE
fix: add nightly uds-bundle.yaml to release-please extras for updates

### DIFF
--- a/.github/bundles/uds-bundle.yaml
+++ b/.github/bundles/uds-bundle.yaml
@@ -3,7 +3,7 @@ metadata:
   name: uds-core-eks-nightly
   description: A UDS bundle for deploying EKS and UDS Core
   # x-release-please-start-version
-  version: "0.18.0"
+  version: "0.19.0"
   # x-release-please-end
 
 packages:
@@ -15,7 +15,7 @@ packages:
   - name: core
     path: ../../build/
     # x-release-please-start-version
-    ref: 0.18.0
+    ref: 0.19.0
     # x-release-please-end
     overrides:
       velero:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,7 @@
       ],
       "versioning": "default",
       "extra-files": [
+        ".github/bundles/uds-bundle.yaml",
         "README.md",
         "packages/slim-dev/zarf.yaml",
         "packages/standard/zarf.yaml",


### PR DESCRIPTION
## Description
I was poking around some things to learn how other teams/repositories used release-please when I noticed what looked to be an accidental mistake where a file wasn't added to the release-please-config.json `extra-files` and the version lapsed behind by a minor.
...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed