### PR TITLE
feat: add keycloak sso realm values

### DIFF
--- a/src/keycloak/chart/templates/secret-kc-realm.yaml
+++ b/src/keycloak/chart/templates/secret-kc-realm.yaml
@@ -9,8 +9,8 @@ type: Opaque
 data:
   {{- range $key, $value := .Values.realmInitEnv }}
   {{- if eq (typeOf $value) "bool" }}
-  realm_{{ $key }}: {{ toString $value | b64enc }}
+  REALM_{{ $key }}: {{ toString $value | b64enc }}
   {{- else }}
-  realm_{{ $key }}: {{ $value | b64enc }}
+  REALM_{{ $key }}: {{ $value | b64enc }}
   {{- end }}
   {{- end }}

--- a/src/keycloak/chart/templates/secret-kc-realm.yaml
+++ b/src/keycloak/chart/templates/secret-kc-realm.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "keycloak.fullname" . }}-realm-env
+  namespace: {{ .Release.Namespace }}  
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+type: Opaque
+data:
+  UDS_GOOGLE_SSO_ENABLED: {{ .Values.google.sso.enabled | toString | b64enc }}
+  UDS_GOOGLE_SSO_CLIENT_ID: {{ .Values.google.sso.client_id | b64enc }}
+  UDS_GOOGLE_SSO_CLIENT_SECRET: {{ .Values.google.sso.client_secret | b64enc }}

--- a/src/keycloak/chart/templates/secret-kc-realm.yaml
+++ b/src/keycloak/chart/templates/secret-kc-realm.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "keycloak.labels" . | nindent 4 }}
 type: Opaque
 data:
-  UDS_GOOGLE_SSO_ENABLED: {{ .Values.google.sso.enabled | toString | b64enc }}
-  UDS_GOOGLE_SSO_CLIENT_ID: {{ .Values.google.sso.client_id | b64enc }}
-  UDS_GOOGLE_SSO_CLIENT_SECRET: {{ .Values.google.sso.client_secret | b64enc }}
+  {{- range $key, $value := .Values.identityConfigEnv }}
+  {{- if eq (typeOf $value) "bool" }}
+  {{ $key }}: {{ toString $value | b64enc }}
+  {{- else }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+  {{- end }}

--- a/src/keycloak/chart/templates/secret-kc-realm.yaml
+++ b/src/keycloak/chart/templates/secret-kc-realm.yaml
@@ -9,8 +9,8 @@ type: Opaque
 data:
   {{- range $key, $value := .Values.realmInitEnv }}
   {{- if eq (typeOf $value) "bool" }}
-  {{ $key }}: {{ toString $value | b64enc }}
+  realm_{{ $key }}: {{ toString $value | b64enc }}
   {{- else }}
-  {{ $key }}: {{ $value | b64enc }}
+  realm_{{ $key }}: {{ $value | b64enc }}
   {{- end }}
   {{- end }}

--- a/src/keycloak/chart/templates/secret-kc-realm.yaml
+++ b/src/keycloak/chart/templates/secret-kc-realm.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "keycloak.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- range $key, $value := .Values.identityConfigEnv }}
+  {{- range $key, $value := .Values.realmInitEnv }}
   {{- if eq (typeOf $value) "bool" }}
   {{ $key }}: {{ toString $value | b64enc }}
   {{- else }}

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -72,6 +72,9 @@ spec:
             # This will only import the realm if it does not exist
             - "--import-realm"
             - "--features=preview"
+          envFrom:
+            - secretRef:
+                name: {{ include "keycloak.fullname" . }}-realm-env            
           env:
             # Common configuration
             - name: UDS_DOMAIN

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -15,6 +15,13 @@ domain: "###ZARF_VAR_DOMAIN###"
 # The primary Keycloak realm
 realm: uds
 
+# Google SSO Values
+google:
+  sso:
+    enabled: "false"
+    client_id: ""
+    client_secret: ""
+
 # Generates an initial password for first admin user - only use if install is headless
 # (i.e. cannot hit keycloak UI with `zarf connect keycloak`), password should be changed after initial login
 insecureAdminPasswordGeneration:

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -15,12 +15,9 @@ domain: "###ZARF_VAR_DOMAIN###"
 # The primary Keycloak realm
 realm: uds
 
-# Google SSO Values
-google:
-  sso:
-    enabled: "false"
-    client_id: ""
-    client_secret: ""
+# UDS Identity Config Environment Variables
+identityConfigEnv:
+  ssoEnabled: false
 
 # Generates an initial password for first admin user - only use if install is headless
 # (i.e. cannot hit keycloak UI with `zarf connect keycloak`), password should be changed after initial login

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -17,10 +17,10 @@ realm: uds
 
 # UDS Identity Config Environment Variables. More info here: https://github.com/defenseunicorns/uds-identity-config/blob/main/docs/CUSTOMIZE.md#override-default-realm
 realmInitEnv:
-  googleIdpEnabled: false
+  GOOGLE_IDP_ENABLED: false
   # Other UDS Identity Config fields that will be used in the realm.json initalization of keycloak
-  # googleIdpClientId: ""
-  # googleIdpClientSecret: ""
+  # GOOGLE_IDP_CLIENTID: ""
+  # GOOGLE_IDP_CLIENT_SECRET: ""
 
 # Generates an initial password for first admin user - only use if install is headless
 # (i.e. cannot hit keycloak UI with `zarf connect keycloak`), password should be changed after initial login

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -16,8 +16,11 @@ domain: "###ZARF_VAR_DOMAIN###"
 realm: uds
 
 # UDS Identity Config Environment Variables
-identityConfigEnv:
-  ssoEnabled: false
+realmInitEnv:
+  realm_googleIdpEnabled: false
+  # Other UDS Identity Config fields that will be used in the realm.json initalization of keycloak
+  # realm_googleIdpClientId: ""
+  # realm_googleIdpClientSecret: ""
 
 # Generates an initial password for first admin user - only use if install is headless
 # (i.e. cannot hit keycloak UI with `zarf connect keycloak`), password should be changed after initial login

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -15,12 +15,12 @@ domain: "###ZARF_VAR_DOMAIN###"
 # The primary Keycloak realm
 realm: uds
 
-# UDS Identity Config Environment Variables
+# UDS Identity Config Environment Variables. More info here: https://github.com/defenseunicorns/uds-identity-config/blob/main/docs/CUSTOMIZE.md#override-default-realm
 realmInitEnv:
-  realm_googleIdpEnabled: false
+  googleIdpEnabled: false
   # Other UDS Identity Config fields that will be used in the realm.json initalization of keycloak
-  # realm_googleIdpClientId: ""
-  # realm_googleIdpClientSecret: ""
+  # googleIdpClientId: ""
+  # googleIdpClientSecret: ""
 
 # Generates an initial password for first admin user - only use if install is headless
 # (i.e. cannot hit keycloak UI with `zarf connect keycloak`), password should be changed after initial login


### PR DESCRIPTION
## Description
Add values for configuring google sso.

Three values:
* Enable SSO
* SSO Client ID
* SSO Client Secret

Default values create the Google IDP, however it is disabled and if enabled would require client id and client secret to be added to work properly.

Values put into secret and then create environment variable from those which are referenced in the uds-identity-config realm.json. A PR will be created in uds-identity-config as well for that side of this process.


## Related Issue
[
uds-identity-config PR](https://github.com/defenseunicorns/uds-identity-config/pull/58)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed