### PR TITLE
chore: add debug logging to endpointslice watch

### DIFF
--- a/src/pepr/operator/controllers/network/generators/kubeAPI.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.ts
@@ -1,5 +1,5 @@
 import { V1NetworkPolicyPeer } from "@kubernetes/client-node";
-import { K8s, Log, R, kind } from "pepr";
+import { K8s, kind, Log, R } from "pepr";
 
 import { RemoteGenerated } from "../../../crd";
 import { anywhere } from "./anywhere";
@@ -36,8 +36,16 @@ export function kubeAPI() {
  * @param slice The EndpointSlice for the API server
  */
 export async function updateAPIServerCIDRFromEndpointSlice(slice: kind.EndpointSlice) {
-  const svc = await K8s(kind.Service).InNamespace("default").Get("kubernetes");
-  await updateAPIServerCIDR(slice, svc);
+  try {
+    Log.debug(
+      "Processing watch for endpointslices, getting k8s service for updating API server CIDR",
+    );
+    const svc = await K8s(kind.Service).InNamespace("default").Get("kubernetes");
+    await updateAPIServerCIDR(slice, svc);
+  } catch (err) {
+    const msg = "Failed to update network policies from endpoint slice watch";
+    Log.error({ err }, msg);
+  }
 }
 
 /**
@@ -45,8 +53,16 @@ export async function updateAPIServerCIDRFromEndpointSlice(slice: kind.EndpointS
  * @param svc The Service for the API server
  */
 export async function updateAPIServerCIDRFromService(svc: kind.Service) {
-  const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
-  await updateAPIServerCIDR(slice, svc);
+  try {
+    Log.debug(
+      "Processing watch for api service, getting endpoint slices for updating API server CIDR",
+    );
+    const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
+    await updateAPIServerCIDR(slice, svc);
+  } catch (err) {
+    const msg = "Failed to update network policies from api service watch";
+    Log.error({ err }, msg);
+  }
 }
 
 /**
@@ -74,24 +90,29 @@ export async function updateAPIServerCIDR(slice: kind.EndpointSlice, svc: kind.S
       },
     }));
 
-    // Get all the KubeAPI NetworkPolicies
-    const netPols = await K8s(kind.NetworkPolicy)
-      .WithLabel("uds.dev/generated", RemoteGenerated.KubeAPI)
-      .Get();
+    try {
+      // Get all the KubeAPI NetworkPolicies
+      const netPols = await K8s(kind.NetworkPolicy)
+        .WithLabel("uds.dev/generated", RemoteGenerated.KubeAPI)
+        .Get();
 
-    for (const netPol of netPols.items) {
-      // Get the old peers
-      const oldPeers = netPol.spec?.egress?.[0].to;
+      for (const netPol of netPols.items) {
+        // Get the old peers
+        const oldPeers = netPol.spec?.egress?.[0].to;
 
-      // Update the NetworkPolicy if the peers have changed
-      if (!R.equals(oldPeers, apiServerPeers)) {
-        // Note using the apiServerPeers variable here instead of the oldPeers variable
-        // in case another EndpointSlice is updated before this one
-        netPol.spec!.egress![0].to = apiServerPeers;
+        // Update the NetworkPolicy if the peers have changed
+        if (!R.equals(oldPeers, apiServerPeers)) {
+          // Note using the apiServerPeers variable here instead of the oldPeers variable
+          // in case another EndpointSlice is updated before this one
+          netPol.spec!.egress![0].to = apiServerPeers;
 
-        Log.debug(`Updating ${netPol.metadata!.namespace}/${netPol.metadata!.name}`);
-        await K8s(kind.NetworkPolicy).Apply(netPol);
+          Log.debug(`Updating ${netPol.metadata!.namespace}/${netPol.metadata!.name}`);
+          await K8s(kind.NetworkPolicy).Apply(netPol);
+        }
       }
+    } catch (err) {
+      const msg = "Failed to update network policies with new API CIDRs";
+      Log.error({ err }, msg);
     }
   }
 }

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.ts
@@ -11,7 +11,9 @@ let apiServerPeers: V1NetworkPolicyPeer[];
  * Initialize the API server CIDR by getting the EndpointSlice and Service for the API server
  */
 export async function initAPIServerCIDR() {
-  const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
+  const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get(
+    "kubernetes",
+  );
   const svc = await K8s(kind.Service).InNamespace("default").Get("kubernetes");
   await updateAPIServerCIDR(slice, svc);
 }
@@ -35,12 +37,16 @@ export function kubeAPI() {
  * When the kubernetes EndpointSlice is created or updated, update the API server CIDR
  * @param slice The EndpointSlice for the API server
  */
-export async function updateAPIServerCIDRFromEndpointSlice(slice: kind.EndpointSlice) {
+export async function updateAPIServerCIDRFromEndpointSlice(
+  slice: kind.EndpointSlice,
+) {
   try {
     Log.debug(
       "Processing watch for endpointslices, getting k8s service for updating API server CIDR",
     );
-    const svc = await K8s(kind.Service).InNamespace("default").Get("kubernetes");
+    const svc = await K8s(kind.Service).InNamespace("default").Get(
+      "kubernetes",
+    );
     await updateAPIServerCIDR(slice, svc);
   } catch (err) {
     const msg = "Failed to update network policies from endpoint slice watch";
@@ -57,7 +63,9 @@ export async function updateAPIServerCIDRFromService(svc: kind.Service) {
     Log.debug(
       "Processing watch for api service, getting endpoint slices for updating API server CIDR",
     );
-    const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
+    const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get(
+      "kubernetes",
+    );
     await updateAPIServerCIDR(slice, svc);
   } catch (err) {
     const msg = "Failed to update network policies from api service watch";
@@ -71,12 +79,15 @@ export async function updateAPIServerCIDRFromService(svc: kind.Service) {
  * @param slice The EndpointSlice for the API server
  * @param svc The Service for the API server
  */
-export async function updateAPIServerCIDR(slice: kind.EndpointSlice, svc: kind.Service) {
+export async function updateAPIServerCIDR(
+  slice: kind.EndpointSlice,
+  svc: kind.Service,
+) {
   const { endpoints } = slice;
   const k8sApiIP = svc.spec?.clusterIP;
 
   // Flatten the endpoints into a list of IPs
-  const peers = endpoints?.flatMap(e => e.addresses);
+  const peers = endpoints?.flatMap((e) => e.addresses);
 
   if (k8sApiIP) {
     peers?.push(k8sApiIP);
@@ -84,35 +95,32 @@ export async function updateAPIServerCIDR(slice: kind.EndpointSlice, svc: kind.S
 
   // If the peers are found, cache and process them
   if (peers?.length) {
-    apiServerPeers = peers.flatMap(ip => ({
+    apiServerPeers = peers.flatMap((ip) => ({
       ipBlock: {
         cidr: `${ip}/32`,
       },
     }));
 
-    try {
-      // Get all the KubeAPI NetworkPolicies
-      const netPols = await K8s(kind.NetworkPolicy)
-        .WithLabel("uds.dev/generated", RemoteGenerated.KubeAPI)
-        .Get();
+    // Get all the KubeAPI NetworkPolicies
+    const netPols = await K8s(kind.NetworkPolicy)
+      .WithLabel("uds.dev/generated", RemoteGenerated.KubeAPI)
+      .Get();
 
-      for (const netPol of netPols.items) {
-        // Get the old peers
-        const oldPeers = netPol.spec?.egress?.[0].to;
+    for (const netPol of netPols.items) {
+      // Get the old peers
+      const oldPeers = netPol.spec?.egress?.[0].to;
 
-        // Update the NetworkPolicy if the peers have changed
-        if (!R.equals(oldPeers, apiServerPeers)) {
-          // Note using the apiServerPeers variable here instead of the oldPeers variable
-          // in case another EndpointSlice is updated before this one
-          netPol.spec!.egress![0].to = apiServerPeers;
+      // Update the NetworkPolicy if the peers have changed
+      if (!R.equals(oldPeers, apiServerPeers)) {
+        // Note using the apiServerPeers variable here instead of the oldPeers variable
+        // in case another EndpointSlice is updated before this one
+        netPol.spec!.egress![0].to = apiServerPeers;
 
-          Log.debug(`Updating ${netPol.metadata!.namespace}/${netPol.metadata!.name}`);
-          await K8s(kind.NetworkPolicy).Apply(netPol);
-        }
+        Log.debug(
+          `Updating ${netPol.metadata!.namespace}/${netPol.metadata!.name}`,
+        );
+        await K8s(kind.NetworkPolicy).Apply(netPol);
       }
-    } catch (err) {
-      const msg = "Failed to update network policies with new API CIDRs";
-      Log.error({ err }, msg);
     }
   }
 }

--- a/src/pepr/operator/index.ts
+++ b/src/pepr/operator/index.ts
@@ -33,7 +33,7 @@ When(a.EndpointSlice)
   .IsCreatedOrUpdated()
   .InNamespace("default")
   .WithName("kubernetes")
-  .Watch(updateAPIServerCIDRFromEndpointSlice);
+  .Reconcile(updateAPIServerCIDRFromEndpointSlice);
 
 // Watch for changes to the API server Service and update the API server CIDR
 When(a.Service)


### PR DESCRIPTION
## Description

Adds additional debug logging around the endpointslice watch, and switches to reconcile so this runs in a queue.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/358

Fixes https://github.com/defenseunicorns/uds-core/issues/317

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed