### PR TITLE
chore: move api service watch to reconcile

### DIFF
--- a/src/pepr/operator/index.ts
+++ b/src/pepr/operator/index.ts
@@ -40,12 +40,12 @@ When(a.Service)
   .IsCreatedOrUpdated()
   .InNamespace("default")
   .WithName("kubernetes")
-  .Watch(updateAPIServerCIDRFromService);
+  .Reconcile(updateAPIServerCIDRFromService);
 
 // Watch for changes to the UDSPackage CRD and cleanup the namespace mutations
 When(UDSPackage)
   .IsDeleted()
-  .Watch(async pkg => {
+  .Watch(async (pkg) => {
     // Cleanup the namespace
     await cleanupNamespace(pkg);
 
@@ -65,4 +65,6 @@ When(UDSPackage)
 When(UDSExemption).IsDeleted().Watch(removeExemptions);
 
 // Watch for changes to the UDSExemption CRD to enqueue an exemption for processing
-When(UDSExemption).IsCreatedOrUpdated().Validate(exemptValidator).Reconcile(exemptReconciler);
+When(UDSExemption).IsCreatedOrUpdated().Validate(exemptValidator).Reconcile(
+  exemptReconciler,
+);

--- a/src/pepr/operator/index.ts
+++ b/src/pepr/operator/index.ts
@@ -45,7 +45,7 @@ When(a.Service)
 // Watch for changes to the UDSPackage CRD and cleanup the namespace mutations
 When(UDSPackage)
   .IsDeleted()
-  .Watch(async (pkg) => {
+  .Watch(async pkg => {
     // Cleanup the namespace
     await cleanupNamespace(pkg);
 
@@ -65,6 +65,4 @@ When(UDSPackage)
 When(UDSExemption).IsDeleted().Watch(removeExemptions);
 
 // Watch for changes to the UDSExemption CRD to enqueue an exemption for processing
-When(UDSExemption).IsCreatedOrUpdated().Validate(exemptValidator).Reconcile(
-  exemptReconciler,
-);
+When(UDSExemption).IsCreatedOrUpdated().Validate(exemptValidator).Reconcile(exemptReconciler);


### PR DESCRIPTION
## Description

Follow up to https://github.com/defenseunicorns/uds-core/pull/359 to move the apiservice watch to a queue/reconcile.

## Related Issue

Resolves https://github.com/defenseunicorns/uds-core/issues/363

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed