### PR TITLE
chore: 🐛 use reconcile to reduce thrash in pod watch and service watch

### DIFF
--- a/src/pepr/istio/index.ts
+++ b/src/pepr/istio/index.ts
@@ -19,7 +19,7 @@ When(a.Pod)
   .IsCreatedOrUpdated()
   .WithLabel("batch.kubernetes.io/job-name")
   .WithLabel("service.istio.io/canonical-name")
-  .Watch(async pod => {
+  .Reconcile(async pod => {
     Log.info(
       pod,
       `Processing Pod ${pod.metadata?.namespace}/${pod.metadata?.name} for istio job termination`,

--- a/src/pepr/operator/index.ts
+++ b/src/pepr/operator/index.ts
@@ -40,7 +40,7 @@ When(a.Service)
   .IsCreatedOrUpdated()
   .InNamespace("default")
   .WithName("kubernetes")
-  .Watch(updateAPIServerCIDRFromService);
+  .Reconcile(updateAPIServerCIDRFromService);
 
 // Watch for changes to the UDSPackage CRD and cleanup the namespace mutations
 When(UDSPackage)


### PR DESCRIPTION
## Description

We are watching for changes to the Kubernetes service and Neuvector Jobs in order to update network policy. This triggers a cascade of events on each change leading to likely thrash in the kube-apiserver. If we put them into a queue then they will be processes one at a time in the order in which the event came in. Cutting down the load on the API Server.

**Visual Proof**

Look at the wild spikes in CPU on the watcher. Now with this ordered processing, it seems to throttle the amount used and therefore is not hitting that strange frozen state.

See the issue for additional screenshots

![image](https://github.com/defenseunicorns/uds-core/assets/1096507/784134b1-0889-4d89-b55d-08c6bec021d8)

52 mins no errors

![image](https://github.com/defenseunicorns/uds-core/assets/1096507/d3eca1c0-1670-4610-bddc-d67e0b1358ce)
![image](https://github.com/defenseunicorns/uds-core/assets/1096507/ca8c16cf-057a-4379-a31b-b1db58ee4987)

First failure after 78 mins (memory seems to be growing)
![image](https://github.com/defenseunicorns/uds-core/assets/1096507/c9672b26-7df8-4c78-adfd-2e45c7925aa1)

## Related Issue

Fixes - Hopefully 🤞 363 
<!-- or -->
Relates to #363  https://github.com/defenseunicorns/pepr/issues/745

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed