### PR TITLE
ci: allow triggering CI in release PRs

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -3,7 +3,8 @@ name: Metadata
 on:
   pull_request:
     branches: [main]
-    types: [opened, edited, synchronize]
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    types: [milestoned, opened, reopened, synchronize]
 
 jobs:
   title_check:

--- a/.github/workflows/pull-request-conditionals.yaml
+++ b/.github/workflows/pull-request-conditionals.yaml
@@ -3,6 +3,8 @@ name: Filter
 # This workflow is triggered on pull requests
 on:
   pull_request:
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    types: [milestoned, opened, reopened, synchronize]
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:


### PR DESCRIPTION
## Description

Adds ability to trigger release-please PR CI by adding a milestone. This is a common pattern that SWF repos have adopted to workaround the limitations of commits made by the Github token.

## Related Issue

Closes https://github.com/defenseunicorns/uds-core/issues/65

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed