### PR TITLE
fix: renovate config grouping, test-infra

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,17 +8,6 @@
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "separateMajorMinor": false,
-  "hostRules": [
-    {
-      "matchHost": "registry1.dso.mil",
-      "hostType": "docker",
-      "description": "Encrypted creds for registry1, scoped to this Github org using: https://github.com/renovatebot/renovate/blob/main/docs/usage/configuration-options.md#encrypted",
-      "encrypted": {
-        "username": "wcFMA/xDdHCJBTolAQ/9FXYzgNUO6MJ9crVH8W1p5U8ecnK6yamVOBmKib+9Lu4dtldIzqJBObR8Ctvq+our0VTXbhuCU0AvghJO+Rbjij+sDK3VNL93ojD2Xcd3IHeZhz4U+K2VPIRKHGPTC2mfc9pRZ076hoRqeAPWYrtU3gtNk7ZedMX75+yEuUWax5wS0gIjHnbu/R8fLTadNPbdyRaVGYembtuF8P2hMorCrjAED07UNivnaJaNb6Dj72Bticwqs2gIStoed3S8luzUJIgOOdS9J4Dq3ybkSIWg3+GJQhLyKIhZpgbRQoMbYLQ/z7obT1xX0avXnjobb5rW445R0LXLXj4MokgGo1p5cA+AhP5JEk49w2uutzD3tPZB58edH4USOk4q/9MXNdXzvU5RxOA6ScGeh1JNa+62/N4HA8UtYEudTFOcHkt3xq6h5VKc5k7JbvkCso29wqC8AR5ctBzuLspnzxhPrjm/BcfB/FMnwJE2MbtBxa8R1Z5Hd1DEfsEV57mF7dtV0SIImV+l/4bK/1xz/G9v31u/5DrfkQR6DjAvX8w4zUZE5gHKGsZoeZEFuUc5YQuwdeWEg20Qah4v6rbDfJUzXj9vbyFLMdIomPkuWkNSDzg6oMWCmeQAeL3+ykjsVdoBoJCvHvFEpw4dlrdlnQK1VXsWSX7TTDkRuYKQUKbKIBOWOCXScgFDQwu+f0mUkmFX1MrAojYgfWyZ1hlUDGcsE4pvTWJKP1lHykRM/qPUVh/YXfayh5upYh2MXT44yqMHhyNJE/KlCTp9KXsdflm3kaCAhqEC746IbvBpPjz3DTA7nwLUhDB3K2Zi9t/kIhMQCbV+wI2FgA",
-        "password": "wcFMA/xDdHCJBTolAQ/6A4VHieAREvIZ35w9tpdLuvCysq3951xcwBD+o5A6QNYz9K5J0X4NDp2NF5FwEeEBgh3CGF7t/jXHdvvFUSo1wnTT0N+XoU4fXta1px9rkZssPWaMmqbmQ+KWXrEo7SMYK4nXBdExtIZ/j8XvjvTZ1apAh+ySW41eAKXbeQC+5I2rjDJegH6hI7kGkQDzmSAoaDX/Nw8seccozzOj9GEGxPbtF1UYJIfG0jZObf0GowXXCtCOEd5QcQQnzILIaiN0tgZgXrQKFehMTboi8rgYLtRI3LIObUjxl7O59q7ZBCkUuyt9nYF14i9PD8IltVdPsTrGpyK/yQMFrjHWkIPGFHZC9dLyjQlhTjMFBYdye9KGfoZHnKR5pXZw7JvCho/PaP3S8y4LXPJa7YHty0wEcP1eWT0b1hapHnsyDEJ22xyCz0hVFeUnXRPj3zSqBzn4+wVPZmxcCwuLNmu28JJ76SNYAf/4hTjlc2+8WasB/C8rNA+ASf+C6SsMMp677JffWXJtfJHgtPGV+gTCBITG7D8pkCVyIdoiGDv503QDiw59YdocEHkIaRw6EzSZ5XFEHz0mbnTZ7HgRYPklsQzVvetEOmctFdZgYZZ1hjVOkWIjiuSR+hDc3IT/TdXEohZxizAZAEmmsli0Q70m2EWJo1tUqxS9soQGKGQc/crIdpHSdgFfBI3gyKZP4ehv1WzYqrWlg1syDgbNllgEJIIBxv+ZI+QMJUF8SdtleMkxE6PYvc1bzpj6nTrM1oahiK8BUKS+cTpXQr1+LneL1mQ/4rSqNQO5ooBweej3Ql0cDNzjahfYc/1AwctQOdjZRpmGUs+RaMezgF8"
-      }
-    }
-  ],
   "helm-values": {
     "ignorePaths": ["src/neuvector/values"]
   },
@@ -119,12 +108,17 @@
       "groupName": "uds-k3d",
       "commitMessageTopic": "uds-k3d"
     },
-    { 
-      "matchFileNames": [".github/**"],
-      "excludePackageNames": ["defenseunicorns/zarf","defenseunicorns/uds-cli"],
+    {
+      "matchFileNames": [".github/workflows/**", ".github/actions/**"],
+      "excludePackageNames": ["defenseunicorns/zarf", "defenseunicorns/uds-cli"],
       "groupName": "githubactions",
       "commitMessageTopic": "githubactions",
       "pinDigests": true
+    },
+    {
+      "matchFileNames": [".github/test-infra/**"],
+      "groupName": "test-infra",
+      "commitMessageTopic": "test-infra"
     },
     {
       "matchFileNames": ["package.json", "package-lock.json", "tasks/create.yaml"],


### PR DESCRIPTION
## Description

- Removes invalid version constraint from terraform (per renovate error)
- Removes host rule/reg1 creds from renovate (included with common config)
- Adds new grouping for test-infra and ensures that github-actions group only applies to actions (not the test bundle)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed