### PR TITLE
fix: integrated docs

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,3 +1,0 @@
-module github.com/defenseunicorns/uds-core/docs
-
-go 1.20

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/defenseunicorns/uds-core
+
+go 1.20


### PR DESCRIPTION
## Description
In order for go modules to pull our docs directories into the `uds` repo and use the tagged release version of uds-core the go.mod file needs to be at the base level of the repo.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed