### PR TITLE
fix: check if exemption exists before cleanup

### DIFF
--- a/pepr.ts
+++ b/pepr.ts
@@ -2,6 +2,7 @@ import { Log, PeprModule } from "pepr";
 
 import cfg from "./package.json";
 
+import { DataStore } from "pepr/dist/lib/storage";
 import { istio } from "./src/pepr/istio";
 import { operator } from "./src/pepr/operator";
 import { Policy } from "./src/pepr/operator/crd";
@@ -28,11 +29,18 @@ import { prometheus } from "./src/pepr/prometheus";
     prometheus,
   ]);
   // Remove legacy policy entries from the pepr store for the 0.5.0 upgrade
-  if (process.env.PEPR_WATCH_MODE === "true" && cfg.version === "0.5.0") {
+  if (
+    process.env.PEPR_MODE === "dev" ||
+    (process.env.PEPR_WATCH_MODE === "true" && cfg.version === "0.5.0")
+  ) {
     Log.debug("Clearing legacy pepr store exemption entries...");
-    policies.Store.onReady(() => {
-      for (const p of Object.values(Policy)) {
-        policies.Store.removeItem(p);
+    policies.Store.onReady((data: DataStore) => {
+      const policiesList = Object.values(Policy);
+      for (const p of Object.keys(data)) {
+        // if p matches a Policy key, remove it
+        if (policiesList.includes(p as Policy)) {
+          policies.Store.removeItem(p);
+        }
       }
     });
   }

--- a/pepr.ts
+++ b/pepr.ts
@@ -39,6 +39,7 @@ import { prometheus } from "./src/pepr/prometheus";
       for (const p of Object.keys(data)) {
         // if p matches a Policy key, remove it
         if (policiesList.includes(p as Policy)) {
+          Log.debug(`Removing legacy storage of ${p} policy exemptions...`);
           policies.Store.removeItem(p);
         }
       }


### PR DESCRIPTION
## Description
Workaround for issue where Pepr store fails to update the store perpetually if a `removeItem` is called on a key that does not exist.

FIxes https://github.com/defenseunicorns/uds-core/issues/463

## Related Issue
Fixes https://github.com/defenseunicorns/uds-core/issues/463
<!-- or -->
Relates to https://github.com/defenseunicorns/pepr/issues/865

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed