### PR TITLE
fix(docs): uds-config.yaml example in k3d-slim-dev README

### DIFF
--- a/bundles/k3d-slim-dev/README.md
+++ b/bundles/k3d-slim-dev/README.md
@@ -25,15 +25,14 @@ Example:
 ```yaml
 variables:
   uds-k3d-dev:
-    set:
-      buckets:
-        - name: "myfavoritebucket"
-          policy: "public"
-          purge: false
-      users:
-        - accessKey: console
-          secretKey: "console-secret"
-          policy: consoleAdmin
+    buckets:
+      - name: "myfavoritebucket"
+        policy: "public"
+        purge: false
+    users:
+      - accessKey: console
+        secretKey: "console-secret"
+        policy: consoleAdmin
 ```
 
 For more details on how to customize the Minio deployment, please see [Configuring Minio](https://github.com/defenseunicorns/uds-k3d/blob/main/docs/MINIO.md).


### PR DESCRIPTION
## Description

The `set` field as documented for `uds-config.yaml` to do deploy-time variable overrides does not work.

On a related note, the pattern in the linked Minio repository also didn't seem to work (using `bundle.deploy.zarf-packages.uds-k3d-dev.set`).

The README for k3d-standard is correct but I didn't reference it since I was only using k3d-slim-dev.

## Related Issue

Closes #529 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed