### PR TITLE
feat!: set istio passthrough gateway as optional component

### DIFF
--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -36,6 +36,8 @@ packages:
     # x-release-please-start-version
     ref: 0.22.2
     # x-release-please-end
+    optionalComponents:
+      - istio-passthrough-gateway
     overrides:
       loki:
         loki:

--- a/packages/slim-dev/zarf.yaml
+++ b/packages/slim-dev/zarf.yaml
@@ -31,7 +31,7 @@ components:
       path: ../../src/istio
 
   - name: istio-passthrough-gateway
-    required: true
+    required: false
     import:
       path: ../../src/istio
 

--- a/packages/standard/zarf.yaml
+++ b/packages/standard/zarf.yaml
@@ -31,7 +31,7 @@ components:
       path: ../../src/istio
 
   - name: istio-passthrough-gateway
-    required: true
+    required: false
     import:
       path: ../../src/istio
 

--- a/src/istio/README.md
+++ b/src/istio/README.md
@@ -1,1 +1,11 @@
 # Istio
+
+A powerful service mesh tool that provides traffic management, load balancing, security, and observability features.
+
+## Gateways
+
+UDS Core provides a few Istio [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) resources to allow ingress into the service mesh. Each one serves a different purpose and can be used to route traffic to different services.
+
+1. **(Required)** Tenant Gateway - This gateway provides ingress to typical end-user applications. By default, UDS Core deploys a few services on this gateway, such as the Keycloak SSO portal. This gateway is typically exposed to end users of the applications deployed on top of UDS Core.
+2. **(Required)** Admin Gateway - This gateway provides ingress to admin-related applications that are not for use by the default end user. By default, UDS Core deploys a few services on this gateway, such as the Admin Keycloak interface. This gateway is typically accessible to admins of the applications deployed on top of UDS Core. *Since the Admin and Tenant Gateways are logically separated, it is possible to have different security controls on each gateway.*
+3. **(Optional)** Passthrough Gateway - This gateway allows mesh ingress without TLS termination performed by Istio. This could be useful for applications that need to (or currently) handle their own TLS termination. This gateway used to be a default component of UDS Core but is no longer deployed by default. To deploy this gateway, you must specify `istio-passthrough-gateway` as an `optionalComponent` in your UDS Bundle configuration.

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -69,7 +69,7 @@ components:
           - "values/config-tenant.yaml"
 
   - name: istio-passthrough-gateway
-    required: true
+    required: false
     charts:
       - name: gateway
         url: https://istio-release.storage.googleapis.com/charts


### PR DESCRIPTION
BREAKING CHANGE: Istio passthrough gateway is no longer deployed by default

## Description
- Sets the `istio-passthrough-gateway` as not required in the `slim-dev` and `standard` package.  
- Added `istio-passthrough-gateway` as an included `optionalComponent` in the `k3d-standard` bundle so that it can still be deployed and tested.  
- Added some documentation around the istio gateways and use cases
...

## Related Issue

Fixes #510

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed