### PR TITLE
docs(site): fix dev command in site docs

### DIFF
--- a/docs/deployment/uds-deploy.md
+++ b/docs/deployment/uds-deploy.md
@@ -90,7 +90,7 @@ Below is an example of the workflow developing the [metrics-server package](http
 
 ```cli
 # Create the dev environment
-uds run dev
+uds run dev-setup
 
 # If developing the Pepr module:
 npx pepr dev


### PR DESCRIPTION
## Description

Fixed a bad command in site docs.  The command referenced `uds run dev` when it should really be `uds dev-setup` as highlighted in this [task](https://github.com/defenseunicorns/uds-core/blob/dcdadb49255a5052dcb3fe079335976b758b32f9/tasks.yaml#L24).
...

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed