### PR TITLE
feat: add optional authservice component to published slim-dev bundle

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -36,6 +36,8 @@ packages:
     # x-release-please-start-version
     ref: 0.24.0
     # x-release-please-end
+    optionalComponents:
+      - authservice
     overrides:
       istio-admin-gateway:
         uds-istio-config:

--- a/packages/slim-dev/README.md
+++ b/packages/slim-dev/README.md
@@ -1,3 +1,5 @@
 # UDS Core Slim Dev
 
-This is a special modified version of UDS Core that only includes the components needed to run Istio, UDS Operator and Keycloak.
+This is a special modified version of UDS Core that only includes the components needed to run Istio, UDS Operator, Keycloak and Authservice 
+
+Note: Authservice is off by default and requires opt-in on deploy.

--- a/packages/slim-dev/zarf.yaml
+++ b/packages/slim-dev/zarf.yaml
@@ -52,3 +52,10 @@ components:
     required: true
     import:
       path: ../../src/keycloak
+
+  # Authservice
+  - name: authservice
+    required: false
+    default: false
+    import:
+      path: ../../src/authservice


### PR DESCRIPTION
## Description

Adds optional Authservice component to published slim-dev bundle to enable delivery CICD for mission apps and incentive AppDev teams to use UDS / increase adoption

## Related Issue

Fixes #534 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed