### PR TITLE
chore(loki): default query settings, config as secret

### DIFF
--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -15,6 +15,7 @@ memberlist:
     publishNotReadyAddresses: true
 
 loki:
+  configStorageType: Secret
   storage:
     bucketNames:
       chunks: uds
@@ -29,9 +30,12 @@ loki:
       insecure: false
   commonConfig:
     replication_factor: 1
+  limits_config:
+    split_queries_by_interval: "30m"
+  query_scheduler:
+    max_outstanding_requests_per_tenant: 32000 # This is the default in Loki 3.0
   extraMemberlistConfig:
     rejoin_interval: 120s
-  # Should authentication be enabled
   auth_enabled: false
   # -- Additional storage config
   storage_config:
@@ -57,11 +61,6 @@ loki:
 enterprise:
   # Enable enterprise features, license must be provided
   enabled: false
-  # -- Configuration for `tokengen` target
-  tokengen:
-    # -- Additional annotations for the `tokengen` Job
-    annotations:
-      sidecar.istio.io/inject: "false"
 # RBAC configuration
 rbac:
   # -- If pspEnabled true, a PodSecurityPolicy is created for K8s that use psp.


### PR DESCRIPTION
## Description

- Updates to the same defaults for loki as are used on our staging test clusters (better experience querying logs)
- Switches to a secret for the config rather than configmap (note that aws access keys end up in this configmap today if not using IRSA)
- Cleans up some unnecessary values on tokengen (disabling sidecar, legacy BB values based on job termination issue)

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed