### PR TITLE
ci: add unicorn upgrade test

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,31 +73,13 @@ jobs:
         if: ${{ always() && !inputs.snapshot }}
         uses: ./.github/actions/debug-output
 
-      # Determine repository to publish to
-      - name: Determine destination repository
-        id: repo
-        run: |
-          repo=ghcr.io/defenseunicorns/packages
-          # Publish unicorn flavor to private repository
-          if [ "${{ matrix.flavor }}" = "unicorn" ]; then
-            repo+=/private
-          fi
-          repo+=/uds
-          # Publish snapshots to snapshot repository
-          if [ "${{ inputs.snapshot }}" = "true" ]; then
-            repo+=/snapshots
-          fi
-
-          echo "repo=${repo}" >> "$GITHUB_OUTPUT"
-          echo "Publishing packages and bundles to ${repo}"
-
       # Publish package and bundle to destination repository
       - name: Publish Standard Package
-        run: uds run -f tasks/publish.yaml standard-package --set FLAVOR=${{ matrix.flavor }} --set TARGET_REPO=${{ steps.repo.outputs.repo }} ${PUBLISH_ARGS} --no-progress
+        run: uds run -f tasks/publish.yaml standard-package --set FLAVOR=${{ matrix.flavor }} --set SNAPSHOT="${{ inputs.snapshot }}" ${PUBLISH_ARGS} --no-progress
 
       - name: Publish Upstream Flavored Bundles
         if: ${{ matrix.flavor == 'upstream' }}
-        run: uds run -f tasks/publish.yaml bundles --set TARGET_REPO=${{ steps.repo.outputs.repo }} ${PUBLISH_ARGS} --no-progress
+        run: uds run -f tasks/publish.yaml bundles --set SNAPSHOT="${{ inputs.snapshot }}" ${PUBLISH_ARGS} --no-progress
 
       - name: Save logs
         if: always()

--- a/.github/workflows/pull-request-conditionals.yaml
+++ b/.github/workflows/pull-request-conditionals.yaml
@@ -68,6 +68,7 @@ jobs:
         package: ${{ fromJSON(needs.check-paths.outputs.packages) }}
         flavor: [upstream, registry1, unicorn]
         test_type: [install]
+        # Upgrade tests are included for all flavors, but ONLY for `all` package tests
         include:
           - package: all
             flavor: registry1
@@ -75,10 +76,9 @@ jobs:
           - package: all
             flavor: upstream
             test_type: upgrade
-          # Commented out until unicorn flavor has a published release
-          # - package: all
-          #   flavor: unicorn
-          #   test_type: upgrade
+          - package: all
+            flavor: unicorn
+            test_type: upgrade
     uses: ./.github/workflows/test.yaml
     with:
       package: ${{ matrix.package }}

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -1,3 +1,6 @@
+includes:
+  - utils: utils.yaml
+
 variables:
   - name: VERSION
     description: "The version of the packages to deploy"
@@ -34,12 +37,13 @@ tasks:
 
   - name: latest-package-release
     actions:
+      - task: utils:determine-repo
       - description: "Get latest tag version from OCI"
-        cmd: uds zarf tools registry ls ghcr.io/defenseunicorns/packages/uds/core | grep ${FLAVOR} | sort -V | tail -1
+        cmd: uds zarf tools registry ls ${TARGET_REPO}/core | grep ${FLAVOR} | sort -V | tail -1
         setVariables:
           - name: LATEST_VERSION
       - description: "Deploy the latest UDS Core package release"
-        cmd: uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/uds/core:${LATEST_VERSION} --confirm --no-progress --components '*'
+        cmd: uds zarf package deploy oci://${TARGET_REPO}/core:${LATEST_VERSION} --confirm --no-progress --components '*'
 
   - name: standard-package
     actions:

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -1,7 +1,7 @@
-variables:
-  - name: TARGET_REPO
-    default: ghcr.io/defenseunicorns/packages/uds
+includes:
+  - utils: utils.yaml
 
+variables:
   - name: FLAVOR
     default: upstream
 
@@ -15,8 +15,10 @@ tasks:
   - name: standard-package
     description: "Publish the UDS package"
     actions:
+      - task: utils:determine-repo
       - description: "Publish amd64/arm64 packages per flavor"
         cmd: |
+          echo "Publishing package to ${TARGET_REPO}"
           uds zarf package publish build/zarf-package-core-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}
 
           # dont publish arm64 for registry1 since IB images are only amd64
@@ -34,8 +36,10 @@ tasks:
   - name: bundles
     description: "Publish UDS Bundles"
     actions:
+      - task: utils:determine-repo
       - description: "Publish amd64 and arm64 bundles"
         cmd: |
+          echo "Publishing bundles to ${TARGET_REPO}"
           uds publish bundles/k3d-standard/uds-bundle-k3d-*-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
           uds publish bundles/k3d-standard/uds-bundle-k3d-*-arm64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
 

--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -1,0 +1,28 @@
+variables:
+  - name: BASE_REPO
+    default: "ghcr.io/defenseunicorns/packages"
+  - name: FLAVOR
+    default: "upstream"
+  - name: SNAPSHOT
+    description: Whether this is a snapshot release
+    default: "false"
+
+tasks:
+  - name: determine-repo
+    actions:
+      - description: "Determine repository for the given flavor/type of release"
+        cmd: |
+          repo="${BASE_REPO}"
+          # unicorn flavor = private repository
+          if [ "${FLAVOR}" = "unicorn" ]; then
+            repo="${repo}/private"
+          fi
+          repo="${repo}/uds"
+          # snapshots = snapshot repository
+          if [ "${SNAPSHOT}" = "true" ]; then
+            repo="${repo}/snapshots"
+          fi
+          echo "${repo}"
+        mute: true
+        setVariables:
+          - name: TARGET_REPO


### PR DESCRIPTION
## Description

Adds the `unicorn` flavor upgrade test. To make the `latest-package-release` lookup from the correct repository (`/private` if `unicorn`) I added a utils task. I also modified the publish to use this same utils task for consistency.

Tested publish workflow changes on fork (excluded create, so expected failures but output shows the correct repositories and zarf packages being referenced):
- Snapshot: https://github.com/BagelLab/uds-core/actions/runs/9981790347
- Normal: https://github.com/BagelLab/uds-core/actions/runs/9981855590

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/577

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed