### PR TITLE
chore(deps): update uds-identity-config to v0.5.1

### DIFF
--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.5.0
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.5.1
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"

--- a/src/keycloak/tasks.yaml
+++ b/src/keycloak/tasks.yaml
@@ -1,5 +1,5 @@
 includes:
-  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.4.5/tasks.yaml
+  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.5.1/tasks.yaml
 
 tasks:
   - name: validate

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -21,7 +21,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:24.0.5
-      - ghcr.io/defenseunicorns/uds/identity-config:0.5.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.5.1
 
   - name: keycloak
     required: true
@@ -37,7 +37,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:24.0.5
-      - ghcr.io/defenseunicorns/uds/identity-config:0.5.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.5.1
 
   - name: keycloak
     required: true
@@ -51,4 +51,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - cgr.dev/du-uds-defenseunicorns/keycloak:24.0.5 # todo: switch to FIPS image
-      - ghcr.io/defenseunicorns/uds/identity-config:0.5.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.5.1


### PR DESCRIPTION
## Description
Update uds-identity-config version. Currently renovate has this update captured inside of the keycloak grouping and is blocked by updating keycloak to v25


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed