### PR TITLE
chore: disable telemetry/analytics for loki/grafana

### DIFF
--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -17,6 +17,11 @@ extraSecretMounts:
 grafana.ini:
   server:
     root_url: https://grafana.admin.###ZARF_VAR_DOMAIN###
+  # Disable telemetry that doesn't function in the airgap
+  analytics:
+    reporting_enabled: false
+    check_for_updates: false
+    check_for_plugin_updates: false
   auth:
     # Disable the login form to force users to use SSO
     disable_login_form: true

--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -16,6 +16,9 @@ memberlist:
 
 loki:
   configStorageType: Secret
+  # Disable telemetry that doesn't function in the airgap
+  analytics:
+    reporting_enabled: false
   storage:
     bucketNames:
       chunks: uds


### PR DESCRIPTION
## Description

Disables analytics/external connections for loki and grafana. Primary reason is these tools should not be phoning home as part of our airgap-first stack.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/487

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed