### PR TITLE
chore: change metric server to optional

### DIFF
--- a/.github/bundles/uds-bundle.yaml
+++ b/.github/bundles/uds-bundle.yaml
@@ -16,6 +16,8 @@ packages:
     # x-release-please-start-version
     ref: 0.24.1
     # x-release-please-end
+    optionalComponents:
+      - metrics-server
     overrides:
       velero:
         velero:

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -36,6 +36,8 @@ packages:
     # x-release-please-start-version
     ref: 0.24.1
     # x-release-please-end
+    optionalComponents:
+      - metrics-server
     overrides:
       istio-admin-gateway:
         uds-istio-config:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -38,6 +38,7 @@ packages:
     # x-release-please-end
     optionalComponents:
       - istio-passthrough-gateway
+      - metrics-server
     overrides:
       loki:
         loki:

--- a/src/metrics-server/common/zarf.yaml
+++ b/src/metrics-server/common/zarf.yaml
@@ -6,7 +6,7 @@ metadata:
 
 components:
   - name: metrics-server
-    required: true
+    required: false # This component is optional since most k8s distros provide this out of the box
     charts:
       - name: uds-metrics-server-config
         namespace: metrics-server


### PR DESCRIPTION
BREAKING CHANGE: metric server is no longer required and is optional. To enable it, add it to the optionalComponents key on the core package

## Description
Since many of our supported Kubernetes distros (rke2, k3d, eks) often come with metrics-server or have an add-on, we make this change to optionally enable it at the uds-core layer.

## Related Issue

Relates to [uds-core#176](https://github.com/defenseunicorns/uds-core/issues/176)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed

BEGIN_COMMIT_OVERRIDE
chore!: change metric server to optional (https://github.com/defenseunicorns/uds-core/pull/611)

Release-As: 0.25.0
END_COMMIT_OVERRIDE