### PR TITLE
feat(istio): add configurable TLS version

### DIFF
--- a/src/istio/chart/templates/gateway.yaml
+++ b/src/istio/chart/templates/gateway.yaml
@@ -32,7 +32,8 @@ spec:
         mode: {{ $server.mode }}
         {{- if ne $server.mode "PASSTHROUGH" }}
         credentialName: gateway-tls
-        minProtocolVersion: TLSV1_3
+        # if supportTLSV1_2 is both defined and true, use TLSV1_2, otherwise use TLSV1_3
+        minProtocolVersion: {{ if $.Values.tls.supportTLSV1_2 }}TLSV1_2{{ else }}TLSV1_3{{ end }}
         {{- end }}
     {{ end }}
 {{ end }}

--- a/src/istio/chart/values.yaml
+++ b/src/istio/chart/values.yaml
@@ -24,3 +24,5 @@ domain: "###ZARF_VAR_DOMAIN###"
 #       # Hosts to add to this gateway
 #       hosts:
 #         - "*"
+#   # Whether to support TLS 1.2 (if false, only TLS 1.3 will be supported)
+#   supportTLSV1_2: true


### PR DESCRIPTION
## Description
- Introduced support for configuring the minimum TLS version for UDS Core.
- Added `supportTLSV1_2` boolean flag in values file to allow selection between TLS 1.2 and TLS 1.3.
- Updated Helm templates to conditionally set `minProtocolVersion` based on `supportTLSV1_2` value.
- Ensured backward compatibility by defaulting to TLS 1.3.
- Commented and documented the new configuration option for clarity.

## Related Issue

Fixes #599
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed