### PR TITLE
chore: generate a schema for keycloak helm chart

### DIFF
--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -1,0 +1,410 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "affinity": {
+      "type": "string"
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "behavior": {
+          "type": "object",
+          "properties": {
+            "scaleDown": {
+              "type": "object",
+              "properties": {
+                "policies": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "periodSeconds": {
+                        "type": "number"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "stabilizationWindowSeconds": {
+                  "type": "number"
+                }
+              }
+            },
+            "scaleUp": {
+              "type": "object",
+              "properties": {
+                "policies": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "periodSeconds": {
+                        "type": "number"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                },
+                "stabilizationWindowSeconds": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "object",
+          "properties": {}
+        },
+        "maxReplicas": {
+          "type": "number"
+        },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "resource": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "object",
+                    "properties": {
+                      "averageUtilization": {
+                        "type": "number"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "type": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "minReplicas": {
+          "type": "number"
+        }
+      }
+    },
+    "clusterDomain": {
+      "type": "string"
+    },
+    "configImage": {
+      "type": "string"
+    },
+    "debugMode": {
+      "type": "boolean"
+    },
+    "devMode": {
+      "type": "boolean"
+    },
+    "domain": {
+      "type": "string"
+    },
+    "enableServiceLinks": {
+      "type": "boolean"
+    },
+    "fips": {
+      "type": "boolean"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "pullPolicy": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "insecureAdminPasswordGeneration": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "jsonLogFormat": {
+      "type": "boolean"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "properties": {}
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "accessMode": {
+          "type": "string"
+        },
+        "conf": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "size": {
+              "type": "string"
+            }
+          }
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "size": {
+              "type": "string"
+            }
+          }
+        },
+        "providers": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "size": {
+              "type": "string"
+            }
+          }
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "themes": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "size": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {}
+    },
+    "podLabels": {
+      "type": "object",
+      "properties": {}
+    },
+    "podManagementPolicy": {
+      "type": "string"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {}
+    },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "database": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "port": {
+          "type": "number"
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "prometheusRule": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "properties": {}
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "object",
+          "properties": {}
+        },
+        "rules": {
+          "type": "array",
+          "items": {}
+        }
+      }
+    },
+    "realm": {
+      "type": "string"
+    },
+    "realmInitEnv": {
+      "type": "object",
+      "properties": {
+        "GOOGLE_IDP_ENABLED": {
+          "type": "boolean"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "restartPolicy": {
+      "type": "string"
+    },
+    "securityContext": {
+      "type": "object",
+      "properties": {}
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "properties": {}
+        },
+        "sessionAffinity": {
+          "type": "string"
+        },
+        "sessionAffinityConfig": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "properties": {}
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "interval": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object",
+          "properties": {}
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "namespaceSelector": {
+          "type": "object",
+          "properties": {}
+        },
+        "path": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "scrapeTimeout": {
+          "type": "string"
+        },
+        "tlsConfig": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    },
+    "smtp": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "number"
+        }
+      }
+    },
+    "statefulsetLabels": {
+      "type": "object",
+      "properties": {}
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "number"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {}
+    },
+    "topologySpreadConstraints": {
+      "type": "null"
+    },
+    "updateStrategy": {
+      "type": "string"
+    }
+  }
+}

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -6,6 +6,22 @@
     "affinity": {
       "type": "string"
     },
+    "additionalGatewayNamespaces": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "resource": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "autoscaling": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Description

Using [remarshal](https://github.com/remarshal-project/remarshal) and [generate-json-schema](https://github.com/Nijikokun/generate-schema), I locally created a `values.schema.json` file for keycloak's chart. I also referenced [this post](https://www.arthurkoziel.com/validate-helm-chart-values-with-json-schemas/) to build context on schemas & helm charts.

## Related Issue

Fixes #563 

## Type of change

- [X] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed