### PR TITLE
fix: reference root scope

### DIFF
--- a/src/keycloak/chart/templates/prometheusrule.yaml
+++ b/src/keycloak/chart/templates/prometheusrule.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "keycloak.fullname" $ }}
-  namespace: {{ .Release.Namespace }}  
+  namespace: {{ $.Release.Namespace }}  
   {{- with .annotations }}
   annotations:
   {{- range $key, $value := . }}


### PR DESCRIPTION
## Description
Fixes a bug where the keycloak helm template `prometheusrule.yaml` would fail to render due to an improper reference to `.Release.Namespace` in the object's metadata.
...

## Related Issue
Fixes #632 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed