### PR TITLE
fix: switch metrics-server to optional everywhere

### DIFF
--- a/packages/standard/zarf.yaml
+++ b/packages/standard/zarf.yaml
@@ -49,7 +49,7 @@ components:
 
   # Metrics Server
   - name: metrics-server
-    required: true
+    required: false
     import:
       path: ../../src/metrics-server
 

--- a/src/metrics-server/zarf.yaml
+++ b/src/metrics-server/zarf.yaml
@@ -6,7 +6,7 @@ metadata:
 
 components:
   - name: metrics-server
-    required: true
+    required: false
     only:
       flavor: upstream
     import:
@@ -19,7 +19,7 @@ components:
       - registry.k8s.io/metrics-server/metrics-server:v0.7.1
 
   - name: metrics-server
-    required: true
+    required: false
     only:
       flavor: registry1
     import:
@@ -32,7 +32,7 @@ components:
       - registry1.dso.mil/ironbank/opensource/kubernetes-sigs/metrics-server:v0.7.1
 
   - name: metrics-server
-    required: true
+    required: false
     only:
       flavor: unicorn
     import:


### PR DESCRIPTION
## Description

Switched everything to `required: false`.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/640

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed