### PR TITLE
docs: fix broken link on docs site

### DIFF
--- a/docs/adrs/0001-record-architecture-decisions.md
+++ b/docs/adrs/0001-record-architecture-decisions.md
@@ -16,7 +16,7 @@ We need to record the architectural decisions made on this project.
 
 ## Decision
 
-We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions), with a couple of small tweaks. See the [Documentation section in the Contributor guide](../CONTRIBUTING.md#documentation) for full details.
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions), with a couple of small tweaks. See the [Contributor guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) for full details.
 
 ## Consequences
 


### PR DESCRIPTION
## Description

Fixes a broken relative link that fails the docs site generation.

## Related Issue

See https://github.com/defenseunicorns/uds-docs/actions/runs/10271759774/job/28422487942?pr=29

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed