### PR TITLE
chore: allow for extra keycloak gateway usage with client certs

### DIFF
--- a/src/keycloak/chart/templates/istio-admin.yaml
+++ b/src/keycloak/chart/templates/istio-admin.yaml
@@ -56,7 +56,7 @@ spec:
             notNamespaces:
             - istio-tenant-gateway
             - istio-admin-gateway
-            {{- range .Values.additionalIstioGatewayNamespaces }}
+            {{- range .Values.additionalGatewayNamespaces }}
             - {{ . }}
             {{- end }}
 {{- end }}

--- a/src/keycloak/chart/templates/istio-admin.yaml
+++ b/src/keycloak/chart/templates/istio-admin.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "security.istio.io/v1beta1" }}
+{{- if .Capabilities..Has "security.istio.io/v1beta1" }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
@@ -56,4 +56,7 @@ spec:
             notNamespaces:
             - istio-tenant-gateway
             - istio-admin-gateway
+            {{- range .Values.additionalIstioGatewayNamespaces }}
+            - {{ . }}
+            {{- end }}
 {{- end }}

--- a/src/keycloak/chart/templates/istio-admin.yaml
+++ b/src/keycloak/chart/templates/istio-admin.yaml
@@ -57,6 +57,9 @@ spec:
             - istio-tenant-gateway
             - istio-admin-gateway
             {{- range .Values.additionalGatewayNamespaces }}
+            {{- if not (hasPrefix "istio-" .) }}
+              {{- fail (printf "Allowed gateway namespace '%s' must start with 'istio-'" .) }}
+            {{- end }}
             - {{ . }}
             {{- end }}
 {{- end }}

--- a/src/keycloak/chart/templates/istio-admin.yaml
+++ b/src/keycloak/chart/templates/istio-admin.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities..Has "security.istio.io/v1beta1" }}
+{{- if .Capabilities.APIVersions.Has "security.istio.io/v1beta1" }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -13,6 +13,7 @@ configImage: ghcr.io/defenseunicorns/uds/identity-config:0.5.2
 domain: "###ZARF_VAR_DOMAIN###"
 
 # Additional Istio Gateways that expose Keycloak, to allow for client cert usage
+# A prefix of `istio-` is required for namespaces to prevent accidental misconfiguration
 additionalGatewayNamespaces: []
 # Example
 # - "istio-login-gateway"

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -12,6 +12,11 @@ configImage: ghcr.io/defenseunicorns/uds/identity-config:0.5.2
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"
 
+# Additional Istio Gateways that expose Keycloak, to allow for client cert usage
+additionalIstioGatewayNamespaces: []
+# Example
+# - "istio-login-gateway"
+
 # The primary Keycloak realm
 realm: uds
 

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -13,7 +13,7 @@ configImage: ghcr.io/defenseunicorns/uds/identity-config:0.5.2
 domain: "###ZARF_VAR_DOMAIN###"
 
 # Additional Istio Gateways that expose Keycloak, to allow for client cert usage
-additionalIstioGatewayNamespaces: []
+additionalGatewayNamespaces: []
 # Example
 # - "istio-login-gateway"
 


### PR DESCRIPTION
## Description

End users may be using different gateways/extra gateways for keycloak. To support this usage, this value would allow adding other namespaces that are allowed to set client certs.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed