### PR TITLE
fix: network allows for core netpols

### DIFF
--- a/src/authservice/chart/templates/uds-package.yaml
+++ b/src/authservice/chart/templates/uds-package.yaml
@@ -19,7 +19,7 @@ spec:
         description: "SSO Provider"
 
       - direction: Ingress
-        podLabels:
+        selector:
           app.kubernetes.io/name: authservice
         remoteNamespace: "" # Any namespace could have a protected app
         port: 10003

--- a/src/promtail/chart/templates/uds-package.yaml
+++ b/src/promtail/chart/templates/uds-package.yaml
@@ -14,7 +14,7 @@ spec:
   network:
     allow:
       - direction: Ingress
-        podSelector:
+        selector:
           app.kubernetes.io/name: promtail
         remoteNamespace: monitoring
         remoteSelector:
@@ -23,7 +23,7 @@ spec:
         description: "Prometheus Metrics"
 
       - direction: Egress
-        podSelector:
+        selector:
           app.kubernetes.io/name: promtail
         remoteGenerated: KubeAPI
 

--- a/src/velero/chart/templates/uds-package.yaml
+++ b/src/velero/chart/templates/uds-package.yaml
@@ -8,12 +8,12 @@ spec:
     allow:
       # Todo: wide open for now for pushing to s3
       - direction: Egress
-        podLabels:
+        selector:
           app.kubernetes.io/name: velero
         remoteGenerated: Anywhere
 
       - direction: Egress
-        podLabels:
+        selector:
           batch.kubernetes.io/job-name: "velero-upgrade-crds"
         remoteGenerated: KubeAPI
 


### PR DESCRIPTION
## Description

Noted an unknown field warning when deploying core this morning. Impact of this change for promtail is that network policies previously were open to the full promtail namespace rather than just the promtail pods (nuance since nothing else runs in the promtail namespace, but a safeguard).

For context on this - we have a deprecated `podLabels` field that gets migrated to `selector` (see [migrate function](https://github.com/defenseunicorns/uds-core/blob/main/src/pepr/operator/crd/migrate.ts#L25-L28)). I did not dig further but unsure if `podSelector` was just an accidental addition or if it was valid at some point in time.

I also migrated two other spots using the deprecated `podLabels` to `selector`.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed