### PR TITLE
chore(neuvector): update source for unicorn images

### DIFF
--- a/src/neuvector/chart/templates/_helpers.tpl
+++ b/src/neuvector/chart/templates/_helpers.tpl
@@ -60,3 +60,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Lookup existing secret key/value
+*/}}
+{{- define "neuvector.secrets.lookup" -}}
+{{- $value := "" -}}
+{{- $secretData := (lookup "v1" "Secret" .namespace .secret).data  -}}
+{{- if and $secretData (hasKey $secretData .key) -}}
+  {{- $value = index $secretData .key -}}
+{{- else if .defaultValue -}}
+  {{- $value = .defaultValue | toString | b64enc -}}
+{{- end -}}
+{{- if $value -}}
+{{- printf "%s" $value -}}
+{{- end -}}
+{{- end -}}

--- a/src/neuvector/chart/templates/internal-cert.yaml
+++ b/src/neuvector/chart/templates/internal-cert.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.generateInternalCert -}}
+{{- $cn := "neuvector" }}
+{{- $ca := genCA "neuvector" 3650 -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 3650 $ca -}}
+{{- $name := "neuvector-internal-cert" -}}
+# This secret generates a cert for internal neuvector comms since these are missing in some non-upstream images
+# While these certs are long-lived, it isn't the primary method for TLS comms since Istio is ensuring mTLS with secure, rotated certificates
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  tls.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" $name "key" "tls.key" "defaultValue" $cert.Key) }}
+  tls.crt: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" $name "key" "tls.crt" "defaultValue" $cert.Cert) }}
+  ca.crt: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" $name "key" "ca.crt" "defaultValue" $ca.Cert) }}
+{{- end }}

--- a/src/neuvector/chart/values.yaml
+++ b/src/neuvector/chart/values.yaml
@@ -2,3 +2,5 @@ domain: "###ZARF_VAR_DOMAIN###"
 
 grafana:
   enabled: false
+
+generateInternalCert: false

--- a/src/neuvector/values/unicorn-config-values.yaml
+++ b/src/neuvector/values/unicorn-config-values.yaml
@@ -1,0 +1,1 @@
+generateInternalCert: true

--- a/src/neuvector/values/unicorn-values.yaml
+++ b/src/neuvector/values/unicorn-values.yaml
@@ -3,24 +3,38 @@ tag: "5.3.4"
 manager:
   image:
     repository: du-uds-defenseunicorns/neuvector-manager
+  certificate:
+    secret: neuvector-internal-cert
+    keyFile: tls.key
+    pemFile: tls.crt
 
 enforcer:
   image:
     repository: du-uds-defenseunicorns/neuvector-enforcer-fips
   containerSecurityContext:
     privileged: true
+  internal:
+    certificate:
+      secret: neuvector-internal-cert
 
 controller:
   image:
     repository: du-uds-defenseunicorns/neuvector-controller-fips
+  internal:
+    certificate:
+      secret: neuvector-internal-cert
 
 cve:
   scanner:
+    internal:
+      certificate:
+        secret: neuvector-internal-cert
     image:
-      repository: du-uds-defenseunicorns/neuvector-scanner-fips
+      registry: docker.io
+      repository: neuvector/scanner
       tag: latest
   updater:
     enabled: true
     image:
       repository: du-uds-defenseunicorns/neuvector-updater-fips
-      tag: 8.8.0-dev
+      tag: 8.9.1-dev

--- a/src/neuvector/values/unicorn-values.yaml
+++ b/src/neuvector/values/unicorn-values.yaml
@@ -1,12 +1,11 @@
+# Generate certs missing from unicorn images
+autoGenerateCert: true
+
 registry: cgr.dev
 tag: "5.3.4"
 manager:
   image:
     repository: du-uds-defenseunicorns/neuvector-manager
-  certificate:
-    secret: neuvector-internal-cert
-    keyFile: tls.key
-    pemFile: tls.crt
 
 enforcer:
   image:

--- a/src/neuvector/values/values.yaml
+++ b/src/neuvector/values/values.yaml
@@ -1,5 +1,5 @@
 leastPrivilege: true
-autoGenerateCert: true
+autoGenerateCert: false
 rbac: true
 manager:
   env:

--- a/src/neuvector/values/values.yaml
+++ b/src/neuvector/values/values.yaml
@@ -1,15 +1,13 @@
 leastPrivilege: true
-autoGenerateCert: false
+autoGenerateCert: true
 rbac: true
 manager:
   env:
     ssl: false
-    disableFipsInJava: true
   svc:
     type: ClusterIP
 
 controller:
-
   apisvc:
     type: ClusterIP
   configmap:
@@ -29,23 +27,8 @@ controller:
       value: "1"
 
 cve:
-  scanner:
-    affinity: {}
-
   updater:
     enabled: true
-
-k3s:
-  enabled: true
-  runtimePath: /run/k3s/containerd/containerd.sock
-
-bottlerocket:
-  enabled: false
-  runtimePath: /run/dockershim.sock
-
-containerd:
-  enabled: false
-  path: /var/run/containerd/containerd.sock
 
 crdwebhook:
   enabled: false

--- a/src/neuvector/zarf.yaml
+++ b/src/neuvector/zarf.yaml
@@ -57,32 +57,19 @@ components:
     import:
       path: common
     charts:
+      - name: uds-neuvector-config
+        valuesFiles:
+          - values/unicorn-config-values.yaml
       - name: core
         valuesFiles:
-          - values/upstream-values.yaml
+          - values/unicorn-values.yaml
       - name: monitor
         valuesFiles:
-          - values/upstream-monitor-values.yaml
+          - values/unicorn-monitor-values.yaml
     images:
-      - docker.io/neuvector/controller:5.3.4
-      - docker.io/neuvector/manager:5.3.4
-      - docker.io/neuvector/updater:latest
+      - cgr.dev/du-uds-defenseunicorns/neuvector-manager:5.3.4
+      - cgr.dev/du-uds-defenseunicorns/neuvector-enforcer-fips:5.3.4
+      - cgr.dev/du-uds-defenseunicorns/neuvector-controller-fips:5.3.4
       - docker.io/neuvector/scanner:latest
-      - docker.io/neuvector/enforcer:5.3.4
-      - docker.io/neuvector/prometheus-exporter:5.3.2
-
-    # todo: switch to chainguard images once manager is functional
-    # charts:
-    #   - name: core
-    #     valuesFiles:
-    #       - values/unicorn-values.yaml
-    #   - name: monitor
-    #     valuesFiles:
-    #       - values/unicorn-monitor-values.yaml
-    # images:
-    #   - cgr.dev/du-uds-defenseunicorns/neuvector-manager:5.3.4
-    #   - cgr.dev/du-uds-defenseunicorns/neuvector-enforcer-fips:5.3.4
-    #   - cgr.dev/du-uds-defenseunicorns/neuvector-controller-fips:5.3.4
-    #   - cgr.dev/du-uds-defenseunicorns/neuvector-scanner-fips:latest
-    #   - cgr.dev/du-uds-defenseunicorns/neuvector-updater-fips:8.9.1-dev
-    #   - cgr.dev/du-uds-defenseunicorns/neuvector-prometheus-exporter-fips:5.3.0
+      - cgr.dev/du-uds-defenseunicorns/neuvector-updater-fips:8.9.1-dev
+      - cgr.dev/du-uds-defenseunicorns/neuvector-prometheus-exporter-fips:5.3.0


### PR DESCRIPTION
## Description

Switches neuvector unicorn flavor to use cgr images for all images except the scanner (this image is not supported by cgr). This requires a cert for internal comms which is generated by helm and valid for the same period of time as the upstream generated cert.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/568

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed