### PR TITLE
chore: add watch config to exemption watch

### DIFF
--- a/src/pepr/policies/index.ts
+++ b/src/pepr/policies/index.ts
@@ -1,4 +1,5 @@
 // Various validation actions for Kubernetes resources from Big Bang
+import { WatchCfg } from "kubernetes-fluent-client";
 import { K8s } from "pepr";
 import { Component, setupLogger } from "../logger";
 import { ExemptionStore } from "../operator/controllers/exemptions/exemption-store";
@@ -21,11 +22,25 @@ export async function startExemptionWatch() {
 
   // only run in admission controller or dev mode
   if (process.env.PEPR_WATCH_MODE === "false" || process.env.PEPR_MODE === "dev") {
+    const watchCfg: WatchCfg = {
+      resyncFailureMax: process.env.PEPR_RESYNC_FAILURE_MAX
+        ? parseInt(process.env.PEPR_RESYNC_FAILURE_MAX, 10)
+        : 5,
+      resyncDelaySec: process.env.PEPR_RESYNC_DELAY_SECONDS
+        ? parseInt(process.env.PEPR_RESYNC_DELAY_SECONDS, 10)
+        : 5,
+      lastSeenLimitSeconds: process.env.PEPR_LAST_SEEN_LIMIT_SECONDS
+        ? parseInt(process.env.PEPR_LAST_SEEN_LIMIT_SECONDS, 10)
+        : 300,
+      relistIntervalSec: process.env.PEPR_RELIST_INTERVAL_SECONDS
+        ? parseInt(process.env.PEPR_RELIST_INTERVAL_SECONDS, 10)
+        : 1800,
+    };
     const watcher = K8s(UDSExemption).Watch(async (exemption, phase) => {
       log.debug(`Processing exemption ${exemption.metadata?.name}, watch phase: ${phase}`);
 
       processExemptions(exemption, phase);
-    });
+    }, watchCfg);
 
     // This will run until the process is terminated or the watch is aborted
     log.debug("Starting exemption watch...");

--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -5,3 +5,5 @@ operator:
   UDS_SINGLE_TEST: "###ZARF_VAR_UDS_SINGLE_TEST###"
   UDS_LOG_LEVEL: "###ZARF_VAR_UDS_LOG_LEVEL###"
   AUTHSERVICE_REDIS_URI: "###ZARF_VAR_AUTHSERVICE_REDIS_URI###"
+  # Tweak Pepr watch config to react to dropped connections faster
+  PEPR_LAST_SEEN_LIMIT_SECONDS: "60"

--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -6,4 +6,4 @@ operator:
   UDS_LOG_LEVEL: "###ZARF_VAR_UDS_LOG_LEVEL###"
   AUTHSERVICE_REDIS_URI: "###ZARF_VAR_AUTHSERVICE_REDIS_URI###"
   # Tweak Pepr watch config to react to dropped connections faster
-  PEPR_LAST_SEEN_LIMIT_SECONDS: "60"
+  PEPR_LAST_SEEN_LIMIT_SECONDS: "300"

--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -5,5 +5,5 @@ operator:
   UDS_SINGLE_TEST: "###ZARF_VAR_UDS_SINGLE_TEST###"
   UDS_LOG_LEVEL: "###ZARF_VAR_UDS_LOG_LEVEL###"
   AUTHSERVICE_REDIS_URI: "###ZARF_VAR_AUTHSERVICE_REDIS_URI###"
-  # Tweak Pepr watch config to react to dropped connections faster
+  # Allow Pepr watch to be configurable to react to dropped connections faster
   PEPR_LAST_SEEN_LIMIT_SECONDS: "300"


### PR DESCRIPTION
## Description

Adds the watch config to exemption watch. Minimal change but ensures that the watch is configurable for all places we are using watches. `PEPR_LAST_SEEN_LIMIT_SECONDS` is also added to the default envs for the config chart, intending to set this to 60s to shrink the window/tolerance for failure in staging environment.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed