### PR TITLE
fix: switch secret `data` to `stringData`

### DIFF
--- a/src/pepr/uds-operator-config/templates/secret.yaml
+++ b/src/pepr/uds-operator-config/templates/secret.yaml
@@ -8,5 +8,5 @@ metadata:
 type: Opaque
 data:
 {{- range $key, $value := .Values.operator }}
-  {{ $key }}: {{ $value | b64enc | quote }}
+  {{ $key }}: {{ $value | toString | b64enc | quote }}
 {{- end }}

--- a/src/pepr/uds-operator-config/templates/secret.yaml
+++ b/src/pepr/uds-operator-config/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "uds-operator-config.labels" . | nindent 4 }}
 type: Opaque
-data:
+stringData:
 {{- range $key, $value := .Values.operator }}
-  {{ $key }}: {{ $value | toString | b64enc | quote }}
+  {{ $key }}: {{ $value | quote }}
 {{- end }}


### PR DESCRIPTION
## Description
Fixes deployment errors with the operator helm chart not properly handling integer helm values.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed