### PR TITLE
feat: add support for Keycloak attribute `saml.assertion.signature`

### DIFF
--- a/docs/configuration/uds-operator.md
+++ b/docs/configuration/uds-operator.md
@@ -217,6 +217,7 @@ The SSO spec supports a subset of the Keycloak attributes for clients, but does 
 - oauth2.device.authorization.grant.enabled
 - pkce.code.challenge.method
 - client.session.idle.timeout
+- saml.assertion.signature
 - saml.client.signature
 - saml_assertion_consumer_url_post
 

--- a/src/pepr/operator/crd/validators/package-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/package-validator.spec.ts
@@ -471,6 +471,7 @@ describe("Test Allowed SSO Client Attributes", () => {
             "oauth2.device.authorization.grant.enabled": "true",
             "pkce.code.challenge.method": "S256",
             "client.session.idle.timeout": "3600",
+            "saml.assertion.signature": "false",
             "saml.client.signature": "false",
             saml_assertion_consumer_url_post: "https://nexus.uds.dev/saml",
           },

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -89,6 +89,7 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
     "oauth2.device.authorization.grant.enabled",
     "pkce.code.challenge.method",
     "client.session.idle.timeout",
+    "saml.assertion.signature",
     "saml.client.signature",
     "saml_assertion_consumer_url_post",
   ]);


### PR DESCRIPTION
## Description
Adds support for Keycloak attribute `saml.assertion.signature`. This is the "Sign assertions" toggle shown in the Keycloak UI.

## Related Issue
...

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed