### PR TITLE
chore: update configure policy exemptions doc link

### DIFF
--- a/src/pepr/operator/README.md
+++ b/src/pepr/operator/README.md
@@ -12,7 +12,7 @@ The UDS Operator manages the lifecycle of UDS Package CRs and their correspondin
 
 #### Exemption
 
-- allowing exemption custom resources only in the `uds-policy-exemptions` namespace unless configured to allow in all namespaces (see [configuring policy exemptions](../../../docs/CONFIGURE_POLICY_EXEMPTIONS.md))
+- allowing exemption custom resources only in the `uds-policy-exemptions` namespace unless configured to allow in all namespaces (see [configuring policy exemptions](../../../docs/configuration/uds-configure-policy-exemptions.md))
 - updating the policies Pepr store with registered exemptions
 
 ### Example UDS Package CR


### PR DESCRIPTION
## Description

Fixes the link in the pepr operator README to point to the correct part of the tree for the policy exemption example doc.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed