### PR TITLE
fix: correct keycloak chart schema for additionalGateways

### DIFF
--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -9,17 +9,7 @@
     "additionalGatewayNamespaces": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "resource": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              }
-            }
-          }
-        }
+        "type": "string"
       }
     },
     "autoscaling": {


### PR DESCRIPTION
## Description
Fixes Keycloak chart schema to accept an array of strings for `additionalGatewayNamespaces`.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/746

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed