### PR TITLE
docs: bump colima memory recommendation

### DIFF
--- a/docs/deployment/uds-deploy.md
+++ b/docs/deployment/uds-deploy.md
@@ -12,7 +12,7 @@ Please ensure that the following prerequisites are on your machine prior to depl
   - If using Colima, please declare the following resources after installing:
 
 ```git
-colima start --cpu 6 --memory 14 --disk 50
+colima start --cpu 7 --memory 14 --disk 50
 ```
 
 - [K3d](https://formulae.brew.sh/formula/k3d#default) for development and test environments or a [CNCF Certified Kubernetes Cluster](https://www.cncf.io/training/certification/software-conformance/#logos) if deploying to production environments.


### PR DESCRIPTION
## Description

Running a core install with colima will exhaust memory right as velero is being deployed.  Bumping memory suggestion from 6 to 7 will get past this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed