### PR TITLE
feat: allow service ports to be overridden in test bundles

### DIFF
--- a/bundles/k3d-slim-dev/README.md
+++ b/bundles/k3d-slim-dev/README.md
@@ -14,7 +14,47 @@ The k3d uds-dev-stack provides:
 - [MetalLB](https://metallb.universe.tf/) - Provides type: LoadBalancer for cluster resources and Istio Gateways
 - [HAProxy](https://www.haproxy.org/) - Utilizes k3d host port mapping to bind ports 80 and 443, facilitating local FQDN-based routing through ACLs to MetalLB load balancer backends for Istio Gateways serving *.uds.dev, keycloak.uds.dev, and *.admin.uds.dev.
 
-## Configuration
+## Available Overrides
+### Package: uds-k3d
+##### uds-dev-stack (minio)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `BUCKETS` | Set Minio Buckets | buckets |
+| `SVCACCTS` | Minio Service Accounts | svcaccts |
+| `USERS` | Minio Users | users |
+| `POLICIES` | Minio policies | policies |
+
+
+### Package: core
+
+##### istio-admin-gateway (uds-istio-config)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `ADMIN_TLS_CERT` | The TLS cert for the admin gateway (must be base64 encoded) | tls.cert |
+| `ADMIN_TLS_KEY` | The TLS key for the admin gateway (must be base64 encoded) | tls.key |
+
+##### istio-tenant-gateway (uds-istio-config)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `TENANT_TLS_CERT` | The TLS cert for the tenant gateway (must be base64 encoded) | tls.cert |
+| `TENANT_TLS_KEY` | The TLS key for the tenant gateway (must be base64 encoded) | tls.key |
+
+##### istio-tenant-gateway (gateway)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `TENANT_SERVICE_PORTS` | The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic) | service.ports |
+
+##### keycloak (keycloak)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `INSECURE_ADMIN_PASSWORD_GENERATION` | Generate an insecure admin password for dev/test | `insecureAdminPasswordGeneration.enabled` |
+| `KEYCLOAK_HA`              | Enable Keycloak HA                         | `autoscaling.enabled`           |
+| `KEYCLOAK_PG_USERNAME`     | Keycloak Postgres username                 | `postgresql.username`           |
+| `KEYCLOAK_PG_PASSWORD`     | Keycloak Postgres password                 | `postgresql.password`           |
+| `KEYCLOAK_PG_DATABASE`     | Keycloak Postgres database                 | `postgresql.database`           |
+| `KEYCLOAK_PG_HOST`         | Keycloak Postgres host                     | `postgresql.host`               |
+| `KEYCLOAK_DEVMODE`         | Enables Keycloak dev mode                  | `devMode`                       |
+
 
 ### Minio
 

--- a/bundles/k3d-slim-dev/README.md
+++ b/bundles/k3d-slim-dev/README.md
@@ -56,7 +56,9 @@ The k3d uds-dev-stack provides:
 | `KEYCLOAK_DEVMODE`         | Enables Keycloak dev mode                  | `devMode`                       |
 
 
-### Minio
+## Override Examples:
+
+### Minio Customization
 
 You can customize the Minio setup at deploy time via your ```uds-config.yaml```.
 

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -55,6 +55,24 @@ packages:
             - name: TENANT_TLS_KEY
               description: "The TLS key for the tenant gateway (must be base64 encoded)"
               path: tls.key
+        gateway:
+          variables:
+            - name: TENANT_SERVICE_PORTS
+              description: "The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic)"
+              path: "service.ports"
+              default:
+                - name: status-port
+                  port: 15021
+                  protocol: TCP
+                  targetPort: 15021
+                - name: http2
+                  port: 80
+                  protocol: TCP
+                  targetPort: 80
+                - name: https
+                  port: 443
+                  protocol: TCP
+                  targetPort: 443
       keycloak:
         keycloak:
           variables:

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -60,19 +60,6 @@ packages:
             - name: TENANT_SERVICE_PORTS
               description: "The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic)"
               path: "service.ports"
-              default:
-                - name: status-port
-                  port: 15021
-                  protocol: TCP
-                  targetPort: 15021
-                - name: http2
-                  port: 80
-                  protocol: TCP
-                  targetPort: 80
-                - name: https
-                  port: 443
-                  protocol: TCP
-                  targetPort: 443
       keycloak:
         keycloak:
           variables:

--- a/bundles/k3d-standard/README.md
+++ b/bundles/k3d-standard/README.md
@@ -44,7 +44,20 @@ This bundle is used for demonstration, development, and testing of UDS Core. In 
 | `TENANT_TLS_KEY` | The TLS key for the tenant gateway (must be base64 encoded) | tls.key |
 
 ##### istio-tenant-gateway (gateway)
+| Variable | Description | Path |
+|----------|-------------|------|
 | `TENANT_SERVICE_PORTS` | The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic) | service.ports |
+
+##### keycloak (keycloak)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `INSECURE_ADMIN_PASSWORD_GENERATION` | Generate an insecure admin password for dev/test | `insecureAdminPasswordGeneration.enabled` |
+| `KEYCLOAK_HA`              | Enable Keycloak HA                         | `autoscaling.enabled`           |
+| `KEYCLOAK_PG_USERNAME`     | Keycloak Postgres username                 | `postgresql.username`           |
+| `KEYCLOAK_PG_PASSWORD`     | Keycloak Postgres password                 | `postgresql.password`           |
+| `KEYCLOAK_PG_DATABASE`     | Keycloak Postgres database                 | `postgresql.database`           |
+| `KEYCLOAK_PG_HOST`         | Keycloak Postgres host                     | `postgresql.host`               |
+| `KEYCLOAK_DEVMODE`         | Enables Keycloak dev mode                  | `devMode`                       |
 
 
 ## Override Examples:

--- a/bundles/k3d-standard/README.md
+++ b/bundles/k3d-standard/README.md
@@ -43,6 +43,9 @@ This bundle is used for demonstration, development, and testing of UDS Core. In 
 | `TENANT_TLS_CERT` | The TLS cert for the tenant gateway (must be base64 encoded) | tls.cert |
 | `TENANT_TLS_KEY` | The TLS key for the tenant gateway (must be base64 encoded) | tls.key |
 
+##### istio-tenant-gateway (gateway)
+| `TENANT_SERVICE_PORTS` | The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic) | service.ports |
+
 
 ## Override Examples:
 

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -94,6 +94,24 @@ packages:
             - name: TENANT_TLS_KEY
               description: "The TLS key for the tenant gateway (must be base64 encoded)"
               path: tls.key
+        gateway:
+          variables:
+            - name: TENANT_SERVICE_PORTS
+              description: "The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic)"
+              path: "service.ports"
+              default:
+                - name: status-port
+                  port: 15021
+                  protocol: TCP
+                  targetPort: 15021
+                - name: http2
+                  port: 80
+                  protocol: TCP
+                  targetPort: 80
+                - name: https
+                  port: 443
+                  protocol: TCP
+                  targetPort: 443
       keycloak:
         keycloak:
           variables:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -99,19 +99,6 @@ packages:
             - name: TENANT_SERVICE_PORTS
               description: "The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic)"
               path: "service.ports"
-              default:
-                - name: status-port
-                  port: 15021
-                  protocol: TCP
-                  targetPort: 15021
-                - name: http2
-                  port: 80
-                  protocol: TCP
-                  targetPort: 80
-                - name: https
-                  port: 443
-                  protocol: TCP
-                  targetPort: 443
       keycloak:
         keycloak:
           variables:


### PR DESCRIPTION
## Description

This adds a variable to override service ports in the uds-core test bundles (useful for adding additional ports to expose)

## Related Issue

Relates to https://github.com/defenseunicorns/uds-package-gitlab/pull/196

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed

BEGIN_COMMIT_OVERRIDE
chore: allow service ports to be overridden in test bundles (#765)
END_COMMIT_OVERRIDE