### PR TITLE
chore: remove unused neuvector exporter

### DIFF
--- a/src/neuvector/common/zarf.yaml
+++ b/src/neuvector/common/zarf.yaml
@@ -25,13 +25,13 @@ components:
         gitPath: charts/core
         valuesFiles:
           - ../values/values.yaml
-      - name: monitor
-        url: https://neuvector.github.io/neuvector-helm/
-        version: 2.7.9
-        namespace: neuvector
-        gitPath: charts/monitor
-        valuesFiles:
-          - ../values/monitor-values.yaml
+      # - name: monitor
+      #   url: https://neuvector.github.io/neuvector-helm/
+      #   version: 2.7.9
+      #   namespace: neuvector
+      #   gitPath: charts/monitor
+      #   valuesFiles:
+      #     - ../values/monitor-values.yaml
     actions:
       onDeploy:
         after:

--- a/src/neuvector/values/registry1-monitor-values.yaml
+++ b/src/neuvector/values/registry1-monitor-values.yaml
@@ -1,9 +1,0 @@
-registry: registry1.dso.mil
-exporter:
-  image:
-    repository: ironbank/neuvector/neuvector/prometheus-exporter
-    tag: 5.3.2
-
-  containerSecurityContext:
-    runAsUser: 1001
-    runAsGroup: 1001

--- a/src/neuvector/values/unicorn-monitor-values.yaml
+++ b/src/neuvector/values/unicorn-monitor-values.yaml
@@ -1,5 +1,0 @@
-registry: cgr.dev
-exporter:
-  image:
-    repository: du-uds-defenseunicorns/neuvector-prometheus-exporter-fips
-    tag: 5.3.0

--- a/src/neuvector/values/upstream-monitor-values.yaml
+++ b/src/neuvector/values/upstream-monitor-values.yaml
@@ -1,5 +1,0 @@
-registry: docker.io
-exporter:
-  image:
-    repository: neuvector/prometheus-exporter
-    tag: 5.3.2

--- a/src/neuvector/zarf.yaml
+++ b/src/neuvector/zarf.yaml
@@ -16,16 +16,12 @@ components:
       - name: core
         valuesFiles:
           - values/upstream-values.yaml
-      - name: monitor
-        valuesFiles:
-          - values/upstream-monitor-values.yaml
     images:
       - docker.io/neuvector/controller:5.3.4
       - docker.io/neuvector/manager:5.3.4
       - docker.io/neuvector/updater:latest
       - docker.io/neuvector/scanner:latest
       - docker.io/neuvector/enforcer:5.3.4
-      - docker.io/neuvector/prometheus-exporter:5.3.2
 
   - name: neuvector
     description: "Deploy Neuvector"
@@ -38,16 +34,12 @@ components:
       - name: core
         valuesFiles:
           - values/registry1-values.yaml
-      - name: monitor
-        valuesFiles:
-          - values/registry1-monitor-values.yaml
     images:
       - registry1.dso.mil/ironbank/neuvector/neuvector/controller:5.3.4
       - registry1.dso.mil/ironbank/neuvector/neuvector/manager:5.3.4
       - registry1.dso.mil/ironbank/redhat/ubi/ubi9-minimal:9.4
       - registry1.dso.mil/ironbank/neuvector/neuvector/scanner:5
       - registry1.dso.mil/ironbank/neuvector/neuvector/enforcer:5.3.4
-      - registry1.dso.mil/ironbank/neuvector/neuvector/prometheus-exporter:5.3.2
 
   - name: neuvector
     description: "Deploy Neuvector"
@@ -63,13 +55,9 @@ components:
       - name: core
         valuesFiles:
           - values/unicorn-values.yaml
-      - name: monitor
-        valuesFiles:
-          - values/unicorn-monitor-values.yaml
     images:
       - cgr.dev/du-uds-defenseunicorns/neuvector-manager:5.3.4
       - cgr.dev/du-uds-defenseunicorns/neuvector-enforcer-fips:5.3.4
       - cgr.dev/du-uds-defenseunicorns/neuvector-controller-fips:5.3.4
       - docker.io/neuvector/scanner:latest
       - cgr.dev/du-uds-defenseunicorns/neuvector-updater-fips:8.10.0-dev
-      - cgr.dev/du-uds-defenseunicorns/neuvector-prometheus-exporter-fips:5.3.0


### PR DESCRIPTION
## Description

Delete, delete, delete.

Exporter is not used and cannot be used in its current form due to auth limitations with accessing the metrics when SSO sign in is enabled.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed