### PR TITLE
fix: validate packages using full resource name

### DIFF
--- a/src/authservice/common/zarf.yaml
+++ b/src/authservice/common/zarf.yaml
@@ -19,7 +19,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: authservice
                 namespace: authservice
                 condition: "'{.status.phase}'=Ready"

--- a/src/grafana/common/zarf.yaml
+++ b/src/grafana/common/zarf.yaml
@@ -25,7 +25,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: grafana
                 namespace: grafana
                 condition: "'{.status.phase}'=Ready"

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -19,7 +19,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: keycloak
                 namespace: keycloak
                 condition: "'{.status.phase}'=Ready"

--- a/src/loki/common/zarf.yaml
+++ b/src/loki/common/zarf.yaml
@@ -24,7 +24,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: loki
                 namespace: loki
                 condition: "'{.status.phase}'=Ready"

--- a/src/metrics-server/common/zarf.yaml
+++ b/src/metrics-server/common/zarf.yaml
@@ -25,7 +25,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: metrics-server
                 namespace: metrics-server
                 condition: "'{.status.phase}'=Ready"

--- a/src/neuvector/common/zarf.yaml
+++ b/src/neuvector/common/zarf.yaml
@@ -39,7 +39,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: neuvector
                 namespace: neuvector
                 condition: "'{.status.phase}'=Ready"

--- a/src/prometheus-stack/common/zarf.yaml
+++ b/src/prometheus-stack/common/zarf.yaml
@@ -25,7 +25,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: prometheus-stack
                 namespace: monitoring
                 condition: "'{.status.phase}'=Ready"

--- a/src/promtail/common/zarf.yaml
+++ b/src/promtail/common/zarf.yaml
@@ -26,7 +26,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: promtail
                 namespace: promtail
                 condition: "'{.status.phase}'=Ready"


### PR DESCRIPTION
## Description

When deploying a uds package to a cluster that has an existing package resource type (such as an eks-d management cluster with eks-anywhere installed in it) that is higher priority than uds-packages, package validation hangs forever since it is waiting on the wrong resource type.

This PR updates the onDeploy/after actions to wait for `packages.uds.dev` instead of just `packages` to avoid this conflict.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed