### PR TITLE
chore: fix github-actions renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -94,7 +94,7 @@
     },
     {
       "matchFileNames": [".github/workflows/**", ".github/actions/**"],
-      "excludePackageNames": ["zarf-dev/zarf", "defenseunicorns/uds-cli"],
+      "matchPackageNames": ["*", "!defenseunicorns/uds-cli", "!defenseunicorns/zarf", "!defenseunicorns/lula", "!k3d-io/k3d"],
       "groupName": "githubactions",
       "commitMessageTopic": "githubactions",
       "pinDigests": true

--- a/renovate.json
+++ b/renovate.json
@@ -94,7 +94,7 @@
     },
     {
       "matchFileNames": [".github/workflows/**", ".github/actions/**"],
-      "matchPackageNames": ["*", "!defenseunicorns/uds-cli", "!defenseunicorns/zarf", "!defenseunicorns/lula", "!k3d-io/k3d"],
+      "matchPackageNames": ["*", "!zarf-dev/zarf", "!defenseunicorns/uds-cli", "!defenseunicorns/lula", "!k3d-io/k3d"],
       "groupName": "githubactions",
       "commitMessageTopic": "githubactions",
       "pinDigests": true


### PR DESCRIPTION
Ensures that pinDigests does not cause errors with renovate (see current issue with https://github.com/defenseunicorns/uds-core/issues/400).

This removes non-actions out of the actions group. Example PRs created by this approach:
- Zarf (no-change): https://github.com/BagelLab/uds-core/pull/28
- UDS (no-change): https://github.com/BagelLab/uds-core/pull/27
- Lula: https://github.com/BagelLab/uds-core/pull/26
- K3d: https://github.com/BagelLab/uds-core/pull/25
- Github-actions: https://github.com/BagelLab/uds-core/pull/24

Modified based on changes to renovate upstream: https://docs.renovatebot.com/release-notes-for-major-versions/#changes-to-package-matching