### PR TITLE
chore: updated pepr watch limit to 60s

### DIFF
--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -6,4 +6,4 @@ operator:
   UDS_LOG_LEVEL: "###ZARF_VAR_UDS_LOG_LEVEL###"
   AUTHSERVICE_REDIS_URI: "###ZARF_VAR_AUTHSERVICE_REDIS_URI###"
   # Allow Pepr watch to be configurable to react to dropped connections faster
-  PEPR_LAST_SEEN_LIMIT_SECONDS: "300"
+  PEPR_LAST_SEEN_LIMIT_SECONDS: "60"

--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -7,3 +7,5 @@ operator:
   AUTHSERVICE_REDIS_URI: "###ZARF_VAR_AUTHSERVICE_REDIS_URI###"
   # Allow Pepr watch to be configurable to react to dropped connections faster
   PEPR_LAST_SEEN_LIMIT_SECONDS: "60"
+  # Allow Pepr to re-list resources more frequently to avoid missing resources
+  PEPR_RELIST_INTERVAL_SECONDS: "60"


### PR DESCRIPTION
## Description

Adjust Pepr watch limit to a lower value to help UDS Package delete/reinstalls succeed more often.

## Related Issue

Fixes # https://github.com/defenseunicorns/uds-core/issues/839

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed