### PR TITLE
fix(ci): switch to larger runners to resolve ci disk space issues

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -20,6 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Free GH runner space
+      shell: bash
       run: |
         df -h
         sudo rm -rf /usr/share/dotnet

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -19,17 +19,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Free GH runner space
-      shell: bash
-      run: |
-        df -h
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo docker image prune --all --force
-        df -h
-
     - name: Use Node.js latest
       uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
       with:

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -19,6 +19,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free GH runner space
+      run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+        df -h
+
     - name: Use Node.js latest
       uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,8 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ inputs.package == 'all' && 'uds-ubuntu-big-boy-8-core' || 'ubuntu-latest'}}"
+    # Use the 8 core runner for full-core or 4 core runner (with larger disk) for func layers tests
+    runs-on: "${{ inputs.package == 'all' && 'uds-ubuntu-big-boy-8-core' || 'uds-ubuntu-big-boy-4-core'}}"
     timeout-minutes: 30
     name: Test
     env:

--- a/src/neuvector/README.md
+++ b/src/neuvector/README.md
@@ -1,1 +1,1 @@
-## Neuvector
+## NeuVector


### PR DESCRIPTION
## Description

As noted in https://github.com/defenseunicorns/uds-core/pull/880 runner space is being exceeded in some functional layer tests. This PR evaluated two options:
1. Run a cleanup script to remove unnecessary files from the runner. In testing this added between 2 and 6 minutes of CI time depending on the runner.
2. Switch to the ["large" 4 core runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#specifications-for-general-larger-runners), which has a 150gb disk. Cost is [$0.016 per minute of usage](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates-for-x64-powered-larger-runners). These tests run for an average of 5-10 minutes, with 3 runs per layer (for each flavor), making the cost ~$0.33 cents for a single commit on a PR changing a single layer.

Given the desire for faster dev/CI cycles and the cost of dev time, this PR flips to the paid runner rather than using the cleanup script.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/pull/880

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed