### PR TITLE
chore: regroup 'support dependencies' in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,36 +78,19 @@
       "commitMessageTopic": "runtime"
     },
     {
-      "matchPackageNames": ["zarf-dev/zarf", "ghcr.io/zarf-dev/packages/init"],
-      "groupName": "zarf",
-      "commitMessageTopic": "zarf"
-    },
-    {
-      "matchPackageNames": ["defenseunicorns/uds-cli"],
-      "groupName": "uds",
-      "commitMessageTopic": "uds"
-    },
-    {
-      "matchPackageNames": ["defenseunicorns/uds-k3d", "ghcr.io/defenseunicorns/packages/uds-k3d"],
-      "groupName": "uds-k3d",
-      "commitMessageTopic": "uds-k3d"
-    },
-    {
-      "matchFileNames": [".github/workflows/**", ".github/actions/**"],
-      "matchPackageNames": ["*", "!zarf-dev/zarf", "!defenseunicorns/uds-cli", "!defenseunicorns/lula", "!k3d-io/k3d"],
-      "groupName": "githubactions",
-      "commitMessageTopic": "githubactions",
-      "pinDigests": true
-    },
-    {
-      "matchFileNames": [".github/test-infra/**"],
-      "groupName": "test-infra",
-      "commitMessageTopic": "test-infra"
-    },
-    {
       "matchFileNames": ["package.json", "package-lock.json", "tasks/create.yaml"],
       "groupName": "pepr",
       "commitMessageTopic": "pepr"
+    },
+    {
+      "matchFileNames": [".github/**", "bundles/**", "tasks/iac.yaml"],
+      "groupName": "support-deps",
+      "commitMessageTopic": "support dependencies"
+    },
+    {
+      "matchPackageNames": ["defenseunicorns/uds-common"],
+      "groupName": "support-deps",
+      "commitMessageTopic": "support-deps"
     }
   ]
 }


### PR DESCRIPTION
## Description

This changes the grouping in renovate to group anything outside of the `src/<package>` folders into a single `support-deps` grouping (with the exception of pepr). I reviewed the current PRs and several previous merged PRs and these matches should catch all the other locations we have dependencies.

Worth noting we do not need the pinDigests option added anywhere since uds-common includes that as a helper for actions/workflows: https://github.com/defenseunicorns/uds-common/blob/main/config/renovate.json5#L8

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed