### PR TITLE
chore: ensure http2 watch config is used by internal exemption watch

### DIFF
--- a/src/pepr/policies/index.ts
+++ b/src/pepr/policies/index.ts
@@ -40,6 +40,7 @@ export async function startExemptionWatch() {
       relistIntervalSec: process.env.PEPR_RELIST_INTERVAL_SECONDS
         ? parseInt(process.env.PEPR_RELIST_INTERVAL_SECONDS, 10)
         : 1800,
+      useHTTP2: process.env.PEPR_HTTP2_WATCH === "true",
     };
     const watcher = K8s(UDSExemption).Watch(async (exemption, phase) => {
       log.debug(`Processing exemption ${exemption.metadata?.name}, watch phase: ${phase}`);

--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -11,3 +11,5 @@ operator:
   PEPR_LAST_SEEN_LIMIT_SECONDS: "60"
   # Allow Pepr to re-list resources more frequently to avoid missing resources
   PEPR_RELIST_INTERVAL_SECONDS: "60"
+  # Use HTTP2 for Pepr watches and exemption watch
+  PEPR_HTTP2_WATCH: false


### PR DESCRIPTION
## Description
The UDS Operator has KFC watch (exemptions) that operates outside of Pepr configured watchers.  This ensures the configuration for using HTTP2 watches is respected by the exemption watch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed