### PR TITLE
fix: istio proxy exiting early when Pod has restart policy

### DIFF
--- a/src/pepr/istio/index.ts
+++ b/src/pepr/istio/index.ts
@@ -53,7 +53,12 @@ When(a.Pod)
         // Ignore the istio-proxy container
         .filter(c => c.name != "istio-proxy")
         // and if ALL are terminated AND restartPolicy is Never or is OnFailure with a 0 exit code then shouldTerminate is true
-        .every(c => c.state?.terminated && (pod.spec?.restartPolicy == "Never" || (pod.spec?.restartPolicy == "OnFailure" && c.state.terminated.exitCode == 0)));
+        .every(
+          c =>
+            c.state?.terminated &&
+            (pod.spec?.restartPolicy == "Never" ||
+              (pod.spec?.restartPolicy == "OnFailure" && c.state.terminated.exitCode == 0)),
+        );
 
       if (shouldTerminate) {
         // Mark the pod as seen

--- a/src/pepr/istio/index.ts
+++ b/src/pepr/istio/index.ts
@@ -52,8 +52,8 @@ When(a.Pod)
       const shouldTerminate = pod.status.containerStatuses
         // Ignore the istio-proxy container
         .filter(c => c.name != "istio-proxy")
-        // and if ALL are terminated then shouldTerminate is true
-        .every(c => c.state?.terminated);
+        // and if ALL are terminated AND restartPolicy is Never or is OnFailure with a 0 exit code then shouldTerminate is true
+        .every(c => c.state?.terminated && (pod.spec?.restartPolicy == "Never" || (pod.spec?.restartPolicy == "OnFailure" && c.state.terminated.exitCode == 0)));
 
       if (shouldTerminate) {
         // Mark the pod as seen


### PR DESCRIPTION
## Description

This changes the proxy cleanup logic to be:

All containers terminated AND either:
- restartPolicy of Never
- restartPolicy of OnFailure w/0 exit code

A restartPolicy of Always should keep restarting the containers inside the pod and should not need proxy cleanup.

## Related Issue

Fixes #913 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed