### PR TITLE
fix: don't add duplicate policy names to `uds-core.pepr.dev/mutated` annotation

### DIFF
--- a/src/pepr/policies/common.ts
+++ b/src/pepr/policies/common.ts
@@ -112,6 +112,8 @@ export function annotateMutation<T extends KubernetesObject>(
   const annotations = request.Raw.metadata?.annotations ?? {};
   const valStr = annotations[key];
   const arr = JSON.parse(valStr || "[]");
-  arr.push(transform(policy));
+  if (!arr.includes(transform(policy))) {
+    arr.push(transform(policy));
+  }
   request.SetAnnotation(key, JSON.stringify(arr));
 }

--- a/src/pepr/policies/common.ts
+++ b/src/pepr/policies/common.ts
@@ -112,8 +112,9 @@ export function annotateMutation<T extends KubernetesObject>(
   const annotations = request.Raw.metadata?.annotations ?? {};
   const valStr = annotations[key];
   const arr = JSON.parse(valStr || "[]");
-  if (!arr.includes(transform(policy))) {
-    arr.push(transform(policy));
+  const safePolicyName = transform(policy);
+  if (!arr.includes(safePolicyName)) {
+    arr.push(safePolicyName);
   }
   request.SetAnnotation(key, JSON.stringify(arr));
 }


### PR DESCRIPTION
## Description
Adds a check to the `annotateMutation` function that prevents duplicate values (policy names) from being added to the `uds-core.pepr.dev/mutated` key

## Related Issue
Fixes https://github.com/defenseunicorns/uds-core/issues/717

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed