### PR TITLE
chore: block local auth for neuvector

### DIFF
--- a/src/neuvector/chart/templates/neuvector-deny.yaml
+++ b/src/neuvector/chart/templates/neuvector-deny.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-{{- if .Values.denyLocalAuth -}}
+{{- if .Values.denyLocalAuth }}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:

--- a/src/neuvector/chart/templates/neuvector-deny.yaml
+++ b/src/neuvector/chart/templates/neuvector-deny.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+{{- if .Values.denyLocalAuth -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: neuvector-deny-local-login
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: DENY
+  selector:
+    matchLabels:
+      app: neuvector-manager-pod
+  rules:
+  - to:
+    - operation:
+        paths: ["/auth"]
+        ports: ["8443"]
+{{- end }}

--- a/src/neuvector/chart/templates/uds-package.yaml
+++ b/src/neuvector/chart/templates/uds-package.yaml
@@ -1,5 +1,6 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+{{- $neuvectorAdminPass := join "" (list (randAlphaNum 12) (randAlpha 2 | upper) (randAlpha 2 | lower) (randNumeric 2))}}
 
 apiVersion: uds.dev/v1alpha1
 kind: Package
@@ -24,6 +25,13 @@ spec:
         - "https://neuvector.admin.{{ .Values.domain }}/openId_auth"
       secretName: neuvector-secret
       secretTemplate:
+        userinitcfg.yaml: |-
+          always_reload: true
+          users:
+            - username: admin
+              fullname: admin
+              password: {{ $neuvectorAdminPass }}
+              role: admin
         oidcinitcfg.yaml: |-
           always_reload: true
           client_id: clientField(clientId)

--- a/src/neuvector/chart/values.yaml
+++ b/src/neuvector/chart/values.yaml
@@ -7,3 +7,5 @@ grafana:
   enabled: false
 
 generateInternalCert: false
+
+denyLocalAuth: true


### PR DESCRIPTION
## Description
Ensure Neuvector local auth is inaccessible:
* Via Istio AuthorizationPolicy DENY to `/auth` on the manager pod
* Adds additional precaution to randomize admin user password

In theory Neuvector should not create an a local admin user as configured by https://github.com/defenseunicorns/uds-core/blob/c8d66fd394328426c523a60680c258ca1f15620c/src/neuvector/values/values.yaml#L28-L30 but it does not seem to honored at the moment.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed