### PR TITLE
chore: regroup renovate support dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -73,14 +73,14 @@
       "commitMessageTopic": "grafana"
     },
     {
+      "matchFileNames": ["e2e/playwright/**", ".github/**", "bundles/**", "tasks/*.yaml", ".vscode/settings.json", "src/test/**", "src/**/tasks.yaml"],
+      "groupName": "support-deps",
+      "commitMessageTopic": "support dependencies"
+    },
+    {
       "matchFileNames": ["package.json", "package-lock.json", "tasks/create.yaml"],
       "groupName": "pepr",
       "commitMessageTopic": "pepr"
-    },
-    {
-      "matchFileNames": ["e2e/playwright/**", ".github/**", "bundles/**", "tasks/iac.yaml", "tasks/setup.yaml", ".vscode/settings.json"],
-      "groupName": "support-deps",
-      "commitMessageTopic": "support dependencies"
     },
     {
       "matchPackageNames": ["defenseunicorns/uds-common"],


### PR DESCRIPTION
## Description

Regroups a few things to ensure support-deps grabs the right stuff:
- glob up all task files at the root level, with the exception of the create task (reordered pepr to ensure this one remains separate)
- includes `src/test` which contains test manifests/images
- includes `src/**/tasks.yaml` which sometimes contain playwright images or other support deps ([example](https://github.com/defenseunicorns/uds-core/blob/main/src/grafana/tasks.yaml#L42-L43))


## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed