### PR TITLE
feat: allow workloads to see and process external IP addresses

### DIFF
--- a/src/istio/values/gateway-values.yaml
+++ b/src/istio/values/gateway-values.yaml
@@ -1,2 +1,5 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
 service:
   externalTrafficPolicy: Local

--- a/src/istio/values/gateway-values.yaml
+++ b/src/istio/values/gateway-values.yaml
@@ -1,0 +1,2 @@
+service:
+  externalTrafficPolicy: Local

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -63,6 +63,8 @@ components:
         version: 1.23.2
         releaseName: admin-ingressgateway
         namespace: istio-admin-gateway
+        valuesFiles:
+          - "values/gateway-values.yaml"
       - name: uds-istio-config
         version: 0.2.0
         localPath: chart
@@ -78,6 +80,8 @@ components:
         version: 1.23.2
         releaseName: tenant-ingressgateway
         namespace: istio-tenant-gateway
+        valuesFiles:
+          - "values/gateway-values.yaml"
       - name: uds-istio-config
         version: 0.2.0
         localPath: chart
@@ -93,6 +97,8 @@ components:
         version: 1.23.2
         releaseName: passthrough-ingressgateway
         namespace: istio-passthrough-gateway
+        valuesFiles:
+          - "values/gateway-values.yaml"
       - name: uds-istio-config
         version: 0.2.0
         localPath: chart


### PR DESCRIPTION
## Description

This is a pair PR to the fix for GitLab to be able to process IP addresses directly so that Rack Attack can be configured and will work correctly:

https://github.com/defenseunicorns/uds-package-gitlab/pull/227

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed