### PR TITLE
fix!: remove remoteCidr exception block

### DIFF
--- a/src/pepr/operator/controllers/network/generate.spec.ts
+++ b/src/pepr/operator/controllers/network/generate.spec.ts
@@ -134,7 +134,6 @@ describe("network policy generate with remoteCidr", () => {
             {
               ipBlock: {
                 cidr: "192.168.0.0/16",
-                except: ["169.254.169.254/32"], // Include the except field here
               },
             },
           ],
@@ -162,7 +161,6 @@ describe("network policy generate with remoteCidr", () => {
             {
               ipBlock: {
                 cidr: "10.0.0.0/8",
-                except: ["169.254.169.254/32"], // Include the except field here
               },
             },
           ],

--- a/src/pepr/operator/controllers/network/generators/remoteCidr.ts
+++ b/src/pepr/operator/controllers/network/generators/remoteCidr.ts
@@ -4,14 +4,12 @@
  */
 
 import { V1NetworkPolicyPeer } from "@kubernetes/client-node";
-import { META_IP } from "./cloudMetadata";
 
-/** Matches a specific custom cidr EXCEPT the Cloud Meta endpoint */
+/** Matches a specific custom cidr without any exclusions */
 export function remoteCidr(cidr: string): V1NetworkPolicyPeer {
   return {
     ipBlock: {
       cidr,
-      except: [META_IP],
     },
   };
 }


### PR DESCRIPTION
## Description
BREAKING CHANGE:Remove the generated exception block from the remoteCidr generation. This change means that a cidr containing the META_IP could be set. 


Conversation with @mjnagel resulted in this implementation but open to other suggestions if we want to try and lock down allowed IP ranges with either generation logic, validations, or other.

## Related Issue

Fixes #950

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed