### PR TITLE
fix: ensure grafana does not install plugins from the internet

### DIFF
--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -28,6 +28,7 @@ grafana.ini:
     feedback_links_enabled: false
   plugins:
     public_key_retrieval_disabled: true
+    preinstall_disabled: true # Ensure we don't try to install plugins from grafana.com which would fail in the airgap
   auth:
     # Disable the login form to force users to use SSO
     disable_login_form: true
@@ -72,18 +73,18 @@ autoscaling:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 70  # Adjust based on expected load
+          averageUtilization: 70 # Adjust based on expected load
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: 75  # Optional, based on memory usage patterns
+          averageUtilization: 75 # Optional, based on memory usage patterns
   # Scaling behavior (optional): Controls how fast to scale up or down
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 300  # Prevent rapid scaling down
+      stabilizationWindowSeconds: 300 # Prevent rapid scaling down
       policies:
         - type: Pods
           value: 1
-          periodSeconds: 300  # Scale down one pod every 5 minutes
+          periodSeconds: 300 # Scale down one pod every 5 minutes


### PR DESCRIPTION
## Description

The Grafana 11.3.0 update contained a [new default pre-install plugin](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v11-3/#explore-logs). While this plugin would be nice, the method of installation involves reaching out to `grafana.com` on startup to download and install the plugin. To workaround this for the time being this PR disables the pre-install functionality.

In reviewing you should notice that before the change there are log failures reaching out to grafana:
```
logger=plugin.backgroundinstaller t=2024-11-07T18:42:14.912141481Z level=info msg="Installing plugin" pluginId=grafana-lokiexplore-app version=
logger=plugin.backgroundinstaller t=2024-11-07T18:42:14.939302134Z level=error msg="Failed to install plugin" pluginId=grafana-lokiexplore-app version= error="Get \"https://grafana.com/api/plugins/grafana-lokiexplore-app/versions\": read tcp 10.42.0.36:49118->34.120.177.193:443: read: connection reset by peer"
```

After this change those failures do not exist.

## Related Issue

Related to https://github.com/defenseunicorns/uds-core/issues/992

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed