### PR TITLE
fix: sets `fail-fast` to `false` for matrix workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish-uds-core:
     strategy:
-      fail-fast: false    
+      fail-fast: false
       matrix:
         flavor: [upstream, registry1, unicorn]
     runs-on: "uds-ubuntu-big-boy-8-core"
@@ -95,6 +95,7 @@ jobs:
   publish-uds-core-layers:
     if: ${{ !inputs.snapshot }}
     strategy:
+      fail-fast: false
       matrix:
         flavor: [upstream, registry1, unicorn]
         layer: [base, identity-authorization, runtime-security, backup-restore, logging, metrics-server, monitoring]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   publish-uds-core:
     strategy:
+      fail-fast: false    
       matrix:
         flavor: [upstream, registry1, unicorn]
     runs-on: "uds-ubuntu-big-boy-8-core"

--- a/.github/workflows/test-aks.yaml
+++ b/.github/workflows/test-aks.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   test-aks-install:
     strategy:
+      fail-fast: false
       matrix:
         flavor: [upstream, registry1, unicorn]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   test-eks-install:
     strategy:
-      fail-fast: false    
+      fail-fast: false
       matrix:
         flavor: [upstream, registry1, unicorn]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   test-eks-install:
     strategy:
+      fail-fast: false    
       matrix:
         flavor: [upstream, registry1, unicorn]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   test-rke2-install:
     strategy:
+      fail-fast: false    
       matrix:
         flavor: [upstream, registry1, unicorn]
     runs-on: ubuntu-latest

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   test-rke2-install:
     strategy:
-      fail-fast: false    
+      fail-fast: false
       matrix:
         flavor: [upstream, registry1, unicorn]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
We've noticed some behavior on the nightly ci pipelines where one failed parallel job was causing other in-progress jobs in the same workflow run to non gracefully terminate as the [cancellation timeout](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/canceling-a-workflow#:~:text=After%20the%205%20minutes%20cancellation%20timeout%20period%2C%20the%20server%20will%20force%20terminate%20all%20jobs%20and%20steps%20that%20don%27t%20finish%20running%20or%20fail%20to%20complete%20the%20cancellation%20process.) would be met. This led to inconsistent behavior with subsequent workflow runs involving terraform where pre-existing state files were locked. Workflows are continually failing until a new commit is made, which forces the workflow to generate a new state key. This would circumvent the issue, but consequentially leave behind orphaned resources. 

The intent of this PR is to ensure that all failed jobs gracefully exit and do not impact the status of other jobs that are running in the same workflow. This will add additional time to workflow runs, but it will always ensure that resources are properly cleaned up and that processes gracefully terminate before the pipeline completing.
...

## Related Issue
Example workflow run:
https://github.com/defenseunicorns/uds-core/actions/runs/11747339383/job/32731009925?pr=989#step:9:63

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed