### PR TITLE
chore: add variables for pepr memory requests in dev/demo bundles

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -40,6 +40,17 @@ packages:
     ref: 0.31.2
     # x-release-please-end
     overrides:
+      pepr-uds-core:
+        module:
+          variables:
+            - name: PEPR_WATCHER_MEMORY_REQUEST
+              description: "Memory requests for the pepr watcher pod"
+              path: "watcher.resources.requests.memory"
+              default: "64Mi"
+            - name: PEPR_ADMISSION_MEMORY_REQUEST
+              description: "Memory requests for the pepr admission pods"
+              path: "admission.resources.requests.memory"
+              default: "64Mi"
       istio-admin-gateway:
         uds-istio-config:
           variables:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -43,6 +43,17 @@ packages:
       - istio-passthrough-gateway
       - metrics-server
     overrides:
+      pepr-uds-core:
+        module:
+          variables:
+            - name: PEPR_WATCHER_MEMORY_REQUEST
+              description: "Memory requests for the pepr watcher pod"
+              path: "watcher.resources.requests.memory"
+              default: "256Mi"
+            - name: PEPR_ADMISSION_MEMORY_REQUEST
+              description: "Memory requests for the pepr admission pods"
+              path: "admission.resources.requests.memory"
+              default: "256Mi"
       loki:
         loki:
           variables:


### PR DESCRIPTION
## Description

Adds variables for memory requests in both bundles. Also defaults the slim-dev bundle requests to the old Pepr defaults (see [here](https://github.com/defenseunicorns/pepr/commit/8e6887b491b5dead3243077043bc8f2fdff0f8c0)).

## Related Issue

N/A - supports lighter weight CI for uds-package runs with slim-dev.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed