### PR TITLE
feat: allow additional network rules for grafana and neuvector

### DIFF
--- a/docs/reference/configuration/uds-networking-configuration.md
+++ b/docs/reference/configuration/uds-networking-configuration.md
@@ -103,7 +103,7 @@ Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configu
 
 ### NeuVector
 
-It may be desired to connect Grafana to additional datasources in or outside of the cluster. To facilitate this, you can provide a bundle override as follows:
+It may be desired send alerts from NeuVector to locations in or outside of the cluster. To facilitate this, you can provide a bundle override as follows:
 
 ```yaml
 packages:

--- a/docs/reference/configuration/uds-networking-configuration.md
+++ b/docs/reference/configuration/uds-networking-configuration.md
@@ -33,9 +33,9 @@ packages:
                   port: 443
 ```
 
-The example above allows Alertmanager to send alerts to any external destination. Alternatively, you could use the remoteNamespace key to specify another namespace within the Kubernetes cluster.
+The example above allows Alertmanager to send alerts to any external destination. Alternatively, you could use the remoteNamespace key to specify another namespace within the Kubernetes cluster (i.e. Mattermost).
 
-Referencing the following spec for [Allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.
+Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.
 
 ### Vector
 
@@ -70,4 +70,60 @@ packages:
 
 The example above allows Vector to send logs to an Elastic instance in the elastic namespace and to an S3 storage service.
 
-Referencing the following spec for [Allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.
+Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.
+
+### Grafana
+
+It may be desired to connect Grafana to additional datasources in or outside of the cluster. To facilitate this, you can provide a bundle override as follows:
+
+```yaml
+packages:
+  - name: uds-core
+    repository: ghcr.io/defenseunicorns/packages/uds/core-monitoring
+    ref: 0.31.1-upstream
+    overrides:
+      grafana:
+        uds-grafana-config:
+          values:
+            - path: additionalNetworkAllow
+              value:
+                - direction: Egress
+                  selector:
+                    app.kubernetes.io/name: grafana
+                  remoteNamespace: thanos
+                  remoteSelector:
+                    app.kubernetes.io/name: thanos
+                  port: 9090
+                  description: "Thanos Query"
+```
+
+The example above allows Grafana to query a remote Thanos instance in your cluster.
+
+Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.
+
+### NeuVector
+
+It may be desired to connect Grafana to additional datasources in or outside of the cluster. To facilitate this, you can provide a bundle override as follows:
+
+```yaml
+packages:
+  - name: uds-core
+    repository: ghcr.io/defenseunicorns/packages/uds/core-monitoring
+    ref: 0.31.1-upstream
+    overrides:
+      neuvector:
+        uds-neuvector-config:
+          values:
+            - path: additionalNetworkAllow
+              value:
+                - direction: Egress
+                  selector:
+                    app: neuvector-manager-pod
+                  remoteGenerated: Anywhere
+                  description: "from neuvector to anywhere"
+                  port: 443
+```
+
+The example above allows NeuVector to send alerts to any external destination. Alternatively, you could use the remoteNamespace key to specify another namespace within the Kubernetes cluster (i.e. Mattermost).
+
+Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.

--- a/src/grafana/chart/templates/uds-package.yaml
+++ b/src/grafana/chart/templates/uds-package.yaml
@@ -93,3 +93,8 @@ spec:
         remoteGenerated: IntraNamespace
         ports:
           - 3000
+
+      # Custom rules for additional networking access
+      {{- with .Values.additionalNetworkAllow }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}

--- a/src/grafana/chart/values.yaml
+++ b/src/grafana/chart/values.yaml
@@ -24,3 +24,15 @@ postgresql:
     enabled: false
     remoteSelector: {}
     remoteNamespace: ""
+
+# Support for custom `network.allow` entries on the Package CR, useful for extra datasources
+additionalNetworkAllow: []
+# ref: https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow
+#   - direction: Egress
+#     selector:
+#       app.kubernetes.io/name: grafana
+#     remoteNamespace: thanos
+#     remoteSelector:
+#       app: thanos
+#     description: "Thanos Query"
+#     port: 9090

--- a/src/neuvector/chart/templates/uds-package.yaml
+++ b/src/neuvector/chart/templates/uds-package.yaml
@@ -93,3 +93,8 @@ spec:
           app: neuvector-controller-pod
         port: 30443
         description: "Webhook"
+
+      # Custom rules for additional networking access
+      {{- with .Values.additionalNetworkAllow }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}

--- a/src/neuvector/chart/values.yaml
+++ b/src/neuvector/chart/values.yaml
@@ -9,3 +9,13 @@ grafana:
 generateInternalCert: false
 
 denyLocalAuth: true
+
+# Support for custom `network.allow` entries on the Package CR, useful for sending NeuVector alerts
+additionalNetworkAllow: []
+# ref: https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow
+#   - direction: Egress
+#     selector:
+#       app: neuvector-manager-pod
+#     remoteGenerated: Anywhere
+#     description: "from neuvector to anywhere"
+#     port: 443


### PR DESCRIPTION
## Description

Following the pattern on Vector and Prometheus this adds support for custom network policies via overrides, as well as the examples for this.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/951

Note that we may want to continue to track usage of these fields and as suggested [here](https://github.com/defenseunicorns/uds-core/issues/951#issuecomment-2432728395) add some specific templated policies for easy toggle on/off if we see them being adopted more widely.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed