### PR TITLE
fix: update nightly ci timeouts

### DIFF
--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -86,7 +86,7 @@ jobs:
         env:
           UDS_CONFIG: .github/bundles/eks/uds-config.yaml
         run: uds deploy .github/bundles/eks/uds-bundle-uds-core-eks-nightly-*.tar.zst --confirm
-        timeout-minutes: 20
+        timeout-minutes: 30
 
       - name: Debug Output
         if: ${{ always() }}

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -90,7 +90,7 @@ jobs:
         env:
           UDS_CONFIG: .github/bundles/rke2/uds-config.yaml
         run: uds deploy .github/bundles/rke2/uds-bundle-uds-core-rke2-nightly-*.tar.zst --confirm
-        timeout-minutes: 60
+        timeout-minutes: 30
 
       - name: Debug Output
         if: ${{ always() }}


### PR DESCRIPTION
## Description

Failure seen on EKS taking just over 20 minutes: https://github.com/defenseunicorns/uds-core/actions/runs/12133948191/job/33830339733

This aligns all timeouts to 30 minutes (azure already was 30).

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed