### PR TITLE
fix: client timeouts

### DIFF
--- a/docs/reference/configuration/uds-operator.md
+++ b/docs/reference/configuration/uds-operator.md
@@ -254,6 +254,8 @@ The SSO spec supports a subset of the Keycloak attributes for clients, but does 
 - oauth2.device.authorization.grant.enabled
 - pkce.code.challenge.method
 - client.session.idle.timeout
+- client.session.max.lifespan
+- access.token.lifespan
 - saml.assertion.signature
 - saml.client.signature
 - saml_assertion_consumer_url_post

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.7.0
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.8.0
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"

--- a/src/keycloak/tasks.yaml
+++ b/src/keycloak/tasks.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
-  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.7.0/tasks.yaml
+  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.8.0/tasks.yaml
 
 tasks:
   - name: validate

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -24,7 +24,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.0.6
-      - ghcr.io/defenseunicorns/uds/identity-config:0.7.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.8.0
 
   - name: keycloak
     required: true
@@ -40,7 +40,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:26.0.6
-      - ghcr.io/defenseunicorns/uds/identity-config:0.7.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.8.0
 
   - name: keycloak
     required: true
@@ -54,4 +54,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - cgr.dev/du-uds-defenseunicorns/keycloak:26.0.6 # todo: switch to FIPS image
-      - ghcr.io/defenseunicorns/uds/identity-config:0.7.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.8.0

--- a/src/pepr/operator/crd/validators/package-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/package-validator.spec.ts
@@ -524,6 +524,8 @@ describe("Test Allowed SSO Client Attributes", () => {
             "oauth2.device.authorization.grant.enabled": "true",
             "pkce.code.challenge.method": "S256",
             "client.session.idle.timeout": "3600",
+            "client.session.max.lifespan": "36000",
+            "access.token.lifespan": "60",
             "saml.assertion.signature": "false",
             "saml.client.signature": "false",
             saml_assertion_consumer_url_post: "https://nexus.uds.dev/saml",

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -119,6 +119,8 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
     "oauth2.device.authorization.grant.enabled",
     "pkce.code.challenge.method",
     "client.session.idle.timeout",
+    "client.session.max.lifespan",
+    "access.token.lifespan",
     "saml.assertion.signature",
     "saml.client.signature",
     "saml_assertion_consumer_url_post",


### PR DESCRIPTION
## Description

Adding client session max lifespan and client access token lifespan attributes to operator for configuring keycloak clients. Identity config was [recently updated](https://github.com/defenseunicorns/uds-identity-config/pull/271) to include environment variables for these realm settings, but also exposing them at the client level via the operator was necessary.

## Related Issue

Relates to #676 & #188

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed