### PR TITLE
fix: kubeapi watch updates, allow configurable cidr

### DIFF
--- a/docs/reference/configuration/uds-networking-configuration.md
+++ b/docs/reference/configuration/uds-networking-configuration.md
@@ -4,7 +4,7 @@ title: Networking Configuration
 
 ## KubeAPI Egress
 
-The UDS operator is responsible for dynamically updating network policies that use `remoteGenerated: KubeAPI` network policies, in response to changes in the Kubernetes API server’s IP address. This ensures that policies remain accurate as cluster configurations evolve. However, in environments where the API server IP(s) frequently change, this behavior can lead to unnecessary overhead or instability.
+The UDS operator is responsible for dynamically updating network policies that use the `remoteGenerated: KubeAPI` custom selector, in response to changes in the Kubernetes API server’s IP address. This ensures that policies remain accurate as cluster configurations evolve. However, in environments where the API server IP(s) frequently change, this behavior can lead to unnecessary overhead or instability.
 
 To address this, the UDS operator provides an option to configure a static CIDR range. This approach eliminates the need for continuous updates by using a predefined range of IP addresses for network policies. To configure a specific CIDR range, set an override to `operator.KUBEAPI_CIDR` in your bundle as a value or variable. For example:
 

--- a/docs/reference/configuration/uds-networking-configuration.md
+++ b/docs/reference/configuration/uds-networking-configuration.md
@@ -2,6 +2,29 @@
 title: Networking Configuration
 ---
 
+## KubeAPI Egress
+
+The UDS operator is responsible for dynamically updating network policies that use `remoteGenerated: KubeAPI` network policies, in response to changes in the Kubernetes API server’s IP address. This ensures that policies remain accurate as cluster configurations evolve. However, in environments where the API server IP(s) frequently change, this behavior can lead to unnecessary overhead or instability.
+
+To address this, the UDS operator provides an option to configure a static CIDR range. This approach eliminates the need for continuous updates by using a predefined range of IP addresses for network policies. To configure a specific CIDR range, set an override to `operator.KUBEAPI_CIDR` in your bundle as a value or variable. For example:
+
+```yaml
+packages:
+  - name: uds-core
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: x.x.x
+    overrides:
+      uds-operator-config:
+        uds-operator-config:
+          values:
+            - path: operator.KUBEAPI_CIDR
+              value: "172.0.0.0/24"
+```
+
+This configuration directs the operator to use the specified CIDR range (`172.0.0.0/24` in this case) for KubeAPI network policies instead of dynamically tracking the API server’s IP(s).
+
+When configuring a static CIDR range, it is important to make the range as restrictive as possible to limit the potential for unexpected networking access. An overly broad range could inadvertently allow egress traffic to destinations beyond the intended scope. Additionally, careful alignment with the actual IP addresses used by the Kubernetes API server is essential. A mismatch between the specified CIDR range and the cluster's configuration can result in network policy enforcement issues or disrupted connectivity.
+
 ## Additional Network Allowances
 
 Applications deployed in UDS Core utilize [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) with a "Deny by Default" configuration to ensure network traffic is restricted to only what is necessary. Some applications in UDS Core allow for overrides to accommodate environment-specific requirements.

--- a/src/pepr/config.ts
+++ b/src/pepr/config.ts
@@ -31,6 +31,9 @@ export const UDSConfig = {
   // Redis URI for Authservice
   authserviceRedisUri,
 
+  // Static CIDR range to use for KubeAPI instead of k8s watch
+  kubeApiCidr: process.env.KUBEAPI_CIDR,
+
   // Track if UDS Core identity-authorization layer is deployed
   isIdentityDeployed: false,
 };

--- a/src/pepr/operator/controllers/network/generate.ts
+++ b/src/pepr/operator/controllers/network/generate.ts
@@ -93,6 +93,11 @@ export function generate(namespace: string, policy: Allow): kind.NetworkPolicy {
     };
   }
 
+  // Add the generated policy label (used to track KubeAPI policies)
+  if (policy.remoteGenerated) {
+    generated.metadata!.labels!["uds/generated"] = policy.remoteGenerated;
+  }
+
   // Create the network policy peers
   const peers: V1NetworkPolicyPeer[] = getPeers(policy);
 

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
@@ -78,6 +78,7 @@ describe("updateAPIServerCIDR", () => {
           ],
         },
       }),
+      { force: true }, // Include the second argument in the call
     );
   });
 
@@ -132,6 +133,7 @@ describe("updateAPIServerCIDR", () => {
           ],
         },
       }),
+      { force: true }, // Include the second argument in the call
     );
   });
 
@@ -182,6 +184,7 @@ describe("updateAPIServerCIDR", () => {
           ],
         },
       }),
+      { force: true }, // Include the second argument in the call
     );
   });
 
@@ -230,6 +233,7 @@ describe("updateAPIServerCIDR", () => {
           ],
         },
       }),
+      { force: true }, // Include the second argument in the call
     );
   });
 

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2024 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+import { describe, expect, it, jest } from "@jest/globals";
+import { kind } from "pepr";
+import * as kubeAPI from "./kubeAPI";
+
+jest.mock("./kubeAPI", () => {
+  const actual = jest.requireActual("./kubeAPI") as typeof kubeAPI;
+  const mockNetPol = jest.fn(); // Create the mock function
+  return {
+    ...actual,
+    updateKubeAPINetworkPolicies: mockNetPol, // Use the mock function directly
+  };
+});
+
+describe("updateAPIServerCIDR", () => {
+  it("handles a static CIDR string", async () => {
+    const mockService = {
+      spec: {
+        clusterIP: "10.0.0.1",
+      },
+    } as kind.Service;
+
+    const staticCIDR = "192.168.1.0/24";
+
+    await kubeAPI.updateAPIServerCIDR(mockService, staticCIDR);
+
+    expect(kubeAPI.updateKubeAPINetworkPolicies).toHaveBeenCalledWith([
+      { ipBlock: { cidr: staticCIDR } },
+      { ipBlock: { cidr: "10.0.0.1/32" } },
+    ]);
+  });
+
+  it("handles an EndpointSlice with multiple endpoints", async () => {
+    const mockService = {
+      spec: {
+        clusterIP: "10.0.0.1",
+      },
+    } as kind.Service;
+
+    const mockSlice = {
+      endpoints: [{ addresses: ["192.168.1.2"] }, { addresses: ["192.168.1.3"] }],
+    } as kind.EndpointSlice;
+
+    await kubeAPI.updateAPIServerCIDR(mockService, mockSlice);
+
+    expect(kubeAPI.updateKubeAPINetworkPolicies).toHaveBeenCalledWith([
+      { ipBlock: { cidr: "192.168.1.2/32" } },
+      { ipBlock: { cidr: "192.168.1.3/32" } },
+      { ipBlock: { cidr: "10.0.0.1/32" } },
+    ]);
+  });
+});

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
@@ -4,8 +4,12 @@
  */
 
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { kind } from "pepr";
+import { K8s, kind } from "pepr";
 import { updateAPIServerCIDR } from "./kubeAPI";
+
+type KubernetesList<T> = {
+  items: T[];
+};
 
 jest.mock("pepr", () => {
   const originalModule = jest.requireActual("pepr") as object;
@@ -14,12 +18,6 @@ jest.mock("pepr", () => {
     K8s: jest.fn(),
   };
 });
-
-import { K8s } from "pepr";
-
-type KubernetesList<T> = {
-  items: T[];
-};
 
 describe("updateAPIServerCIDR", () => {
   const mockApply = jest.fn();

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.ts
@@ -126,12 +126,12 @@ export async function updateAPIServerCIDR(svc: kind.Service, slice: kind.Endpoin
   if (peers.length) {
     apiServerPeers = peers.flatMap(cidr => ({
       ipBlock: {
-        cidr,
+        cidr: cidr,
       },
     }));
 
     // Update NetworkPolicies
-    await updateNetworkPolicies(apiServerPeers);
+    await updateKubeAPINetworkPolicies(apiServerPeers);
   } else {
     log.warn("No peers found for the API server CIDR update.");
   }
@@ -142,7 +142,7 @@ export async function updateAPIServerCIDR(svc: kind.Service, slice: kind.Endpoin
  *
  * @param {V1NetworkPolicyPeer[]} newPeers - The updated list of peers to apply to the NetworkPolicies.
  */
-async function updateNetworkPolicies(newPeers: V1NetworkPolicyPeer[]) {
+export async function updateKubeAPINetworkPolicies(newPeers: V1NetworkPolicyPeer[]) {
   const netPols = await K8s(kind.NetworkPolicy)
     .WithLabel("uds.dev/generated", RemoteGenerated.KubeAPI)
     .Get();

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.ts
@@ -6,6 +6,7 @@
 import { V1NetworkPolicyPeer } from "@kubernetes/client-node";
 import { K8s, kind, R } from "pepr";
 
+import { UDSConfig } from "../../../../config";
 import { Component, setupLogger } from "../../../../logger";
 import { RemoteGenerated } from "../../../crd";
 import { anywhere } from "./anywhere";
@@ -17,19 +18,33 @@ const log = setupLogger(Component.OPERATOR_GENERATORS);
 let apiServerPeers: V1NetworkPolicyPeer[];
 
 /**
- * Initialize the API server CIDR by getting the EndpointSlice and Service for the API server
+ * Initialize the API server CIDR.
+ *
+ * This function checks if a static CIDR is defined in the configuration.
+ * If a static CIDR exists, it skips the EndpointSlice lookup and uses the static value.
+ * Otherwise, it fetches the EndpointSlice and updates the CIDR dynamically.
  */
 export async function initAPIServerCIDR() {
-  const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
   const svc = await K8s(kind.Service).InNamespace("default").Get("kubernetes");
-  await updateAPIServerCIDR(slice, svc);
+
+  // If static CIDR is defined, pass it directly
+  if (UDSConfig.kubeApiCidr) {
+    log.info(
+      `Static CIDR (${UDSConfig.kubeApiCidr}) is defined for KubeAPI, skipping EndpointSlice lookup.`,
+    );
+    await updateAPIServerCIDR(svc, UDSConfig.kubeApiCidr); // Pass static CIDR
+  } else {
+    const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
+    await updateAPIServerCIDR(svc, slice);
+  }
 }
 
 /**
- * Get the API server CIDR
- * @returns The API server CIDR
+ * Get the API server CIDR.
+ *
+ * @returns {V1NetworkPolicyPeer[]} The cached API server CIDR if available; otherwise, defaults to `0.0.0.0/0`.
  */
-export function kubeAPI() {
+export function kubeAPI(): V1NetworkPolicyPeer[] {
   // If the API server peers are already cached, return them
   if (apiServerPeers) {
     return apiServerPeers;
@@ -41,8 +56,9 @@ export function kubeAPI() {
 }
 
 /**
- * When the kubernetes EndpointSlice is created or updated, update the API server CIDR
- * @param slice The EndpointSlice for the API server
+ * When the Kubernetes EndpointSlice is created or updated, update the API server CIDR.
+ *
+ * @param {kind.EndpointSlice} slice - The EndpointSlice object for the API server.
  */
 export async function updateAPIServerCIDRFromEndpointSlice(slice: kind.EndpointSlice) {
   try {
@@ -50,7 +66,7 @@ export async function updateAPIServerCIDRFromEndpointSlice(slice: kind.EndpointS
       "Processing watch for endpointslices, getting k8s service for updating API server CIDR",
     );
     const svc = await K8s(kind.Service).InNamespace("default").Get("kubernetes");
-    await updateAPIServerCIDR(slice, svc);
+    await updateAPIServerCIDR(svc, slice);
   } catch (err) {
     const msg = "Failed to update network policies from endpoint slice watch";
     log.error({ err }, msg);
@@ -58,65 +74,89 @@ export async function updateAPIServerCIDRFromEndpointSlice(slice: kind.EndpointS
 }
 
 /**
- * When the kubernetes Service is created or updated, update the API server CIDR
- * @param svc The Service for the API server
+ * When the Kubernetes Service is created or updated, update the API server CIDR.
+ *
+ * If a static CIDR is defined, it skips fetching the EndpointSlice and uses the static value.
+ *
+ * @param {kind.Service} svc - The Service object for the API server.
  */
 export async function updateAPIServerCIDRFromService(svc: kind.Service) {
   try {
-    log.debug(
-      "Processing watch for api service, getting endpoint slices for updating API server CIDR",
-    );
-    const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
-    await updateAPIServerCIDR(slice, svc);
+    if (UDSConfig.kubeApiCidr) {
+      log.debug("Processing watch for api service, using configured API CIDR for endpoints");
+      await updateAPIServerCIDR(svc, UDSConfig.kubeApiCidr);
+    } else {
+      log.debug(
+        "Processing watch for api service, getting endpoint slices for updating API server CIDR",
+      );
+      const slice = await K8s(kind.EndpointSlice).InNamespace("default").Get("kubernetes");
+      await updateAPIServerCIDR(svc, slice);
+    }
   } catch (err) {
-    const msg = "Failed to update network policies from api service watch";
+    const msg = "Failed to update network policies from API service watch";
     log.error({ err }, msg);
   }
 }
 
 /**
- * Update the API server CIDR and update the NetworkPolicies
+ * Update the API server CIDR and apply it to the NetworkPolicies.
  *
- * @param slice The EndpointSlice for the API server
- * @param svc The Service for the API server
+ * @param {kind.Service} svc - The Service object representing the Kubernetes API server.
+ * @param {kind.EndpointSlice | string} slice - Either the EndpointSlice for dynamic CIDR generation or a static CIDR string.
  */
-export async function updateAPIServerCIDR(slice: kind.EndpointSlice, svc: kind.Service) {
-  const { endpoints } = slice;
+export async function updateAPIServerCIDR(svc: kind.Service, slice: kind.EndpointSlice | string) {
   const k8sApiIP = svc.spec?.clusterIP;
 
-  // Flatten the endpoints into a list of IPs
-  const peers = endpoints?.flatMap(e => e.addresses);
+  let peers: string[] = [];
 
-  if (k8sApiIP) {
-    peers?.push(k8sApiIP);
+  // Handle static CIDR or dynamic EndpointSlice
+  if (typeof slice === "string") {
+    peers.push(slice);
+  } else {
+    const { endpoints } = slice;
+    peers = endpoints?.flatMap(e => `${e.addresses}/32`) || [];
   }
 
-  // If the peers are found, cache and process them
-  if (peers?.length) {
-    apiServerPeers = peers.flatMap(ip => ({
+  // Add the clusterIP from the service
+  if (k8sApiIP) {
+    peers.push(`${k8sApiIP}/32`);
+  }
+
+  // Convert peers into NetworkPolicyPeer objects
+  if (peers.length) {
+    apiServerPeers = peers.flatMap(cidr => ({
       ipBlock: {
-        cidr: `${ip}/32`,
+        cidr,
       },
     }));
 
-    // Get all the KubeAPI NetworkPolicies
-    const netPols = await K8s(kind.NetworkPolicy)
-      .WithLabel("uds.dev/generated", RemoteGenerated.KubeAPI)
-      .Get();
+    // Update NetworkPolicies
+    await updateNetworkPolicies(apiServerPeers);
+  } else {
+    log.warn("No peers found for the API server CIDR update.");
+  }
+}
 
-    for (const netPol of netPols.items) {
-      // Get the old peers
-      const oldPeers = netPol.spec?.egress?.[0].to;
+/**
+ * Update NetworkPolicies with new API server peers.
+ *
+ * @param {V1NetworkPolicyPeer[]} newPeers - The updated list of peers to apply to the NetworkPolicies.
+ */
+async function updateNetworkPolicies(newPeers: V1NetworkPolicyPeer[]) {
+  const netPols = await K8s(kind.NetworkPolicy)
+    .WithLabel("uds.dev/generated", RemoteGenerated.KubeAPI)
+    .Get();
 
-      // Update the NetworkPolicy if the peers have changed
-      if (!R.equals(oldPeers, apiServerPeers)) {
-        // Note using the apiServerPeers variable here instead of the oldPeers variable
-        // in case another EndpointSlice is updated before this one
-        netPol.spec!.egress![0].to = apiServerPeers;
+  for (const netPol of netPols.items) {
+    const oldPeers = netPol.spec?.egress?.[0].to;
 
-        log.debug(`Updating ${netPol.metadata!.namespace}/${netPol.metadata!.name}`);
-        await K8s(kind.NetworkPolicy).Apply(netPol);
-      }
+    if (!R.equals(oldPeers, newPeers)) {
+      netPol.spec!.egress![0].to = newPeers;
+
+      log.debug(
+        `Updating KubeAPI NetworkPolicy ${netPol.metadata!.namespace}/${netPol.metadata!.name} with new CIDRs.`,
+      );
+      await K8s(kind.NetworkPolicy).Apply(netPol);
     }
   }
 }

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -99,7 +99,15 @@ export async function retryWithDelay<T>(
       if (attempt >= retries) {
         throw err; // Exceeded retries, rethrow the error.
       }
-      log.warn(`Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms. Error: ${err}`);
+      let message = `Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms.`;
+      if (err.message) {
+        message += `Error: ${err.message}`;
+      } else if (err.data?.message) {
+        message += `Error: ${err.data.message}`;
+      } else {
+        message += "Unknown error while running function.";
+      }
+      log.warn(message);
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
   }

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -99,9 +99,7 @@ export async function retryWithDelay<T>(
       if (attempt >= retries) {
         throw err; // Exceeded retries, rethrow the error.
       }
-      log.warn(`Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms...`, {
-        error: (err as Error).message,
-      });
+      log.warn(`Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms. Error: ${err}`);
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
   }

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -100,12 +100,15 @@ export async function retryWithDelay<T>(
         throw err; // Exceeded retries, rethrow the error.
       }
       let message = `Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms.`;
+      // Standard errors should have a message
       if (err.message) {
         message += `Error: ${err.message}`;
+        // Error responses from network calls (i.e. K8s().Get() will be this shape)
       } else if (err.data?.message) {
         message += `Error: ${err.data.message}`;
+        // If we don't find one of these error messages, log the full error as JSON
       } else {
-        message += "Unknown error while running function.";
+        message += `Error: ${JSON.stringify(err)}`;
       }
       log.warn(message);
       await new Promise(resolve => setTimeout(resolve, delayMs));

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -100,12 +100,12 @@ export async function retryWithDelay<T>(
         throw err; // Exceeded retries, rethrow the error.
       }
       let message = `Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms. `;
-      // Standard errors should have a message
-      if (err.message) {
-        message += `Error: ${err.message}`;
-        // Error responses from network calls (i.e. K8s().Get() will be this shape)
-      } else if (err.data?.message) {
+      // Error responses from network calls (i.e. K8s().Get() will be this shape)
+      if (err.data?.message) {
         message += `Error: ${err.data.message}`;
+        // Other error types have a message
+      } else if (err.message) {
+        message += `Error: ${err.message}`;
         // If we don't find one of these error messages, log the full error as JSON
       } else {
         message += `Error: ${JSON.stringify(err)}`;

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -99,7 +99,7 @@ export async function retryWithDelay<T>(
       if (attempt >= retries) {
         throw err; // Exceeded retries, rethrow the error.
       }
-      let message = `Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms.`;
+      let message = `Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms. `;
       // Standard errors should have a message
       if (err.message) {
         message += `Error: ${err.message}`;

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -99,18 +99,15 @@ export async function retryWithDelay<T>(
       if (attempt >= retries) {
         throw err; // Exceeded retries, rethrow the error.
       }
-      let message = `Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms. `;
+      let error = `${JSON.stringify(err)}`;
       // Error responses from network calls (i.e. K8s().Get() will be this shape)
       if (err.data?.message) {
-        message += `Error: ${err.data.message}`;
+        error = err.data.message;
         // Other error types have a message
       } else if (err.message) {
-        message += `Error: ${err.message}`;
-        // If we don't find one of these error messages, log the full error as JSON
-      } else {
-        message += `Error: ${JSON.stringify(err)}`;
+        error = err.message;
       }
-      log.warn(message);
+      log.warn(`Attempt ${attempt} of ${fn.name} failed, retrying in ${delayMs}ms.`, { error });
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
   }

--- a/src/pepr/operator/index.ts
+++ b/src/pepr/operator/index.ts
@@ -34,11 +34,14 @@ const log = setupLogger(Component.OPERATOR);
 void initAPIServerCIDR();
 
 // Watch for changes to the API server EndpointSlice and update the API server CIDR
-When(a.EndpointSlice)
-  .IsCreatedOrUpdated()
-  .InNamespace("default")
-  .WithName("kubernetes")
-  .Reconcile(updateAPIServerCIDRFromEndpointSlice);
+// Skip if a CIDR is defined in the UDS Config
+if (!UDSConfig.kubeApiCidr) {
+  When(a.EndpointSlice)
+    .IsCreatedOrUpdated()
+    .InNamespace("default")
+    .WithName("kubernetes")
+    .Reconcile(updateAPIServerCIDRFromEndpointSlice);
+}
 
 // Watch for changes to the API server Service and update the API server CIDR
 When(a.Service)

--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -7,6 +7,7 @@ operator:
   UDS_ALLOW_ALL_NS_EXEMPTIONS: "###ZARF_VAR_ALLOW_ALL_NS_EXEMPTIONS###"
   UDS_LOG_LEVEL: "###ZARF_VAR_UDS_LOG_LEVEL###"
   AUTHSERVICE_REDIS_URI: "###ZARF_VAR_AUTHSERVICE_REDIS_URI###"
+  KUBEAPI_CIDR: ""
   # Allow Pepr watch to be configurable to react to dropped connections faster
   PEPR_LAST_SEEN_LIMIT_SECONDS: "300"
   # Allow Pepr to re-list resources more frequently to avoid missing resources


### PR DESCRIPTION
## Description

This PR contains two changes, both aimed at providing fixes for lingering issues with the KubeAPI watch:
1. NetworkPolicy updates based on changes to KubeAPI endpoints have never actually run as expected. The label we use to select existing KubeAPI network policies was never actually applied to policies in the first place. Previously we applied a `uds/generated` label but selected on `uds.dev/generated`, so these never lined up. Additionally our apply would have failed due to the existence of managed fields on the object. This has been the main cause of the problem with our auto-update logic. Pepr watcher restarts fixed the network policies not because of watch fixes, but because we re-reconcile all packages on startup.
2. While the watch does appear to be stable, this PR additionally adds a config option to manually set a CIDR to use instead of relying on the watch. This could be useful in some clusters (such as EKS) where the controlplane IPs update frequently to reduce churn on network policy modifications.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/821

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed