### PR TITLE
chore: update README to explicitly indicate the need for a running co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ UDS Core establishes a secure baseline for cloud-native systems and ships with c
 
 ### Prerequisites
 
-- A running container environment for K3D to interact with
+- A running container environment for K3D to interact with for dev & test environments
 - [K3D](https://k3d.io/) for dev & test environments or any [CNCF Certified Kubernetes Cluster](https://www.cncf.io/training/certification/software-conformance/#logos) for production environments.
 <!-- renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver -->
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli?tab=readme-ov-file#install) v0.8.1 or later

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ UDS Core establishes a secure baseline for cloud-native systems and ships with c
 
 ### Prerequisites
 
+- A running container environment for K3D to interact with
 - [K3D](https://k3d.io/) for dev & test environments or any [CNCF Certified Kubernetes Cluster](https://www.cncf.io/training/certification/software-conformance/#logos) for production environments.
 <!-- renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver -->
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli?tab=readme-ov-file#install) v0.8.1 or later


### PR DESCRIPTION
Chore: Adding an explicit callout in `README.md` that a running container environment is required for K3D to interact with. Most folks won't need this said. Those who do will definitely benefit from the addition.