### PR TITLE
chore: bump aks sku from free to standard to address API server perfo…

### DIFF
--- a/.github/test-infra/azure/aks/variables.tf
+++ b/.github/test-infra/azure/aks/variables.tf
@@ -29,7 +29,7 @@ variable "sku_tier" {
   type        = string
 
   validation {
-    condition     = contains(["Free", "Paid"], var.sku_tier)
+    condition     = contains(["Free", "Standard", "Premium"], var.sku_tier)
     error_message = "The sku tier is invalid."
   }
 }

--- a/.github/test-infra/azure/aks/variables.tf
+++ b/.github/test-infra/azure/aks/variables.tf
@@ -25,7 +25,7 @@ variable "dns_prefix" {
 
 variable "sku_tier" {
   description = "(Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free."
-  default     = "Free"
+  default     = "Standard"
   type        = string
 
   validation {

--- a/.github/test-infra/azure/aks/variables.tf
+++ b/.github/test-infra/azure/aks/variables.tf
@@ -24,7 +24,7 @@ variable "dns_prefix" {
 }
 
 variable "sku_tier" {
-  description = "(Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Paid (which includes the Uptime SLA). Defaults to Free."
+  description = "(Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are Free and Standard (which includes the Uptime SLA), and Premium. Defaults to Free."
   default     = "Standard"
   type        = string
 


### PR DESCRIPTION
## Description
We've been seeing consistent nightly ci failures on AKS that suggest that the API server is a bottleneck to uds-core deployment.
From @mjnagel:
- https://github.com/defenseunicorns/uds-core/actions/runs/12310537338/job/34359271873#step:11:320: no error message but failed to reconcile authservice :thonk:
- https://github.com/defenseunicorns/uds-core/actions/runs/12290831792/job/34298610444#step:11:292: doesn't look like pepr picked up prometheus
- https://github.com/defenseunicorns/uds-core/actions/runs/12308571271/job/34354169433?pr=1117#step:11:304: Failed to apply network policies ([this](https://github.com/defenseunicorns/uds-core/blob/6426c5aaf75bcb761b27ca415cf5736631a72f85/src/pepr/operator/controllers/network/policies.ts#L155) is where that error comes from)
- https://github.com/defenseunicorns/uds-core/actions/runs/12308571271/job/34354169733?pr=1117#step:11:360: more netpol failures + token failure

This PR bumps the cluster SKU from `Free` to `Standard` as there are inflight request [limits](https://learn.microsoft.com/en-us/azure/aks/quotas-skus-regions#:~:text=server/etcd%20instances.-,Free%20tier,-Limited%20resources%20with) for `Free` tier clusters. 
## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
N/A

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed