### PR TITLE
chore: update infra ci to run weekly and on release pr

### DIFF
--- a/.github/workflows/test-aks.yaml
+++ b/.github/workflows/test-aks.yaml
@@ -1,12 +1,13 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-name: AKS Nightly Test
+name: AKS Test
 
 on:
   schedule:
-    - cron: '0 6 * * *' # Runs at midnight Mountain every day
+    - cron: '0 0 * * 0' # Every Sunday Midnight (UTC) / Saturday 5pm MT
   pull_request:
+    types: [milestoned, opened, reopened, synchronize]
     paths:
       - tasks/iac.yaml
       - .github/bundles/aks/*

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -1,12 +1,13 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-name: EKS Nightly Test
+name: EKS Test
 
 on:
   schedule:
-    - cron: '0 6 * * *' # Runs at midnight Mountain every day
+    - cron: '0 0 * * 0' # Every Sunday Midnight (UTC) / Saturday 5pm MT
   pull_request:
+    types: [milestoned, opened, reopened, synchronize]
     paths:
       - tasks/iac.yaml
       - .github/bundles/eks/*

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -1,12 +1,13 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-name: RKE2 Nightly Test
+name: RKE2 Test
 
 on:
   schedule:
-    - cron: '0 6 * * *' # Runs at midnight Mountain every day
+    - cron: '0 0 * * 0' # Every Sunday Midnight (UTC) / Saturday 5pm MT
   pull_request:
+    types: [milestoned, opened, reopened, synchronize]
     paths:
       - tasks/iac.yaml
       - .github/bundles/rke2/*

--- a/tasks/iac.yaml
+++ b/tasks/iac.yaml
@@ -115,7 +115,7 @@ tasks:
 
           # wait for cluster components
           while true; do
-            if [ $(uds zarf tools kubectl get po -A --no-headers=true | egrep -v 'Running|Completed' | wc -l) -gt 0 ]; then
+            if [ $(uds zarf tools kubectl get po,job -A --no-headers=true | egrep -v 'Running|Complete' | wc -l) -gt 0 ]; then
               echo "Waiting for cluster components to be ready...";
               sleep 5;
             else


### PR DESCRIPTION
## Description

Switches nightly CI to weekly, but also adds `milestoned` trigger to run this CI pre-release. To date we have seen minimal issues with uds-core in these environments that have actually been caused by core issues. Reducing this CI to weekly + before release will still ensure that we can catch issues, but also optimize our time/cost.

I also added a modification to the cluster wait script to wait on jobs. Some of our recent CI has failed due to metallb not being installed completely yet (it is installed via a rancher `helmchart` CR, which creates a job). Example failure this should resolve: https://github.com/defenseunicorns/uds-core/actions/runs/12327456734/job/34409486515

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/1122

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed