### PR TITLE
chore: add action to check readiness on renovate PRs before running CI

### DIFF
--- a/.github/actions/renovate-readiness/action.yaml
+++ b/.github/actions/renovate-readiness/action.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+name: renovate-readiness
+description: "Check if Renovate PRs are ready for testing"
+
+runs:
+  using: composite
+  steps:
+    # This is current a stub for future logic that would auto-detect readiness
+    # In lieu of that, we require an engineer to review changes and manually add the `renovate-ready` label
+    - name: Check if PR has the ready label
+      if: ${{ ! contains(github.event.pull_request.labels.*.name, 'renovate-ready') }}
+      run: |
+        echo "This PR is not ready to run CI. Failing job."
+        exit 1
+      shell: bash

--- a/.github/workflows/checkpoint.yaml
+++ b/.github/workflows/checkpoint.yaml
@@ -6,7 +6,8 @@ name: Checkpoint UDS Core
 on:
   pull_request:
     # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
-    types: [milestoned, opened, reopened, synchronize]
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
     paths:
       - packages/checkpoint-dev/**
       - .github/workflows/checkpoint**
@@ -34,6 +35,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
 
       - name: Environment setup
         uses: ./.github/actions/setup

--- a/.github/workflows/docs-shim.yaml
+++ b/.github/workflows/docs-shim.yaml
@@ -5,7 +5,9 @@ name: CI Docs
 
 on:
   pull_request:
-    types: [milestoned, opened, reopened, synchronize]
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
     paths:
       - "**.md"
       - "**.jpg"
@@ -28,6 +30,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
+
       - name: lint-check
         uses: ./.github/actions/lint-check
 

--- a/.github/workflows/pull-request-conditionals.yaml
+++ b/.github/workflows/pull-request-conditionals.yaml
@@ -7,7 +7,8 @@ name: Filter
 on:
   pull_request:
     # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
-    types: [milestoned, opened, reopened, synchronize]
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
     paths-ignore:
       - "**.md"
       - "**.jpg"
@@ -61,6 +62,10 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
 
       # Uses a custom action to filter paths for source packages.
       - name: Check src paths

--- a/.github/workflows/slim-dev-test.yaml
+++ b/.github/workflows/slim-dev-test.yaml
@@ -7,7 +7,8 @@ name: Slim Dev
 on:
   pull_request:
     # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
-    types: [milestoned, opened, reopened, synchronize]
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
     paths:
       - src/pepr/**
       - src/keycloak/**
@@ -49,6 +50,9 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
       - name: Environment setup
         uses: ./.github/actions/setup
       - name: Deploy Slim Dev Bundle

--- a/.github/workflows/test-aks.yaml
+++ b/.github/workflows/test-aks.yaml
@@ -7,7 +7,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Every Sunday Midnight (UTC) / Saturday 5pm MT
   pull_request:
-    types: [milestoned, opened, reopened, synchronize]
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
     paths:
       - tasks/iac.yaml
       - .github/bundles/aks/*
@@ -47,6 +49,10 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
 
       - name: Azure login
         uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -7,7 +7,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Every Sunday Midnight (UTC) / Saturday 5pm MT
   pull_request:
-    types: [milestoned, opened, reopened, synchronize]
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
     paths:
       - tasks/iac.yaml
       - .github/bundles/eks/*
@@ -43,6 +45,10 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -7,7 +7,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Every Sunday Midnight (UTC) / Saturday 5pm MT
   pull_request:
-    types: [milestoned, opened, reopened, synchronize]
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    # labeled is added here to allow for "manual" triggering of CI on renovate PRs
+    types: [milestoned, opened, reopened, synchronize, labeled]
     paths:
       - tasks/iac.yaml
       - .github/bundles/rke2/*
@@ -43,6 +45,10 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4


### PR DESCRIPTION
## Description

Adds a new action that checks renovate PR readiness and fails CI before using the large runners if the PR is not ready. At this point the action just checks for a `renovate-ready` label, but this could be changed in the future to look for changes in the PR, etc.

## Related Issue

Related to https://github.com/defenseunicorns/uds-core/issues/168

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

This functionality was validated on [my fork](https://github.com/BagelLab/uds-core) due to some of the complexities around testing it on this repo. A demo/walkthrough can be provided by appointment.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed