### PR TITLE
docs: add note on minimum k3d version, update cli version reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ UDS Core establishes a secure baseline for cloud-native systems and ships with c
 ### Prerequisites
 
 - A running container environment for K3D to interact with for dev & test environments
-- [K3D](https://k3d.io/) for dev & test environments or any [CNCF Certified Kubernetes Cluster](https://www.cncf.io/training/certification/software-conformance/#logos) for production environments.
+- [K3D](https://k3d.io/) version 5.7.1 or higher for dev & test environments or any [CNCF Certified Kubernetes Cluster](https://www.cncf.io/training/certification/software-conformance/#logos) for production environments.
 <!-- renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver -->
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli?tab=readme-ov-file#install) v0.8.1 or later
 
@@ -48,7 +48,7 @@ While the UDS Bundles published by this repo can be used for dev and test enviro
 
 ### Quickstart, Dev & Test Environments
 
-UDS Core publishes bundles you can use for trying out UDS Core or for UDS Package development where you only need part of UDS Core. These bundles leverage [UDS K3d](https://github.com/defenseunicorns/uds-k3d) to create a local k3d cluster with tools installed to emulate a cloud environment. You must have `k3d` version 5.7.1 or higher to be able to deploy these bundles (check your version with `k3d version`).
+UDS Core publishes bundles you can use for trying out UDS Core or for UDS Package development where you only need part of UDS Core. These bundles leverage [UDS K3d](https://github.com/defenseunicorns/uds-k3d) to create a local k3d cluster with tools installed to emulate a cloud environment.
 
 > [!NOTE]
 > These UDS Bundles are intended for dev and test environments and should not be used for production. They also serve as examples to create custom bundles.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ UDS Core establishes a secure baseline for cloud-native systems and ships with c
 ### Prerequisites
 
 - A running container environment for K3D to interact with for dev & test environments
-- [K3D](https://k3d.io/) version 5.7.1 or higher for dev & test environments or any [CNCF Certified Kubernetes Cluster](https://www.cncf.io/training/certification/software-conformance/#logos) for production environments.
+- [K3D](https://k3d.io/) v5.7.1 or later for dev & test environments or any [CNCF Certified Kubernetes Cluster](https://www.cncf.io/training/certification/software-conformance/#logos) for production environments.
 <!-- renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver -->
-- [UDS CLI](https://github.com/defenseunicorns/uds-cli?tab=readme-ov-file#install) v0.8.1 or later
+- [UDS CLI](https://github.com/defenseunicorns/uds-cli?tab=readme-ov-file#install): v0.20.0 or later
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ While the UDS Bundles published by this repo can be used for dev and test enviro
 
 ### Quickstart, Dev & Test Environments
 
-UDS Core publishes bundles you can use for trying out UDS Core or for UDS Package development where you only need part of UDS Core. These bundles leverage [UDS K3d](https://github.com/defenseunicorns/uds-k3d) to create a local k3d cluster with tools installed to emulate a cloud environment.
+UDS Core publishes bundles you can use for trying out UDS Core or for UDS Package development where you only need part of UDS Core. These bundles leverage [UDS K3d](https://github.com/defenseunicorns/uds-k3d) to create a local k3d cluster with tools installed to emulate a cloud environment. You must have `k3d` version 5.7.1 or higher to be able to deploy these bundles (check your version with `k3d version`).
 
 > [!NOTE]
 > These UDS Bundles are intended for dev and test environments and should not be used for production. They also serve as examples to create custom bundles.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "changelog-sections": [
         { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug Fixes", "hidden": false },
-        { "type": "chore", "section": "Miscellaneous", "hidden": false }
+        { "type": "chore", "section": "Miscellaneous", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false }
       ],
       "bump-minor-pre-major": true,
       "versioning": "default",

--- a/renovate.json
+++ b/renovate.json
@@ -74,7 +74,7 @@
       "commitMessageTopic": "grafana"
     },
     {
-      "matchFileNames": ["test/**", ".github/**", "bundles/**", "tasks/*.yaml", ".vscode/settings.json", "src/test/**"],
+      "matchFileNames": ["test/**", ".github/**", "bundles/**", "tasks/*.yaml", ".vscode/settings.json", "src/test/**", "README.md"],
       "groupName": "support-deps",
       "commitMessageTopic": "support dependencies"
     },


### PR DESCRIPTION
## Description

3 Changes in this PR:
- Updates to note the required minimum k3d version for the dev/demo bundles based on user reports.
- Updates to the latest uds-cli version in the docs and fixes the renovate reference so that this will be auto-updated in the future (pending https://github.com/defenseunicorns/uds-common/pull/378).
- Adds a release-please section for documentation so that this PR (and others) can be represented in the releases properly.

## Related Issue

Related to https://github.com/defenseunicorns/uds-k3d/issues/139

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed