### PR TITLE
fix: remove unnecessary docker command in dev docs task

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -141,7 +141,6 @@ tasks:
       - description: "Cleanup previous runs"
         cmd: |
           rm -rf uds-docs
-          docker stop uds-docs &>/dev/null && docker rm uds-docs &>/dev/null || true
       - description: "Clone the docs repo and symlink the reference docs"
         cmd: |
           git clone https://github.com/defenseunicorns/uds-docs.git uds-docs


### PR DESCRIPTION
## Description

This was a lingering artifact from when I tried out running the dev docs in docker.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed