### PR TITLE
chore: ignore uds-docs on commit linting

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 # Lint Codespell configurations
 [codespell]
-skip = .codespellrc,.git,node_modules,build,dist,*.zst,CHANGELOG.md,.playwright,.terraform,*.svg,**/pepr/operator/crd/generated/*.ts
+skip = .codespellrc,.git,node_modules,build,dist,*.zst,CHANGELOG.md,.playwright,.terraform,*.svg,**/pepr/operator/crd/generated/*.ts,**/uds-docs/**
 ignore-words-list = NotIn,AKS,LICENS,aks,afterAll
 enable-colors =
 check-hidden =

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
     "node_modules",
     "dist",
     "jest.*.js",
-    "test/playwright/"
+    "test/playwright/",
+    "uds-docs/"
   ],
   "root": true,
   "rules": {


### PR DESCRIPTION
## Description
After running `uds run dev-docs` and then attempting to commit a new change eslint and codespell both fail. Adding uds-docs repo to ignore paths to fix this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- not on this branch, run `uds run dev-docs` and then run `uds run lint-check` and you'll see errors happen
- on this branch you can do the same and won't see those errors

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed