### PR TITLE
fix: Add Keycloak workaround for Kernels 6.12+

### DIFF
--- a/bundles/k3d-slim-dev/README.md
+++ b/bundles/k3d-slim-dev/README.md
@@ -45,15 +45,16 @@ The k3d uds-dev-stack provides:
 | `TENANT_SERVICE_PORTS` | The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic) | service.ports |
 
 ##### keycloak (keycloak)
-| Variable | Description | Path |
-|----------|-------------|------|
-| `INSECURE_ADMIN_PASSWORD_GENERATION` | Generate an insecure admin password for dev/test | `insecureAdminPasswordGeneration.enabled` |
-| `KEYCLOAK_HA`              | Enable Keycloak HA                         | `autoscaling.enabled`           |
-| `KEYCLOAK_PG_USERNAME`     | Keycloak Postgres username                 | `postgresql.username`           |
-| `KEYCLOAK_PG_PASSWORD`     | Keycloak Postgres password                 | `postgresql.password`           |
-| `KEYCLOAK_PG_DATABASE`     | Keycloak Postgres database                 | `postgresql.database`           |
-| `KEYCLOAK_PG_HOST`         | Keycloak Postgres host                     | `postgresql.host`               |
-| `KEYCLOAK_DEVMODE`         | Enables Keycloak dev mode                  | `devMode`                       |
+| Variable                             | Description                                                 | Path                                      |
+|--------------------------------------|-------------------------------------------------------------|-------------------------------------------|
+| `INSECURE_ADMIN_PASSWORD_GENERATION` | Generate an insecure admin password for dev/test            | `insecureAdminPasswordGeneration.enabled` |
+| `KEYCLOAK_HA`                        | Enable Keycloak HA                                          | `autoscaling.enabled`                     |
+| `KEYCLOAK_PG_USERNAME`               | Keycloak Postgres username                                  | `postgresql.username`                     |
+| `KEYCLOAK_PG_PASSWORD`               | Keycloak Postgres password                                  | `postgresql.password`                     |
+| `KEYCLOAK_PG_DATABASE`               | Keycloak Postgres database                                  | `postgresql.database`                     |
+| `KEYCLOAK_PG_HOST`                   | Keycloak Postgres host                                      | `postgresql.host`                         |
+| `KEYCLOAK_DEVMODE`                   | Enables Keycloak dev mode                                   | `devMode`                                 |
+| `KEYCLOAK_KERNEL_6_12_MODE`          | Enables Keycloak compatibility mode for Linux Kernels 6.12+ | `workarounds.kernel6_12`                  |
 
 
 ## Override Examples:

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -119,6 +119,9 @@ packages:
             - name: KEYCLOAK_DEVMODE
               description: "Enables Keycloak dev mode"
               path: devMode
+            - name: KEYCLOAK_KERNEL_6_12_MODE
+              description: "Enables Keycloak configuration suitable for Linux kernel 6.12 onwards. This setting is a temporary workaround is will be removed in the future."
+              path: workarounds.kernel6_12
           values:
             - path: realmInitEnv
               value:

--- a/bundles/k3d-standard/README.md
+++ b/bundles/k3d-standard/README.md
@@ -49,15 +49,16 @@ This bundle is used for demonstration, development, and testing of UDS Core. In 
 | `TENANT_SERVICE_PORTS` | The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic) | service.ports |
 
 ##### keycloak (keycloak)
-| Variable | Description | Path |
-|----------|-------------|------|
-| `INSECURE_ADMIN_PASSWORD_GENERATION` | Generate an insecure admin password for dev/test | `insecureAdminPasswordGeneration.enabled` |
-| `KEYCLOAK_HA`              | Enable Keycloak HA                         | `autoscaling.enabled`           |
-| `KEYCLOAK_PG_USERNAME`     | Keycloak Postgres username                 | `postgresql.username`           |
-| `KEYCLOAK_PG_PASSWORD`     | Keycloak Postgres password                 | `postgresql.password`           |
-| `KEYCLOAK_PG_DATABASE`     | Keycloak Postgres database                 | `postgresql.database`           |
-| `KEYCLOAK_PG_HOST`         | Keycloak Postgres host                     | `postgresql.host`               |
-| `KEYCLOAK_DEVMODE`         | Enables Keycloak dev mode                  | `devMode`                       |
+| Variable                             | Description                                                 | Path                                      |
+|--------------------------------------|-------------------------------------------------------------|-------------------------------------------|
+| `INSECURE_ADMIN_PASSWORD_GENERATION` | Generate an insecure admin password for dev/test            | `insecureAdminPasswordGeneration.enabled` |
+| `KEYCLOAK_HA`                        | Enable Keycloak HA                                          | `autoscaling.enabled`                     |
+| `KEYCLOAK_PG_USERNAME`               | Keycloak Postgres username                                  | `postgresql.username`                     |
+| `KEYCLOAK_PG_PASSWORD`               | Keycloak Postgres password                                  | `postgresql.password`                     |
+| `KEYCLOAK_PG_DATABASE`               | Keycloak Postgres database                                  | `postgresql.database`                     |
+| `KEYCLOAK_PG_HOST`                   | Keycloak Postgres host                                      | `postgresql.host`                         |
+| `KEYCLOAK_DEVMODE`                   | Enables Keycloak dev mode                                   | `devMode`                                 |
+| `KEYCLOAK_KERNEL_6_12_MODE`          | Enables Keycloak compatibility mode for Linux Kernels 6.12+ | `workarounds.kernel6_12`                  |
 
 ##### grafana (grafana)
 | Variable | Description | Path |

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -151,6 +151,9 @@ packages:
             - name: KEYCLOAK_DEVMODE
               description: "Enables Keycloak dev mode"
               path: devMode
+            - name: KEYCLOAK_KERNEL_6_12_MODE
+              description: "Enables Keycloak configuration suitable for Linux kernel 6.12 onwards. This setting is a temporary workaround is will be removed in the future."
+              path: workarounds.kernel6_12
           values:
             - path: realmInitEnv
               value:

--- a/docs/reference/configuration/resource-configuration-and-ha.md
+++ b/docs/reference/configuration/resource-configuration-and-ha.md
@@ -144,6 +144,8 @@ packages:
               path: postgresql.password
 ```
 
+When running Keycloak on new Kernels 6.12+, it is also necessary to specify the `KEYCLOAK_KERNEL_6_12_MODE` setting and set it `true`. This is a temporary workaround for [this](https://github.com/keycloak/keycloak/issues/36609) Keycloak issue. Once addressed, this setting will be removed.
+
 ### AuthService
 
 AuthService can be configured in a HA setup if an [external session store](https://docs.tetrate.io/istio-authservice/configuration/oidc#session-store-configuration) is provided (key value store like Redis/Valkey). For configuring an external session store you can set the `UDS_AUTHSERVICE_REDIS_URI` env when deploying or via your `uds-config.yaml`:

--- a/src/keycloak/chart/README.md
+++ b/src/keycloak/chart/README.md
@@ -44,3 +44,9 @@ We would have to truncate the chart's fullname to six characters because pods ge
 Using a StatefulSet allows us to truncate to 20 characters leaving room for up to 99 replicas, which is much better.
 Additionally, we get stable values for `jboss.node.name` which can be advantageous for cluster discovery.
 The headless service that governs the StatefulSet is used for DNS discovery via DNS_PING.
+
+## Workarounds
+
+### Kernel 6.12+
+
+When running Keycloak on new Kernels 6.12+, it is also necessary to specify the `KEYCLOAK_KERNEL_6_12_MODE` setting and set it `true`. This is a temporary workaround for [this](https://github.com/keycloak/keycloak/issues/36609) Keycloak issue. Once addressed, this setting will be removed.s

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -174,6 +174,10 @@ spec:
               value: "-Dcom.redhat.fips=true"
             {{- end }}
           {{- end }}
+          {{- if or .Values.workarounds.kernel6_12 }}
+            - name: JAVA_OPTS_KC_HEAP
+              value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
+          {{- end }}
           {{- if .Values.insecureAdminPasswordGeneration.enabled }}
             - name: KEYCLOAK_ADMIN
               valueFrom:

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -431,6 +431,14 @@
     },
     "updateStrategy": {
       "type": "string"
+    },
+    "workarounds": {
+      "type": "object",
+      "properties": {
+        "kernel6_12": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -273,3 +273,7 @@ autoscaling:
         - type: Pods
           value: 1
           periodSeconds: 300
+
+workarounds:
+    # Enables Keycloak configuration suitable for Linux kernel 6.12 onwards. This setting is a temporary workaround is will be removed in the future.
+    kernel6_12: false


### PR DESCRIPTION
## Description

This Pull Request changes the Keycloak memory settings when with `KEYCLOAK_KERNEL_6_12_MODE` setting.

## Related Issue

Fixes #1212

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Run this on a Linux Kernel 6.12+ with `KEYCLOAK_KERNEL_6_12_MODE` set to `true`. You should notice that Keycloak boots up properly in such a setup.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed