### PR TITLE
fix: add patch for adding nv enforcer readiness probe

### DIFF
--- a/src/pepr/patches/index.ts
+++ b/src/pepr/patches/index.ts
@@ -70,7 +70,7 @@ When(a.DaemonSet)
       const readinessProbe = {
         exec: { command: ["curl", "--no-progress-meter", "127.0.0.1:8500"] },
         initialDelaySeconds: 10,
-        periodSeconds: 5
+        periodSeconds: 5,
       };
       enforcerContainer.readinessProbe = readinessProbe;
     }

--- a/src/pepr/patches/index.ts
+++ b/src/pepr/patches/index.ts
@@ -64,4 +64,14 @@ When(a.DaemonSet)
       };
       enforcerContainer.livenessProbe = livenessProbe;
     }
+
+    if (enforcerContainer && enforcerContainer.readinessProbe === undefined) {
+      log.debug("Patching NeuVector Enforcer Daemonset to add readinessProbe");
+      const readinessProbe = {
+        exec: { command: ["curl", "--no-progress-meter", "127.0.0.1:8500"] },
+        initialDelaySeconds: 10,
+        periodSeconds: 5
+      };
+      enforcerContainer.readinessProbe = readinessProbe;
+    }
   });


### PR DESCRIPTION
## Description
addresses flakiness that has been seen during nv e2e tests

## Related Issue
No related issue, but addresses behavior that has been observed over time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
```bash
uds run -f tasks/test.yaml layer-dependencies --set FLAVOR=unicorn --set LAYER=runtime-security
uds run -f tasks/test.yaml single-layer --set FLAVOR=unicorn --set LAYER=runtime-security
```

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed