### PR TITLE
chore: switch registry1 ztunnel to proper source

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -39,8 +39,6 @@ packages:
     # x-release-please-start-version
     ref: 0.34.1
     # x-release-please-end
-    optionalComponents:
-      - istio-ambient
     overrides:
       pepr-uds-core:
         module:

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -39,6 +39,8 @@ packages:
     # x-release-please-start-version
     ref: 0.34.1
     # x-release-please-end
+    optionalComponents:
+      - istio-ambient
     overrides:
       pepr-uds-core:
         module:

--- a/docs/reference/UDS Core/prerequisites.md
+++ b/docs/reference/UDS Core/prerequisites.md
@@ -57,7 +57,7 @@ The UDS Operator will dynamically provision network policies to secure traffic b
 Istio requires a number of kernel modules to be loaded for full functionality. The below is a script that will ensure these modules are loaded and persisted across reboots (see also Istio's [upstream requirements list](https://istio.io/latest/docs/ops/deployment/platform-requirements/)). Ideally this script is used as part of an image build or cloud-init process on each node.
 
 ```console
-modules=("br_netfilter" "xt_REDIRECT" "xt_owner" "xt_statistic" "iptable_mangle" "iptable_nat" "xt_conntrack" "xt_tcpudp")
+modules=("br_netfilter" "xt_REDIRECT" "xt_owner" "xt_statistic" "iptable_mangle" "iptable_nat" "xt_conntrack" "xt_tcpudp" "xt_connmark" "xt_mark" "ip_set")
 for module in "${modules[@]}"; do
   modprobe "$module"
   echo "$module" >> "/etc/modules-load.d/istio-modules.conf"

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -70,6 +70,7 @@ components:
     charts:
       - name: cni
         valuesFiles:
+          # https://repo1.dso.mil/dsop/tetrate/istio/1.24/install-cni/-/issues/12
           # - "values/registry1/cni.yaml"
           - "values/upstream/cni.yaml"
       - name: ztunnel
@@ -77,6 +78,7 @@ components:
           - "values/registry1/ztunnel.yaml"
     images:
       - docker.io/istio/install-cni:1.24.2-distroless
+      # https://repo1.dso.mil/dsop/tetrate/istio/1.24/install-cni/-/issues/12
       # - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
       - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.24.2-tetratefips0
 

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -70,24 +70,13 @@ components:
     charts:
       - name: cni
         valuesFiles:
-          # Update once Registry1 has working cni image
-          #- "values/registry1/cni.yaml"
-          - "values/upstream/cni.yaml"
+          - "values/registry1/cni.yaml"
       - name: ztunnel
         valuesFiles:
-          # Update once Registry1 has working ztunnel image
-          #- "values/registry1/ztunnel.yaml"
-          - "values/upstream/ztunnel.yaml"
+          - "values/registry1/ztunnel.yaml"
     images:
-      # https://github.com/defenseunicorns/uds-core/issues/1225
-      # Registry1 ztunnel image is not working right now
-      # https://repo1.dso.mil/dsop/tetrate/istio/1.24/ztunnel/-/issues/9
-      #- registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.24.2-tetratefips0
-      - docker.io/istio/ztunnel:1.24.2-distroless
-      # Registry1s install-cni-fips is not working right now
-      # https://repo1.dso.mil/dsop/tetrate/istio/1.24/install-cni/-/issues/11
-      #- registry1.dso.mil/ironbank/opensource/istio/install-cni:1.24.2
-      - docker.io/istio/install-cni:1.24.2-distroless
+      - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.24.2-tetratefips0
+      - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
 
   - name: istio-controlplane
     required: true

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -70,13 +70,15 @@ components:
     charts:
       - name: cni
         valuesFiles:
-          - "values/registry1/cni.yaml"
+          # - "values/registry1/cni.yaml"
+          - "values/upstream/cni.yaml"
       - name: ztunnel
         valuesFiles:
           - "values/registry1/ztunnel.yaml"
     images:
+      - docker.io/istio/install-cni:1.24.2-distroless
+      # - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
       - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.24.2-tetratefips0
-      - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
 
   - name: istio-controlplane
     required: true


### PR DESCRIPTION
## Description

Switches the registry1 flavored ztunnel image to the registry1 source. Note that there is still an issue with the install-cni image that has been reported upstream.

Also updated docs to note additional modules from the upstream docs - https://istio.io/latest/docs/ops/deployment/platform-requirements/

## Related Issue

Related to https://github.com/defenseunicorns/uds-core/issues/1225

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

N/A, could test deploy with the istio-ambient component enabled.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed