### PR TITLE
chore: switch to registry1 cni image

### DIFF
--- a/.github/workflows/slim-dev-test.yaml
+++ b/.github/workflows/slim-dev-test.yaml
@@ -55,6 +55,11 @@ jobs:
         uses: ./.github/actions/renovate-readiness
       - name: Environment setup
         uses: ./.github/actions/setup
+        with:
+          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
+          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
+          ghToken: ${{ secrets.GITHUB_TOKEN }}
+          chainguardIdentity: ${{ secrets.CHAINGUARD_IDENTITY }}
       - name: Deploy Slim Dev Bundle
         # Temp: test the registry1 flavor
         run: uds run slim-dev --set flavor=registry1 --no-progress

--- a/.github/workflows/slim-dev-test.yaml
+++ b/.github/workflows/slim-dev-test.yaml
@@ -61,8 +61,7 @@ jobs:
           ghToken: ${{ secrets.GITHUB_TOKEN }}
           chainguardIdentity: ${{ secrets.CHAINGUARD_IDENTITY }}
       - name: Deploy Slim Dev Bundle
-        # Temp: test the registry1 flavor
-        run: uds run slim-dev --set flavor=registry1 --no-progress
+        run: uds run slim-dev --no-progress
       - name: Test Slim Dev Bundle
         run: uds run test:slim-dev --no-progress
       - name: Debug Output

--- a/.github/workflows/slim-dev-test.yaml
+++ b/.github/workflows/slim-dev-test.yaml
@@ -56,7 +56,8 @@ jobs:
       - name: Environment setup
         uses: ./.github/actions/setup
       - name: Deploy Slim Dev Bundle
-        run: uds run slim-dev --no-progress
+        # Temp: test the registry1 flavor
+        run: uds run slim-dev --set flavor=registry1 --no-progress
       - name: Test Slim Dev Bundle
         run: uds run test:slim-dev --no-progress
       - name: Debug Output

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -39,6 +39,8 @@ packages:
     # x-release-please-start-version
     ref: 0.35.0
     # x-release-please-end
+    optionalComponents:
+      - istio-ambient
     overrides:
       pepr-uds-core:
         module:

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -39,8 +39,6 @@ packages:
     # x-release-please-start-version
     ref: 0.35.0
     # x-release-please-end
-    optionalComponents:
-      - istio-ambient
     overrides:
       pepr-uds-core:
         module:

--- a/src/istio/values/registry1/cni.yaml
+++ b/src/istio/values/registry1/cni.yaml
@@ -3,7 +3,3 @@
 
 cni:
   image: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
-
-# For testing registry1 image
-logging:
-  level: "debug"

--- a/src/istio/values/registry1/cni.yaml
+++ b/src/istio/values/registry1/cni.yaml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 cni:
-  image: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
+  image: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips0

--- a/src/istio/values/registry1/cni.yaml
+++ b/src/istio/values/registry1/cni.yaml
@@ -3,3 +3,7 @@
 
 cni:
   image: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
+
+# For testing registry1 image
+logging:
+  level: "debug"

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -70,15 +70,11 @@ components:
     charts:
       - name: cni
         valuesFiles:
-          # https://repo1.dso.mil/dsop/tetrate/istio/1.24/install-cni/-/issues/12
           - "values/registry1/cni.yaml"
-          # - "values/upstream/cni.yaml"
       - name: ztunnel
         valuesFiles:
           - "values/registry1/ztunnel.yaml"
     images:
-      # - docker.io/istio/install-cni:1.24.2-distroless
-      # https://repo1.dso.mil/dsop/tetrate/istio/1.24/install-cni/-/issues/12
       - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
       - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.24.2-tetratefips0
 

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -75,7 +75,7 @@ components:
         valuesFiles:
           - "values/registry1/ztunnel.yaml"
     images:
-      - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
+      - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips0
       - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.24.2-tetratefips0
 
   - name: istio-controlplane

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -71,15 +71,15 @@ components:
       - name: cni
         valuesFiles:
           # https://repo1.dso.mil/dsop/tetrate/istio/1.24/install-cni/-/issues/12
-          # - "values/registry1/cni.yaml"
-          - "values/upstream/cni.yaml"
+          - "values/registry1/cni.yaml"
+          # - "values/upstream/cni.yaml"
       - name: ztunnel
         valuesFiles:
           - "values/registry1/ztunnel.yaml"
     images:
-      - docker.io/istio/install-cni:1.24.2-distroless
+      # - docker.io/istio/install-cni:1.24.2-distroless
       # https://repo1.dso.mil/dsop/tetrate/istio/1.24/install-cni/-/issues/12
-      # - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
+      - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.24.2-tetratefips-v0
       - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.24.2-tetratefips0
 
   - name: istio-controlplane


### PR DESCRIPTION
## Description

Switches to the registry1 sourced CNI image.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/1225

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Deploy registry1 flavor of the demo bundle and validate that the cni pod comes up healthy.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed