### PR TITLE
chore(deps): remove Keycloak architectures

### DIFF
--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -33,8 +33,6 @@ components:
     required: true
     only:
       flavor: registry1
-      cluster:
-        architecture: amd64
     import:
       path: common
     charts:


### PR DESCRIPTION
## Description

The new IronBank image contains both `arm64` and `amd64` architectures (see
[here](https://registry1.dso.mil/harbor/projects/3/repositories/opensource%2Fkeycloak%2Fkeycloak/artifacts-tab/depth/sha256:a548b81a3d12b5c8c0e4f1486d775b7d8a679df85fd7f8a375dbfae83f5714c6)). Based on previous comments, it is safe to remove unnecesary architectures tag

## Related Issue

Fixes #1257

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Check if all automated tests pass

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed
