### PR TITLE
feat: introduced a new option CREATE_OPTIONS and skip SBOMs in tests

### DIFF
--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -22,7 +22,7 @@ tasks:
     description: Test app used for UDS Core validation
     actions:
       - description: Create zarf package for the test resources
-        cmd: "uds zarf package create src/test --confirm --no-progress"
+        cmd: "uds zarf package create src/test --confirm --no-progress --skip-sbom"
 
       - description: Deploy the test resources
         cmd: "uds zarf package deploy build/zarf-package-uds-core-test-apps-*.zst --confirm --no-progress"

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -15,11 +15,16 @@ variables:
 
   - name: LAYER
 
+  - name: CREATE_OPTIONS
+    description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
+    default: ""
+
 tasks:
   - name: standard-package
     description: "Create the UDS Core Zarf Package"
     inputs:
       create_options:
+        default: ${CREATE_OPTIONS}
         description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
     actions:
       - task: single-layer
@@ -57,7 +62,7 @@ tasks:
         with:
           path: packages/checkpoint-dev
           config: ./zarf-config.yaml
-          options: "--skip-sbom"
+          options: "${CREATE_OPTIONS} --skip-sbom"
           architecture: ${ZARF_ARCHITECTURE}
 
   # This task is a wrapper to support --set LAYER=identity-authorization
@@ -73,6 +78,7 @@ tasks:
         default: base
         description: The UDS Core layer to build
       create_options:
+        default: ${CREATE_OPTIONS}
         description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
     actions:
       - task: pepr-build

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -15,14 +15,22 @@ variables:
 
   - name: LAYER
 
+  - name: CREATE_OPTIONS
+    description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
+    default: ""
+
 tasks:
   - name: standard-package
     description: "Create the UDS Core Zarf Package"
+    inputs:
+      create_options:
+        default: ${CREATE_OPTIONS}
+        description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
     actions:
-      - task: pepr-build
-
-      - description: "Create the UDS Core Standard Zarf Package"
-        cmd: "uds zarf package create packages/standard --confirm --no-progress --flavor ${FLAVOR}"
+      - task: single-layer
+        with:
+          layer: standard
+          create_options: ${{ .inputs.create_options }}
 
   - name: k3d-standard-bundle
     description: "Create the K3d-UDS Core Bundle"
@@ -50,7 +58,12 @@ tasks:
     description: "Create the K3d + UDS Core Checkpoint Zarf Package"
     actions:
       - description: "Create the UDS Core Checkpoint Zarf Package"
-        cmd: "uds zarf package create packages/checkpoint-dev --confirm --no-progress --skip-sbom"
+        task: common:package
+        with:
+          path: packages/checkpoint-dev
+          config: ./zarf-config.yaml
+          options: "${CREATE_OPTIONS} --skip-sbom"
+          architecture: ${ZARF_ARCHITECTURE}
 
   # This task is a wrapper to support --set LAYER=identity-authorization
   - name: single-layer-callable
@@ -64,10 +77,19 @@ tasks:
       layer:
         default: base
         description: The UDS Core layer to build
+      create_options:
+        default: ${CREATE_OPTIONS}
+        description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
     actions:
       - task: pepr-build
-        if: ${{ eq .inputs.layer "base"}}
-      - cmd: uds zarf package create packages/${{ index .inputs "layer" }} --confirm --no-progress --flavor ${FLAVOR}
+        if: ${{ eq .inputs.layer "base" or eq .inputs.layer "standard" }}
+      - description: "Create the UDS Core Zarf Package"
+        task: common:package
+        with:
+          path: packages/${{ index .inputs "layer" }}
+          config: ./zarf-config.yaml
+          options: ${{ .inputs.create_options }}
+          architecture: ${ZARF_ARCHITECTURE}
 
   - name: pepr-build
     description: "Build the UDS Core Pepr Module"

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -15,16 +15,11 @@ variables:
 
   - name: LAYER
 
-  - name: CREATE_OPTIONS
-    description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
-    default: ""
-
 tasks:
   - name: standard-package
     description: "Create the UDS Core Zarf Package"
     inputs:
       create_options:
-        default: ${CREATE_OPTIONS}
         description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
     actions:
       - task: single-layer
@@ -62,7 +57,7 @@ tasks:
         with:
           path: packages/checkpoint-dev
           config: ./zarf-config.yaml
-          options: "${CREATE_OPTIONS} --skip-sbom"
+          options: "--skip-sbom"
           architecture: ${ZARF_ARCHITECTURE}
 
   # This task is a wrapper to support --set LAYER=identity-authorization
@@ -78,7 +73,6 @@ tasks:
         default: base
         description: The UDS Core layer to build
       create_options:
-        default: ${CREATE_OPTIONS}
         description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
     actions:
       - task: pepr-build

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -5,6 +5,8 @@
 includes:
   - utils: utils.yaml
   - test: test.yaml
+  - create: create.yaml
+  - deploy: deploy.yaml
   - setup: setup.yaml
 
 variables:
@@ -72,7 +74,15 @@ tasks:
     description: "Test and Publish UDS Core layer"
     actions:
       - task: test:layer-dependencies
-      - task: test:single-layer
+      - task: create:single-layer
+        with:
+          layer: ${LAYER}
+      - task: deploy:single-layer
+        with:
+          layer: ${LAYER}
+      - task: test:validate-package
+        with:
+          layer: ${LAYER}
       - task: utils:determine-repo
       - description: "Publish build of layer"
         cmd: uds zarf package publish build/zarf-package-core-${LAYER}-${UDS_ARCH}-${VERSION}.tar.zst oci://${TARGET_REPO}

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -26,6 +26,7 @@ tasks:
       - task: create:single-layer
         with:
           layer: ${LAYER}
+          create_options: "--skip-sbom"
       - task: deploy:single-layer
         with:
           layer: ${LAYER}
@@ -86,6 +87,8 @@ tasks:
     description: "Build and test UDS Core"
     actions:
       - task: create:standard-package
+        with:
+          create_options: "--skip-sbom"
       - task: create:k3d-standard-bundle
       - task: deploy:k3d-standard-bundle
       - task: validate-packages
@@ -100,6 +103,8 @@ tasks:
     description: "Build and test UDS Core"
     actions:
       - task: create:standard-package
+        with:
+          create_options: "--skip-sbom"
       - task: create:k3d-standard-bundle
       - task: deploy:k3d-standard-bundle-ha
       - task: validate-packages
@@ -110,6 +115,8 @@ tasks:
       - task: setup:k3d-test-cluster
       - task: deploy:latest-package-release
       - task: create:standard-package
+        with:
+          create_options: "--skip-sbom"
       - task: deploy:standard-package
       - task: validate-packages
       - task: e2e-tests

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -22,16 +22,21 @@ tasks:
 
   - name: single-layer
     description: "Build and test a single layer, must set UDS_LAYER environment variable"
+    inputs:
+      create_options:
+        default: "--skip-sbom"
+        description: "Additional options passed in when creating Zarf packages. Defaults to: --skip-sbom"
     actions:
       - task: create:single-layer
         with:
           layer: ${LAYER}
-          create_options: "--skip-sbom"
+          create_options: ${{ .inputs.create_options }}
       - task: deploy:single-layer
         with:
           layer: ${LAYER}
-      - description: "Validate the package"
-        cmd: uds run -f packages/${LAYER}/tasks.yaml validate --no-progress
+      - task: validate-package
+        with:
+          layer: ${LAYER}
 
   - name: layer-dependencies
     description: "Sets up a k3d cluster and deploys dependencies for the given layer"
@@ -55,6 +60,16 @@ tasks:
             uds run -f ${package}/tasks.yaml validate --no-progress
           done
           set +e
+
+  - name: validate-package
+    description: "Validate a single package"
+    inputs:
+      layer:
+        description: The UDS Core layer to validate
+        required: true
+    actions:
+      - cmd: |
+          uds run -f packages/${{ index .inputs "layer" }}/tasks.yaml validate --no-progress
 
   - name: e2e-tests
     description: "E2E Test all packages"


### PR DESCRIPTION
## Description

This Pull Request introduces a new option `CREATE_OPTIONS` that being passed
into the `create:single-layer` task. This option can be used to pass for
example `--skip-sbom` command and speed up development process. Here's an
example:

```bash
uds run create:standard-package --log-level debug --set CREATE_OPTIONS="--skip-sbom"
```

Skipping SBOMs has also been added to all tests and dependent tasks. In other
words - in all places where we are certain that we won't need them.

## Related Issue

Fixes #1168

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Comparing CI results from a Unicorn flavor from this Pull Request and a baseline, we shortened the CI tests from 22m 11s  to 17m 56s. That's roughly 4 mins per each job.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed
