### PR TITLE
feat(k3d-slim-dev): add Istio Proxy resource configuration

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -1,6 +1,7 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/refs/heads/main/uds.schema.json
 kind: UDSBundle
 metadata:
   name: k3d-core-slim-dev
@@ -59,6 +60,25 @@ packages:
               description: "CPU requests for the pepr admission pods"
               path: "admission.resources.requests.cpu"
               default: "100m"
+      istio-controlplane:
+        istiod:
+          variables:
+            - name: PROXY_MEMORY_REQUEST
+              description: "Memory request for the Istio Proxy Sidecar"
+              path: "global.proxy.resources.requests.memory"
+              default: "40Mi"
+            - name: PROXY_MEMORY_LIMIT
+              description: "Memory limit for the Istio Proxy Sidecar"
+              path: "global.proxy.resources.limits.memory"
+              default: "1024Mi"
+            - name: PROXY_CPU_REQUEST
+              description: "CPU request for the Istio Proxy Sidecar"
+              path: "global.proxy.resources.requests.cpu"
+              default: "10m"
+            - name: PROXY_CPU_LIMIT
+              description: "CPU limit for the Istio Proxy Sidecar"
+              path: "global.proxy.resources.limits.cpu"
+              default: "2000m"
       istio-admin-gateway:
         uds-istio-config:
           variables:


### PR DESCRIPTION
## Description
Added variables for configuring memory and CPU resources for the Istio Proxy Sidecar in the k3d-slim-dev UDS bundle. This includes memory and CPU requests and limits, enabling fine-grained resource management for Istio components.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed