### PR TITLE
fix: lint errors on unused caught errors

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2025 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+module.exports = {
+    '*': 'codespell',
+    '*.ts': (stagedFiles) => [
+        'npx pepr format --validate-only'
+    ]
+}

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,8 +1,0 @@
-{
-    "*": [
-        "codespell"
-    ],
-    "*.ts": [
-        "npx pepr format --validate-only"
-    ]
-}

--- a/src/pepr/operator/controllers/config/config.ts
+++ b/src/pepr/operator/controllers/config/config.ts
@@ -54,9 +54,9 @@ export async function updateUDSConfig(config: kind.Secret) {
     if (UDSConfig.caCert) {
       try {
         atob(UDSConfig.caCert);
-      } catch (e) {
+      } catch {
         log.error(
-          "Invalid CA Cert provided in uds-operator-config secret, falling back to no CA Cert",
+          "Invalid CA Cert provided in uds-operator-config secret, CA Cert value must be base64 encoded. Falling back to no CA Cert.",
         );
         UDSConfig.caCert = "";
       }

--- a/src/pepr/operator/controllers/keycloak/authservice/config.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/config.ts
@@ -58,7 +58,7 @@ export async function setupAuthserviceSecret() {
         .InNamespace(operatorConfig.namespace)
         .Get(operatorConfig.secretName);
       log.info(`Authservice Secret exists, skipping creation - ${secret.metadata?.name}`);
-    } catch (e) {
+    } catch {
       log.info("Secret does not exist, creating authservice secret");
       try {
         // Build and create the initial secret configuration

--- a/src/pepr/operator/controllers/keycloak/client-sync.ts
+++ b/src/pepr/operator/controllers/keycloak/client-sync.ts
@@ -176,7 +176,7 @@ async function syncClient(
     await retryWithDelay(async function setStoreToken() {
       return Store.setItemAndWait(name, client.registrationAccessToken!);
     }, log);
-  } catch (err) {
+  } catch {
     throw Error(
       `Failed to set token in store for client '${client.clientId}', package ` +
         `${pkg.metadata?.namespace}/${pkg.metadata?.name}`,


### PR DESCRIPTION
## Description

Resolves some errors that show in pepr format due to unused errors that we catch. In each case we don't have a need to use the error so I just dropped the variable.

This also resolves an issue with the latest format command where it would error on staged ts files. By moving to the `cjs` format of the lint config we can specify how to use the list of files (and in our case just not use them).

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

May be worth validating the new lint config by committing misspellings and poorly formatted files.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed