### PR TITLE
chore(deps): update uds-identity-config image

### DIFF
--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.9.1
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.10.0
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"

--- a/src/keycloak/tasks.yaml
+++ b/src/keycloak/tasks.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
-  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.9.1/tasks.yaml
+  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.10.0/tasks.yaml
 
 tasks:
   - name: validate

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -27,7 +27,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.1.1
-      - ghcr.io/defenseunicorns/uds/identity-config:0.9.1
+      - ghcr.io/defenseunicorns/uds/identity-config:0.10.0
 
   - name: keycloak
     required: true
@@ -41,7 +41,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:26.1.1
-      - ghcr.io/defenseunicorns/uds/identity-config:0.9.1
+      - ghcr.io/defenseunicorns/uds/identity-config:0.10.0
 
   - name: keycloak
     required: true
@@ -55,4 +55,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - cgr.dev/du-uds-defenseunicorns/keycloak:26.1.1 # todo: switch to FIPS image
-      - ghcr.io/defenseunicorns/uds/identity-config:0.9.1
+      - ghcr.io/defenseunicorns/uds/identity-config:0.10.0


### PR DESCRIPTION
## Description

Update identity-config image, currently this is captured inside of the keycloak renovate PR which is not ready to be merged.

Upgrade documentation: https://uds.defenseunicorns.com/reference/uds-core/idam/upgrading-versions/#v091-to-v0100

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed