### PR TITLE
feat(k3d-slim-dev): add resource configuration for Istiod and Keycloak

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -141,7 +141,7 @@ packages:
             - name: KEYCLOAK_CPU_LIMIT
               description: "CPU limit for the Keycloak pod"
               path: "resources.limits.cpu"
-              default: "1"
+              default: "1000m"
             - name: INSECURE_ADMIN_PASSWORD_GENERATION
               description: "Generate an insecure admin password for dev/test"
               path: insecureAdminPasswordGeneration.enabled

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -63,6 +63,14 @@ packages:
       istio-controlplane:
         istiod:
           variables:
+            - name: ISTIOD_MEMORY_REQUEST
+              description: "Memory request for Istiod"
+              path: "resources.requests.memory"
+              default: "1024Mi"
+            - name: ISTIOD_CPU_REQUEST
+              description: "CPU request for Istiod"
+              path: "resources.requests.cpu"
+              default: "100m"
             - name: PROXY_MEMORY_REQUEST
               description: "Memory request for the Istio Proxy Sidecar"
               path: "global.proxy.resources.requests.memory"
@@ -118,6 +126,22 @@ packages:
       keycloak:
         keycloak:
           variables:
+            - name: KEYCLOAK_MEMORY_REQUEST
+              description: "Memory request for the Keycloak pod"
+              path: "resources.requests.memory"
+              default: "512Mi"
+            - name: KEYCLOAK_CPU_REQUEST
+              description: "CPU request for the Keycloak pod"
+              path: "resources.requests.cpu"
+              default: "100m"
+            - name: KEYCLOAK_MEMORY_LIMIT
+              description: "Memory limit for the Keycloak pod"
+              path: "resources.limits.memory"
+              default: "1Gi"
+            - name: KEYCLOAK_CPU_LIMIT
+              description: "CPU limit for the Keycloak pod"
+              path: "resources.limits.cpu"
+              default: "1"
             - name: INSECURE_ADMIN_PASSWORD_GENERATION
               description: "Generate an insecure admin password for dev/test"
               path: insecureAdminPasswordGeneration.enabled


### PR DESCRIPTION
## Description

Added memory and CPU request/limit variables for Istiod and Keycloak in the uds-bundle.yaml. This enhances flexibility in resource allocation, allowing customization of resource usage for these components.

The istio chart doesn't seem to expose configurable limits for istiod, just requests.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed