### PR TITLE
fix: image name parsing for cve scan

### DIFF
--- a/tasks/scan.yaml
+++ b/tasks/scan.yaml
@@ -108,7 +108,7 @@ tasks:
             # Extract image name and format properly
             image_name=$(basename "$scan" .md)
             image_name=${image_name//_/\/}    # Replace all `_` with `/`
-            image_name=${image_name/%\//:}    # Replace the LAST `/` with `:`
+            image_name=${image_name%/*}:${image_name##*/}  # Replace last `/` with `:`
 
             # Check if the scan file contains any vulnerabilities (ignoring headers)
             vuln_count=$(tail -n +3 "$scan")


### PR DESCRIPTION
## Description

Noticed in the [CVE dashboard issue](https://www.github.com/defenseunicorns/uds-core/issues/1283) that the tag was not getting properly separated by a `:`. This fixes the text parsing.

## Related Issue

Related to https://www.github.com/defenseunicorns/uds-core/issues/1283

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Can run a scan locally with `uds run -f tasks/scan.yaml --set PACKAGE=core --set MIN_SEVERITY=High --set SNAPSHOT=true --set VERSION=latest --set FLAVOR=unicorn` (scans the latest snapshot) to validate that images are properly separated with tag `:`.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed