### PR TITLE
fix: checkpoint package creation

### DIFF
--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -62,12 +62,7 @@ tasks:
     description: "Create the K3d + UDS Core Checkpoint Zarf Package"
     actions:
       - description: "Create the UDS Core Checkpoint Zarf Package"
-        task: common:package
-        with:
-          path: packages/checkpoint-dev
-          config: ./zarf-config.yaml
-          options: "${CREATE_OPTIONS} --skip-sbom"
-          architecture: ${ZARF_ARCHITECTURE}
+        cmd: "uds zarf package create packages/checkpoint-dev --confirm --no-progress --skip-sbom"
 
   # This task is a wrapper to support --set LAYER=identity-authorization
   - name: single-layer-callable


### PR DESCRIPTION
## Description

Checkpoint dev package is publishing with the flavor ( which doesnt exist so it defaults to upstream ) appended to the end of the image name. Fixing this so that there is no flavor appended.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed