### PR TITLE
fix: workaround for Keycloak and Mac M4 issue

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -173,9 +173,10 @@ packages:
                 GOOGLE_IDP_CORE_ENTITY_ID: "https://sso.uds.dev/realms/uds"
                 GOOGLE_IDP_ADMIN_GROUP: "uds-core-dev-admin"
                 GOOGLE_IDP_AUDITOR_GROUP: "uds-core-dev-auditor"
-            # This is a workaround for Keycloak and Kernel 6.12+ memory issue. It will be removed once
-            # https://github.com/defenseunicorns/uds-core/issues/1212 is sorted
+            # This is a workaround for Keycloak and Kernel 6.12+ memory issue (https://github.com/defenseunicorns/uds-core/issues/1212)
+            # and Mac M4 issue (https://github.com/defenseunicorns/uds-core/issues/1309). It will be removed once
+            # both issues are sorted (est. mid-April 2025).
             - path: env
               value:
                 - name: JAVA_OPTS_KC_HEAP
-                  value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
+                  value: "-XX:UseSVE=0 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -162,12 +162,13 @@ packages:
                 GOOGLE_IDP_CORE_ENTITY_ID: "https://sso.uds.dev/realms/uds"
                 GOOGLE_IDP_ADMIN_GROUP: "uds-core-dev-admin"
                 GOOGLE_IDP_AUDITOR_GROUP: "uds-core-dev-auditor"
-            # This is a workaround for Keycloak and Kernel 6.12+ memory issue. It will be removed once
-            # https://github.com/defenseunicorns/uds-core/issues/1212 is sorted
+            # This is a workaround for Keycloak and Kernel 6.12+ memory issue (https://github.com/defenseunicorns/uds-core/issues/1212)
+            # and Mac M4 issue (https://github.com/defenseunicorns/uds-core/issues/1309). It will be removed once
+            # both issues are sorted (est. mid-April 2025).
             - path: env
               value:
                 - name: JAVA_OPTS_KC_HEAP
-                  value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
+                  value: "-XX:UseSVE=0 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
       grafana:
         grafana:
           variables:


### PR DESCRIPTION
## Description

This ticket passes `-XX:UseSVE=0` to the Java settings and acts as a  workaround for running Keycloak on M4 Macs

JVM tracking issue: https://bugs.openjdk.org/browse/JDK-8345296
Keycloak tracking issue: https://github.com/keycloak/keycloak/issues/36008

This issue will be solved in JVM 21.0.7 and will go away once Keycloak picks it
up. According to the schedule this should happen mid-April 2025.

## Related Issue

Fixes #1309

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

The only way to validate this issue is to run UDS Core against M4 Mac.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed
