### PR TITLE
chore: enable ambient component for rke2/aks ci

### DIFF
--- a/.github/bundles/aks/uds-bundle.yaml
+++ b/.github/bundles/aks/uds-bundle.yaml
@@ -19,9 +19,8 @@ packages:
     # x-release-please-start-version
     ref: 0.36.2
     # x-release-please-end
-    # https://github.com/defenseunicorns/uds-core/issues/1222
-    # optionalComponents:
-    #   - istio-ambient
+    optionalComponents:
+      - istio-ambient
     overrides:
       istio-admin-gateway:
         gateway:

--- a/.github/bundles/rke2/uds-bundle.yaml
+++ b/.github/bundles/rke2/uds-bundle.yaml
@@ -41,8 +41,7 @@ packages:
     ref: 0.36.2
     # x-release-please-end
     optionalComponents:
-      # https://github.com/defenseunicorns/uds-core/issues/1222
-      # - istio-ambient
+      - istio-ambient
       - metrics-server
     overrides:
       velero:

--- a/docs/reference/UDS Core/prerequisites.md
+++ b/docs/reference/UDS Core/prerequisites.md
@@ -101,6 +101,8 @@ or via `--set` if deploying the package via `zarf`:
 uds zarf package deploy uds-core --set CNI_CONF_DIR=/etc/cni/net.d --set CNI_BIN_DIR=/opt/cni/bin
 ```
 
+If you are using Cilium you will also need to make some additional configuration changes and add a cluster wide network policy to prevent Cilium's CNI from interfering with the Istio CNI plugin (part of the ambient stack). See the [upstream documentation](https://istio.io/latest/docs/ambient/install/platform-prerequisites/#cilium) for these required changes.
+
 #### NeuVector
 
 NeuVector historically has functioned best when the host is using cgroup v2. Cgroup v2 is enabled by default on many modern Linux distributions, but you may need to enable it depending on your operating system. Enabling this tends to be OS specific, so you will need to evaluate this for your specific hosts.

--- a/src/istio/ambient/chart/templates/exemptions.yaml
+++ b/src/istio/ambient/chart/templates/exemptions.yaml
@@ -15,6 +15,7 @@ spec:
        - RestrictCapabilities # CNI plugin requires NET_ADMIN, NET_RAW, SYS_PTRACE, SYS_ADMIN, and DAC_OVERRIDE capabilities
        - RestrictHostPathWrite # CNI plugin requires access to write to CNI
        - RestrictHostPorts # CNI plugin requires access to host ports
+       - RestrictSELinuxType # CNI plugin requires spc_t SELinux type when running in SELinux-enforcing environments
      matcher:
        namespace: istio-system
        kind: pod
@@ -27,6 +28,7 @@ spec:
        - RestrictVolumeTypes # ztunnel uses 'hostPath' volume type
        - RestrictCapabilities # ztunnel requires NET_ADMIN, NET_RAW, and SYS_ADMIN capabilities
        - RestrictHostPathWrite # ztunnel requires access to write to CNI
+       - RestrictSELinuxType # ztunnel requires spc_t SELinux type when running in SELinux-enforcing environments
      matcher:
        namespace: istio-system
        kind: pod

--- a/src/istio/ambient/zarf.yaml
+++ b/src/istio/ambient/zarf.yaml
@@ -32,6 +32,8 @@ components:
         url: https://istio-release.storage.googleapis.com/charts
         version: 1.24.3
         namespace: istio-system
+        valuesFiles:
+          - "../values/base-ztunnel.yaml"
     actions:
       onDeploy:
         before:

--- a/src/istio/values/base-ztunnel.yaml
+++ b/src/istio/values/base-ztunnel.yaml
@@ -1,11 +1,6 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-profile: ambient
-
-cniConfDir: ###ZARF_VAR_CNI_CONF_DIR###
-cniBinDir: ###ZARF_VAR_CNI_BIN_DIR###
-
 # SELinux enforcing environments require the spc_t SELinux type
 seLinuxOptions:
   type: spc_t


### PR DESCRIPTION
## Description

Enables the istio-ambient component for AKS and RKE2. The main issue was RKE2 is using an SELinux enforcing host, to run properly we had to add SELinux Options to the cni and ztunnel pods. These don't appear to have any effect on non-enforcing hosts (may affect/help with audit log) so we should be safe adding these by default.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/1222

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Success can be validated in the CI output, these components install as expected.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed