### PR TITLE
chore(ci): swap to new aws account for rke/eks tests

### DIFF
--- a/.github/test-infra/aws/rke2/data.tf
+++ b/.github/test-infra/aws/rke2/data.tf
@@ -21,5 +21,6 @@ data "aws_subnet" "rke2_ci_subnet" {
 data "aws_ami" "rhel_rke2" {
   most_recent = true
   name_regex  = "^uds-rhel-rke2-v${var.rke2_version}"
-  owners      = ["self"]
+  owners      = [var.uds_images_aws_account_id]
 }
+

--- a/.github/test-infra/aws/rke2/variables.tf
+++ b/.github/test-infra/aws/rke2/variables.tf
@@ -15,7 +15,7 @@ variable "vpc_name" {
 variable "subnet_name" {
   type        = string
   description = "Name of subnet tobrew install libtool use for testing. Can use a wildcard as long as it only matches one subnet per az."
-  default     = "uds-ci-commercial-*-public*"
+  default     = "uds-vpc-public*"
 }
 
 variable "region" {

--- a/.github/test-infra/aws/rke2/variables.tf
+++ b/.github/test-infra/aws/rke2/variables.tf
@@ -9,7 +9,7 @@ variable "environment" {
 variable "vpc_name" {
   type        = string
   description = "VPC ID to deploy into"
-  default     = "uds-ci-commercial-*"
+  default     = "uds-vpc"
 }
 
 variable "subnet_name" {
@@ -106,4 +106,9 @@ variable "client_id_list" {
 
 variable "run_id" {
   description = "Github Actions Run ID. Used to tag AWS resources that are created by this workspace."
+}
+
+variable "uds_images_aws_account_id" {
+  description = "The AWS Account ID for uds-images that the RKE2 amis are published to"
+  type        = string
 }

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -33,8 +33,8 @@ jobs:
       UDS_REGION: us-west-2
       UDS_PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
       UDS_PERMISSIONS_BOUNDARY_NAME: ${{ secrets.PERMISSIONS_BOUNDARY_NAME }}
-      UDS_STATE_BUCKET_NAME: uds-aws-ci-commercial-us-west-2-5246-tfstate
-      UDS_STATE_DYNAMODB_TABLE_NAME: uds-aws-ci-commercial-org-us-west-2-5246-tfstate-lock
+      UDS_STATE_BUCKET_NAME: uds-tf-state-20250305185900362500000001
+      UDS_STATE_DYNAMODB_TABLE_NAME: uds-tf-state-lock
     steps:
       - name: Set ENV
         run: |
@@ -58,7 +58,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: ${{ env.UDS_REGION }}
-          role-duration-seconds: 21600
+          role-duration-seconds: 3600
 
       - name: Environment setup
         uses: ./.github/actions/setup

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -58,7 +58,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: ${{ env.UDS_REGION }}
-          role-duration-seconds: 3600
+          role-duration-seconds: 7200
 
       - name: Environment setup
         uses: ./.github/actions/setup

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -60,7 +60,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: ${{ env.UDS_REGION }}
-          role-duration-seconds: 3600
+          role-duration-seconds: 7200
 
       - name: Environment setup
         uses: ./.github/actions/setup

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -33,8 +33,8 @@ jobs:
       UDS_REGION: us-west-2
       UDS_PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
       UDS_PERMISSIONS_BOUNDARY_NAME: ${{ secrets.PERMISSIONS_BOUNDARY_NAME }}
-      UDS_STATE_BUCKET_NAME: uds-aws-ci-commercial-us-west-2-5246-tfstate
-      UDS_STATE_DYNAMODB_TABLE_NAME: uds-aws-ci-commercial-org-us-west-2-5246-tfstate-lock
+      UDS_STATE_BUCKET_NAME: uds-tf-state-20250305185900362500000001
+      UDS_STATE_DYNAMODB_TABLE_NAME: uds-tf-state-lock
     steps:
       - name: Set ENV
         run: |
@@ -58,7 +58,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: ${{ env.UDS_REGION }}
-          role-duration-seconds: 21600
+          role-duration-seconds: 3600
 
       - name: Environment setup
         uses: ./.github/actions/setup

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -35,6 +35,7 @@ jobs:
       UDS_PERMISSIONS_BOUNDARY_NAME: ${{ secrets.PERMISSIONS_BOUNDARY_NAME }}
       UDS_STATE_BUCKET_NAME: uds-tf-state-20250305185900362500000001
       UDS_STATE_DYNAMODB_TABLE_NAME: uds-tf-state-lock
+      UDS_IMAGES_AWS_ACCOUNT_ID: ${{ secrets.UDS_IMAGES_AWS_ACCOUNT_ID }}
     steps:
       - name: Set ENV
         run: |
@@ -44,6 +45,7 @@ jobs:
           echo "TF_VAR_run_id=$GITHUB_RUN_ID" >> $GITHUB_ENV
           echo "TF_VAR_use_permissions_boundary=true" >> $GITHUB_ENV
           echo "TF_VAR_permissions_boundary_name=${UDS_PERMISSIONS_BOUNDARY_NAME}" >> $GITHUB_ENV
+          echo "TF_VAR_uds_images_aws_account_id=${UDS_IMAGES_AWS_ACCOUNT_ID}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Description

Swaps over the eks/rke2 tests to the new AWS commercial account.  Points the CI to use the new vpc, state bucket, state lock table provisioned in that account.  The base infra is defined in this [repo](https://github.com/defenseunicorns/infra-uds-core) and managed with our spacelift integration.

Additionally for the rke2 workflow, the terraform data filter needs to provide the new owning aws account id (since the AMIs are published in a different account than which the CI runs in).  The following secrets will need to be updated/created before this will work (I can provide these out of band and then rerun the test CI):

- `PERMISSIONS_BOUNDARY_ARN`
- `PERMISSIONS_BOUNDARY_NAME`
- `AWS_COMMERCIAL_ROLE_TO_ASSUME`
- `UDS_IMAGES_AWS_ACCOUNT_ID`

## Related Issue

Fixes #1287

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- N/A

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed