### PR TITLE
chore(ci): rm `create_bucket_lifecycle` input to s3 module calls

### DIFF
--- a/.github/test-infra/aws/eks/main.tf
+++ b/.github/test-infra/aws/eks/main.tf
@@ -62,7 +62,6 @@ module "S3" {
   name_prefix             = "${each.value.name}-"
   kms_key_arn             = local.kms_key_arns[each.key].kms_key_arn
   force_destroy           = "true"
-  create_bucket_lifecycle = true
 }
 
 module "irsa" {

--- a/.github/test-infra/aws/rke2/modules/storage/main.tf
+++ b/.github/test-infra/aws/rke2/modules/storage/main.tf
@@ -35,7 +35,6 @@ module "s3" {
   name_prefix             = "${each.value.name}-${each.value.bucket_prefix}-"
   kms_key_arn             = module.generate_kms[each.key].kms_key_arn
   force_destroy           = "true"
-  create_bucket_lifecycle = true
 
   depends_on = [
     module.generate_kms

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -13,7 +13,7 @@ on:
     paths:
       - tasks/iac.yaml
       - .github/bundles/rke2/*
-      - .github/test-infra/aws/rke2/*
+      - .github/test-infra/aws/rke2/**
       - .github/workflows/test-rke2.yaml
 
 permissions:


### PR DESCRIPTION
## Description
Removes `create_bucket_lifeycle` input to s3 module calls across our `aws` ci testing. Avoids the slim chance of [this](https://github.com/defenseunicorns/uds-core/actions/runs/13742749345/job/38433898443) recurring bug from causing IaC provisioning to fail. 
...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed