### PR TITLE
fix: renovate not checking test directory versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,7 +74,7 @@
       "commitMessageTopic": "grafana"
     },
     {
-      "matchFileNames": ["test/**", ".github/**", "bundles/**", "tasks/*.yaml", ".vscode/settings.json", "src/test/**", "README.md"],
+      "matchFileNames": ["test/**/*", ".github/**", "bundles/**", "tasks/*.yaml", ".vscode/settings.json", "src/test/**", "README.md"],
       "groupName": "support-deps",
       "commitMessageTopic": "support dependencies"
     },


### PR DESCRIPTION
## Description
Noticed that KFC was way out of date in out jest package.json. This was because the renovate only checked the top level of the test directory and not the sub directories.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed