### PR TITLE
feat: add alertmanager datasource to grafana

### DIFF
--- a/src/grafana/chart/templates/datasources.yaml
+++ b/src/grafana/chart/templates/datasources.yaml
@@ -22,3 +22,11 @@ data:
       name: Loki
       type: loki
       url: http://loki-gateway.loki.svc.cluster.local:80
+    - access: proxy
+      editable: true
+      name: Alertmanager
+      type: alertmanager
+      jsonData:
+        implementation: prometheus
+        handleGrafanaManagedAlerts: true
+      url: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093

--- a/src/grafana/chart/templates/uds-package.yaml
+++ b/src/grafana/chart/templates/uds-package.yaml
@@ -55,7 +55,19 @@ spec:
         description: "Prometheus Datasource"
         port: 9090
 
-      # Egress allowed to Keyclaok
+      # Egress allowed to Alertmanager
+      - direction: Egress
+        selector:
+          app.kubernetes.io/name: grafana
+        remoteNamespace: monitoring
+        remoteSelector:
+          app.kubernetes.io/name: alertmanager
+        selector:
+          app.kubernetes.io/name: grafana
+        description: "Alertmanager Datasource"
+        port: 9093
+
+      # Egress allowed to Keycloak
       - direction: Egress
         selector:
           app.kubernetes.io/name: grafana

--- a/src/prometheus-stack/chart/templates/uds-package.yaml
+++ b/src/prometheus-stack/chart/templates/uds-package.yaml
@@ -71,6 +71,15 @@ spec:
         port: 9090
         description: "Grafana Metrics Queries"
 
+      - direction: Ingress
+        remoteNamespace: grafana
+        remoteSelector:
+          app.kubernetes.io/name: grafana
+        selector:
+          app.kubernetes.io/name: alertmanager
+        description: Grafana Alerts Queries
+        port: 9093
+
       # Custom rules for additional networking access
       {{- with .Values.additionalNetworkAllow }}
       {{ toYaml . | nindent 6 }}

--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -30,6 +30,16 @@ test("validate prometheus datasource", async ({ page }) => {
   });
 });
 
+test("validate alertmanager datasource", async ({ page }) => {
+  await test.step("check alertmanager", async () => {
+    await page.goto(`/connections/datasources`);
+    await page.getByRole('link', { name: 'Alertmanager' }).click();
+    await page.click('text=Save & test');
+    // Allow 20 second timeout for datasource validation
+    await expect(page.locator('[data-testid="data-testid Alert success"]')).toBeVisible({ timeout: 20000 });
+  });
+});
+
 // This dashboard is added by the upstream kube-prometheus-stack
 test("validate namespace dashboard", async ({ page }) => {
   await test.step("check dashboard", async () => {


### PR DESCRIPTION
## Description

Adds the alertmanager datasource to grafana. This enables both configuration and observability of alerts in grafana.
## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/issues/967

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Deploy core (or at least the single-layer-test of monitoring) and validate that the datasource for alertmanager exists and works:
- It should show up here: https://grafana.admin.uds.dev/connections/datasources
- After clicking on Alertmanager, click the save & test button
- Also validate that (at minimum) the watchdog alert (on k3d you will also see some controlplane alerts): https://grafana.admin.uds.dev/alerting/groups?groupBy=alertname

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed