### PR TITLE
chore: add additionalNetworkAllow to keycloak and loki

### DIFF
--- a/docs/reference/configuration/uds-networking-configuration.md
+++ b/docs/reference/configuration/uds-networking-configuration.md
@@ -59,8 +59,8 @@ To accomplish this, you can provide a bundle override as follows:
 ```yaml
 packages:
   - name: uds-core
-    repository: ghcr.io/defenseunicorns/packages/uds/core-monitoring
-    ref: 0.31.1-upstream
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: 0.x.x-upstream
     overrides:
       kube-prometheus-stack:
         uds-prometheus-config:
@@ -86,8 +86,8 @@ It may also be desired to allow Vector to send logs to an external service. To f
 ```yaml
 packages:
   - name: uds-core
-    repository: ghcr.io/defenseunicorns/packages/uds/core-monitoring
-    ref: 0.31.1-upstream
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: 0.x.x-upstream
     overrides:
       vector:
         uds-vector-config:
@@ -121,8 +121,8 @@ It may be desired to connect Grafana to additional datasources in or outside of 
 ```yaml
 packages:
   - name: uds-core
-    repository: ghcr.io/defenseunicorns/packages/uds/core-monitoring
-    ref: 0.31.1-upstream
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: 0.x.x-upstream
     overrides:
       grafana:
         uds-grafana-config:
@@ -150,8 +150,8 @@ It may be desired send alerts from NeuVector to locations in or outside of the c
 ```yaml
 packages:
   - name: uds-core
-    repository: ghcr.io/defenseunicorns/packages/uds/core-monitoring
-    ref: 0.31.1-upstream
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: 0.x.x-upstream
     overrides:
       neuvector:
         uds-neuvector-config:
@@ -167,5 +167,59 @@ packages:
 ```
 
 The example above allows NeuVector to send alerts to any external destination. Alternatively, you could use the remoteNamespace key to specify another namespace within the Kubernetes cluster (i.e. Mattermost).
+
+Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.
+
+### Keycloak
+
+You may have a need to connect Keycloak to an external IdP or other service that the default network policies do not support. To facilitate this, you can provide a bundle override as follows:
+
+```yaml
+packages:
+  - name: uds-core
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: 0.x.x-upstream
+    overrides:
+      keycloak:
+        keycloak:
+          values:
+            - path: additionalNetworkAllow
+              value:
+                - direction: Egress
+                  selector:
+                    app.kubernetes.io/name: keycloak
+                  remoteCidr: 72.123.123.123
+                  description: "IdP Connection"
+                  port: 443
+```
+
+The example above allows Keycloak to connect to an "external IdP" at a specific remoteCidr.
+
+Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.
+
+### Loki
+
+You may have a need to configure Loki with egress to an additional destination, such as for [external caching](https://grafana.com/docs/loki/latest/operations/caching/) connections. To facilitate this, you can provide a bundle override as follows:
+
+```yaml
+packages:
+  - name: uds-core
+    repository: ghcr.io/defenseunicorns/packages/uds/core
+    ref: 0.x.x-upstream
+    overrides:
+      loki:
+        uds-loki-config:
+          values:
+            - path: additionalNetworkAllow
+              value:
+                - direction: Egress
+                  selector:
+                    app.kubernetes.io/name: loki
+                  remoteCidr: 72.123.123.123
+                  description: "Cache Connection"
+                  port: 6379
+```
+
+The example above allows Loki to connect to an "external cache" at a specific remoteCidr.
 
 Reference the [spec for allow](https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow) for all available fields.

--- a/src/keycloak/chart/templates/uds-package.yaml
+++ b/src/keycloak/chart/templates/uds-package.yaml
@@ -85,6 +85,11 @@ spec:
           - 57800
       {{- end }}
 
+      # Custom rules for additional networking access
+      {{- with .Values.additionalNetworkAllow }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
+
     expose:
       - description: "remove private paths from public gateway"
         host: sso

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -15,6 +15,12 @@
     "pathParameterProtection": {
       "type": "boolean"
     },
+    "additionalNetworkAllow": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "autoscaling": {
       "type": "object",
       "properties": {

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -58,6 +58,18 @@ insecureAdminPasswordGeneration:
   enabled: false
   username: admin
 
+# Support for custom `network.allow` entries on the Package CR, useful for extra datasources
+additionalNetworkAllow: []
+# ref: https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow
+#   - direction: Egress
+#     selector:
+#       app.kubernetes.io/name: grafana
+#     remoteNamespace: thanos
+#     remoteSelector:
+#       app: thanos
+#     description: "Thanos Query"
+#     port: 9090
+
 # Indicates whether information about services should be injected into Pod's environment variables, matching the syntax of Docker links
 enableServiceLinks: true
 

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -63,12 +63,10 @@ additionalNetworkAllow: []
 # ref: https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow
 #   - direction: Egress
 #     selector:
-#       app.kubernetes.io/name: grafana
-#     remoteNamespace: thanos
-#     remoteSelector:
-#       app: thanos
-#     description: "Thanos Query"
-#     port: 9090
+#       app.kubernetes.io/name: keycloak
+#     remoteCidr: 72.123.123.123
+#     description: "IDP"
+#     port: 443
 
 # Indicates whether information about services should be injected into Pod's environment variables, matching the syntax of Docker links
 enableServiceLinks: true

--- a/src/loki/chart/templates/uds-package.yaml
+++ b/src/loki/chart/templates/uds-package.yaml
@@ -59,3 +59,8 @@ spec:
         {{- else }}
         remoteGenerated: Anywhere
         {{- end }}
+
+      # Custom rules for additional networking access
+      {{- with .Values.additionalNetworkAllow }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}

--- a/src/loki/chart/values.yaml
+++ b/src/loki/chart/values.yaml
@@ -15,9 +15,7 @@ additionalNetworkAllow: []
 # ref: https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow
 #   - direction: Egress
 #     selector:
-#       app.kubernetes.io/name: grafana
-#     remoteNamespace: thanos
-#     remoteSelector:
-#       app: thanos
-#     description: "Thanos Query"
-#     port: 9090
+#       app.kubernetes.io/name: loki
+#     remoteCidr: 72.123.123.123
+#     description: "Cache"
+#     port: 6379

--- a/src/loki/chart/values.yaml
+++ b/src/loki/chart/values.yaml
@@ -9,3 +9,15 @@ storage:
   egressCidr: ""
 
 dashboardAnnotations: {}
+
+# Support for custom `network.allow` entries on the Package CR, useful for extra datasources
+additionalNetworkAllow: []
+# ref: https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow
+#   - direction: Egress
+#     selector:
+#       app.kubernetes.io/name: grafana
+#     remoteNamespace: thanos
+#     remoteSelector:
+#       app: thanos
+#     description: "Thanos Query"
+#     port: 9090


### PR DESCRIPTION
## Description

This PR exposes `additionalNetworkAllow` for Keycloak and Loki:
- Keycloak: IdP connections can sometimes require egress. While other network policies may cover this (i.e. the postgres/db policy), it's better for all policies to be more restrictive and finegrained.
- Loki: Loki supports external caching. While we may want to build this into the package itself at some point, for now this value would allow this and any other "conditional features" to be utilized.

These changes are especially helpful as we look towards Istio ambient and only allowing a single `Package` CR per namespace. This will ensure that any and all network policies are created in this interface (securely) and not via bolt-on netpols.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Review new chart values/alignment, validate with `helm template` if desired.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed