### PR TITLE
chore: update unicorn ztunnel image to 1.25.0

### DIFF
--- a/src/istio/values/unicorn/ztunnel.yaml
+++ b/src/istio/values/unicorn/ztunnel.yaml
@@ -1,4 +1,4 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-image: cgr.dev/du-uds-defenseunicorns/ztunnel-fips:1.24.3
+image: cgr.dev/du-uds-defenseunicorns/ztunnel-fips:1.25.0

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -107,7 +107,7 @@ components:
           - "values/unicorn/ztunnel.yaml"
     images:
       - cgr.dev/du-uds-defenseunicorns/istio-install-cni:1.25.0
-      - cgr.dev/du-uds-defenseunicorns/ztunnel-fips:1.24.3
+      - cgr.dev/du-uds-defenseunicorns/ztunnel-fips:1.25.0
 
   - name: istio-admin-gateway
     required: true


### PR DESCRIPTION
## Description

Creating this update separately from Renovate since it was missed in the prior PR. This brings all istio images in line on 1.25.0.

## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/pull/1387

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

N/A - normal istio functionality.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed