### PR TITLE
fix: add delete credential keycloak secret value

### DIFF
--- a/src/keycloak/chart/templates/secret-kc-realm.yaml
+++ b/src/keycloak/chart/templates/secret-kc-realm.yaml
@@ -31,4 +31,5 @@ data:
   WEBAUTHN_FLOW_ENABLED: {{ ternary "REQUIRED" "DISABLED" (.Values.realmAuthFlows.WEBAUTHN_ENABLED) | b64enc }}
   X509_MFA_ENABLED: {{ .Values.realmAuthFlows.X509_MFA_ENABLED | toString | b64enc }}
   X509_MFA_FLOW_ENABLED: {{ ternary "REQUIRED" "DISABLED" (.Values.realmAuthFlows.X509_MFA_ENABLED) | b64enc }}
+  MFA_ENABLED: {{ or .Values.realmAuthFlows.OTP_ENABLED .Values.realmAuthFlows.WEBAUTHN_ENABLED | toString | b64enc }}
   MFA_FLOW_ENABLED: {{ ternary "REQUIRED" "DISABLED" (or .Values.realmAuthFlows.OTP_ENABLED .Values.realmAuthFlows.WEBAUTHN_ENABLED) | b64enc }}


### PR DESCRIPTION
## Description
After enabling webauthn passkeys, we need to be able to allow users to delete their passkey so that they can re-add that passkey.

These changes don't change the existing behavior of core or identity config.

## Related Issue

Relates to this Identity Config [issue](https://github.com/defenseunicorns/uds-identity-config/issues/397)
Relates to this Identity Config [PR](https://github.com/defenseunicorns/uds-identity-config/pull/398)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- steps to validate will be in [the identity-config PR](https://github.com/defenseunicorns/uds-identity-config/pull/398)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed