### PR TITLE
fix: broken selectors for internal dependencies on charts

### DIFF
--- a/src/authservice/chart/templates/uds-package.yaml
+++ b/src/authservice/chart/templates/uds-package.yaml
@@ -27,7 +27,8 @@ spec:
       - direction: Egress
         description: Redis Session Store
         {{- if .Values.redis.internal.enabled }}
-        remoteSelector: {{ .Values.redis.internal.remoteSelector }}
+        remoteSelector:
+          {{- .Values.redis.internal.remoteSelector | toYaml | nindent 10 }}
         remoteNamespace: {{ .Values.redis.internal.remoteNamespace }}
         {{- else if .Values.redis.egressCidr }}
         remoteCidr: {{ .Values.redis.egressCidr }}

--- a/src/keycloak/chart/templates/uds-package.yaml
+++ b/src/keycloak/chart/templates/uds-package.yaml
@@ -62,7 +62,8 @@ spec:
           app.kubernetes.io/name: keycloak
         port: {{ .Values.postgresql.port }}
         {{- if .Values.postgresql.internal.enabled }}
-        remoteSelector: {{ .Values.postgresql.internal.remoteSelector }}
+        remoteSelector:
+          {{- .Values.postgresql.internal.remoteSelector | toYaml | nindent 10 }}
         remoteNamespace: {{ .Values.postgresql.internal.remoteNamespace }}
         {{- else if .Values.postgresql.egressCidr }}
         remoteCidr: {{ .Values.postgresql.egressCidr }}

--- a/src/loki/chart/templates/uds-package.yaml
+++ b/src/loki/chart/templates/uds-package.yaml
@@ -52,7 +52,8 @@ spec:
           app.kubernetes.io/name: loki
         description: Storage
         {{- if .Values.storage.internal.enabled }}
-        remoteSelector: {{ .Values.storage.internal.remoteSelector }}
+        remoteSelector:
+          {{- .Values.storage.internal.remoteSelector | toYaml | nindent 10 }}
         remoteNamespace: {{ .Values.storage.internal.remoteNamespace }}
         {{- else if .Values.storage.egressCidr }}
         remoteCidr: {{ .Values.storage.egressCidr }}

--- a/src/velero/chart/templates/uds-package.yaml
+++ b/src/velero/chart/templates/uds-package.yaml
@@ -15,7 +15,8 @@ spec:
           app.kubernetes.io/name: velero
         description: Storage
         {{- if .Values.storage.internal.enabled }}
-        remoteSelector: {{ .Values.storage.internal.remoteSelector }}
+        remoteSelector:
+          {{- .Values.storage.internal.remoteSelector | toYaml | nindent 10 }}
         remoteNamespace: {{ .Values.storage.internal.remoteNamespace }}
         {{- else if .Values.storage.egressCidr }}
         remoteCidr: {{ .Values.storage.egressCidr }}


### PR DESCRIPTION
## Description

Fixes several broken templates where selector was not getting populated properly in the `Package` CR. Thanks to @JaseKoonce for finding this 😄

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Run helm templates and validate the output looks as expected for the `remoteSelector`:
```console
helm template src/authservice/chart --set redis.internal.enabled=true --set redis.internal.remoteSelector.app=redis
helm template src/keycloak/chart --set postgresql.internal.enabled=true --set postgresql.internal.remoteSelector.app=postgres --set postgresql.username=user --set postgresql.password=pass --set postgresql.database=keycloak --set postgresql.host=postgres --set postgresql.port=1234 --set devMode=false
helm template src/loki/chart --set storage.internal.enabled=true --set storage.internal.remoteSelector.app=s3
helm template src/velero/chart --set storage.internal.enabled=true --set storage.internal.remoteSelector.app=s3
```

If you repeat these steps on `main` you will see the issue, it templates out as `remoteSelector: map[app:s3]`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed