### PR TITLE
chore: prefer `===` for comparisons

### DIFF
--- a/src/pepr/operator/controllers/keycloak/authservice/authservice.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/authservice.ts
@@ -10,17 +10,17 @@ import { UDSPackage } from "../../../crd";
 import { Client } from "../types";
 import { updatePolicy } from "./authorization-policy";
 import {
-    getAuthserviceConfig,
-    operatorConfig,
-    setAuthserviceConfig,
-    updateAuthServiceSecret,
+  getAuthserviceConfig,
+  operatorConfig,
+  setAuthserviceConfig,
+  updateAuthServiceSecret,
 } from "./config";
 import {
-    Action,
-    AddOrRemoveClientEvent,
-    AuthServiceEvent,
-    AuthserviceConfig,
-    Chain,
+  Action,
+  AddOrRemoveClientEvent,
+  AuthServiceEvent,
+  AuthserviceConfig,
+  Chain,
 } from "./types";
 
 export const log = setupLogger(Component.OPERATOR_AUTHSERVICE);

--- a/src/pepr/operator/controllers/keycloak/authservice/authservice.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/authservice.ts
@@ -10,17 +10,17 @@ import { UDSPackage } from "../../../crd";
 import { Client } from "../types";
 import { updatePolicy } from "./authorization-policy";
 import {
-  getAuthserviceConfig,
-  operatorConfig,
-  setAuthserviceConfig,
-  updateAuthServiceSecret,
+    getAuthserviceConfig,
+    operatorConfig,
+    setAuthserviceConfig,
+    updateAuthServiceSecret,
 } from "./config";
 import {
-  Action,
-  AddOrRemoveClientEvent,
-  AuthServiceEvent,
-  AuthserviceConfig,
-  Chain,
+    Action,
+    AddOrRemoveClientEvent,
+    AuthServiceEvent,
+    AuthserviceConfig,
+    Chain,
 } from "./types";
 
 export const log = setupLogger(Component.OPERATOR_AUTHSERVICE);
@@ -122,7 +122,7 @@ export async function updateConfig(event: AuthServiceEvent) {
 export function buildConfig(config: AuthserviceConfig, event: AuthServiceEvent) {
   let chains: Chain[];
 
-  if (event.action == Action.AddClient) {
+  if (event.action === Action.AddClient) {
     // Add the new chain to the existing authservice config
     chains = config.chains.filter(chain => chain.name !== event.name);
     chains = chains.concat(buildChain(event));
@@ -130,12 +130,12 @@ export function buildConfig(config: AuthserviceConfig, event: AuthServiceEvent) 
     // sorting here is not relevant, only the consistency.
     const sortByName = R.sortBy(R.prop("name"));
     chains = sortByName(chains);
-  } else if (event.action == Action.RemoveClient) {
+  } else if (event.action === Action.RemoveClient) {
     // Search in the existing chains for the chain to remove by name.
     // Filtering here should preserve the order, so there is no need to re-sort.
     chains = config.chains.filter(chain => chain.name !== event.name);
     // Handle global config updates
-  } else if (event.action == Action.UpdateGlobalConfig) {
+  } else if (event.action === Action.UpdateGlobalConfig) {
     if (!event.redisUri) {
       // Remove the redis session store config if a URI is not provided
       delete config.default_oidc_config.redis_session_store_config;

--- a/src/pepr/operator/crd/validators/exempt-validator.ts
+++ b/src/pepr/operator/crd/validators/exempt-validator.ts
@@ -16,7 +16,7 @@ const kindToPolicyMap = new Map<MatcherKind, Policy[]>([
   [
     MatcherKind.Pod,
     Object.values(Policy).filter(
-      p => p != Policy.DisallowNodePortServices && p != Policy.RestrictExternalNames,
+      p => p !== Policy.DisallowNodePortServices && p !== Policy.RestrictExternalNames,
     ),
   ],
   [MatcherKind.Service, [Policy.RestrictExternalNames, Policy.DisallowNodePortServices]],

--- a/src/pepr/operator/reconcilers/index.ts
+++ b/src/pepr/operator/reconcilers/index.ts
@@ -169,10 +169,10 @@ export function getReadinessConditions(ready: boolean = true) {
   return [
     {
       type: "Ready",
-      status: ready == true ? StatusEnum.True : StatusEnum.False,
+      status: ready === true ? StatusEnum.True : StatusEnum.False,
       lastTransitionTime: new Date(),
       message:
-        ready == true ? "The package is ready for use." : "The package is not ready for use.",
+        ready === true ? "The package is ready for use." : "The package is not ready for use.",
       reason: "ReconciliationComplete",
     },
   ];

--- a/src/pepr/policies/exemptions/index.ts
+++ b/src/pepr/policies/exemptions/index.ts
@@ -27,7 +27,7 @@ export function isExempt<T extends KubernetesObject>(
   const resourceName = request.Raw.metadata?.name || request.Raw.metadata?.generateName;
   const resourceNamespace = request.Raw.metadata?.namespace;
 
-  if (exemptList.length != 0) {
+  if (exemptList.length !== 0) {
     // Debug log to provide current exemptions for policy
     log.debug(
       `Checking ${resourceName} against ${policy} exemptions: ${JSON.stringify(exemptList)}`,

--- a/src/pepr/prometheus/index.ts
+++ b/src/pepr/prometheus/index.ts
@@ -6,12 +6,12 @@
 import { Capability, K8s, kind } from "pepr";
 import { Component, setupLogger } from "../logger";
 import {
-    PodMonitorEndpoint,
-    PodMonitorScheme,
-    PrometheusPodMonitor,
-    PrometheusServiceMonitor,
-    ServiceMonitorEndpoint,
-    ServiceMonitorScheme,
+  PodMonitorEndpoint,
+  PodMonitorScheme,
+  PrometheusPodMonitor,
+  PrometheusServiceMonitor,
+  ServiceMonitorEndpoint,
+  ServiceMonitorScheme,
 } from "../operator/crd";
 import { FallbackScrapeProtocol } from "../operator/crd/generated/prometheus/servicemonitor-v1";
 // configure subproject logger

--- a/src/pepr/prometheus/index.ts
+++ b/src/pepr/prometheus/index.ts
@@ -6,12 +6,12 @@
 import { Capability, K8s, kind } from "pepr";
 import { Component, setupLogger } from "../logger";
 import {
-  PodMonitorEndpoint,
-  PodMonitorScheme,
-  PrometheusPodMonitor,
-  PrometheusServiceMonitor,
-  ServiceMonitorEndpoint,
-  ServiceMonitorScheme,
+    PodMonitorEndpoint,
+    PodMonitorScheme,
+    PrometheusPodMonitor,
+    PrometheusServiceMonitor,
+    ServiceMonitorEndpoint,
+    ServiceMonitorScheme,
 } from "../operator/crd";
 import { FallbackScrapeProtocol } from "../operator/crd/generated/prometheus/servicemonitor-v1";
 // configure subproject logger
@@ -30,7 +30,7 @@ const { When } = prometheus;
 When(PrometheusServiceMonitor)
   .IsCreatedOrUpdated()
   .Mutate(async sm => {
-    if (sm.Raw.spec === undefined || sm.Raw.spec.scrapeClass != undefined) {
+    if (sm.Raw.spec === undefined || sm.Raw.spec.scrapeClass !== undefined) {
       // Support the legacy (Prometheus 2.x fallback) until upstream applications properly handle protocol
       if (sm.Raw.spec && !sm.Raw.spec.fallbackScrapeProtocol) {
         sm.Raw.spec.fallbackScrapeProtocol = FallbackScrapeProtocol.PrometheusText004;
@@ -82,7 +82,7 @@ When(PrometheusServiceMonitor)
 When(PrometheusPodMonitor)
   .IsCreatedOrUpdated()
   .Mutate(async pm => {
-    if (pm.Raw.spec === undefined || pm.Raw.spec.scrapeClass != undefined) {
+    if (pm.Raw.spec === undefined || pm.Raw.spec.scrapeClass !== undefined) {
       // Support the legacy (Prometheus 2.x fallback) until upstream applications properly handle protocol
       if (pm.Raw.spec && !pm.Raw.spec.fallbackScrapeProtocol) {
         pm.Raw.spec.fallbackScrapeProtocol = FallbackScrapeProtocol.PrometheusText004;
@@ -116,7 +116,7 @@ When(PrometheusPodMonitor)
     }
   });
 
-// This assumes istio-injection == strict mTLS due to complexity around mTLS lookup
+// This assumes istio-injection === strict mTLS due to complexity around mTLS lookup
 async function isIstioInjected(monitor: PrometheusServiceMonitor | PrometheusPodMonitor) {
   // If monitor allows any namespace assume istio injection
   if (monitor.Raw.spec?.namespaceSelector?.any) {


### PR DESCRIPTION
## Description

This PR relates to #1411 and changes the comparison operator used in `src/pepr/*.ts` files. It does not enforce this change as a linter rule.

## Related Issue

Fixes #1411 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed