### PR TITLE
chore(ci): pin uds cli to v0.24.0

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -34,8 +34,8 @@ runs:
     - name: Install UDS CLI
       uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
       with:
-        # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-        version: v0.25.0
+        # ignored renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+        version: v0.24.0
 
     - name: Install Lula
       uses: defenseunicorns/lula-action/setup@badad8c4b1570095f57e66ffd62664847698a3b9 # v0.0.1


### PR DESCRIPTION
## Description
Pins UDS CLI to version v0.24.0 to mitigate uncaught failures in CI builds


## Related Issue
See [this](https://github.com/defenseunicorns/uds-core/actions/runs/14205155758/job/39801068681#step:9:125) pipeline run

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed