### PR TITLE
fix: conditional pepr build in tasks

### DIFF
--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -1,7 +1,6 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-
 includes:
   - common: https://raw.githubusercontent.com/defenseunicorns/uds-common/v1.11.2/tasks/create.yaml
 
@@ -80,8 +79,11 @@ tasks:
         default: ${CREATE_OPTIONS}
         description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
     actions:
+      # Note: Maru does not support `or` for this conditional task so we just duplicate it for each case
       - task: pepr-build
-        if: ${{ eq .inputs.layer "base" or eq .inputs.layer "standard" }}
+        if: ${{ eq .inputs.layer "standard" }}
+      - task: pepr-build
+        if: ${{ eq .inputs.layer "base" }}
       - description: "Create the UDS Core Zarf Package"
         task: common:package
         with:


### PR DESCRIPTION
## Description

While running `uds run test-single-layer --set LAYER=runtime-security` I noticed that pepr was being rebuilt several times. From what I can tell this `or` syntax is not supported so it appears this silently "failed"/ran for all layer inputs.

This change

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

```console
# Expect pepr build
uds run -f tasks/create.yaml single-layer --with layer=standard
uds run -f tasks/create.yaml single-layer --with layer=base
# Expect no pepr build
uds run -f tasks/create.yaml single-layer --with layer=runtime-security
uds run -f tasks/create.yaml single-layer --with layer=metrics-server
uds run -f tasks/create.yaml single-layer --with layer=logging
```

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed