### PR TITLE
fix: authpol remoteserviceaccount enablement

### DIFF
--- a/src/keycloak/chart/templates/uds-package.yaml
+++ b/src/keycloak/chart/templates/uds-package.yaml
@@ -26,6 +26,7 @@ spec:
         remoteNamespace: pepr-system
         remoteSelector:
           app: pepr-uds-core-watcher
+        remoteServiceAccount: pepr-uds-core
         port: 8080
 
       - description: "Keycloak backchannel access"

--- a/src/loki/chart/templates/uds-package.yaml
+++ b/src/loki/chart/templates/uds-package.yaml
@@ -22,6 +22,7 @@ spec:
         remoteNamespace: grafana
         remoteSelector:
           app.kubernetes.io/name: grafana
+        remoteServiceAccount: grafana
         ports:
           - 8080
         description: "Grafana Log Queries"
@@ -32,6 +33,7 @@ spec:
         remoteNamespace: monitoring
         remoteSelector:
           app.kubernetes.io/name: prometheus
+        remoteServiceAccount: kube-prometheus-stack-prometheus
         ports:
           - 3100
         description: "Prometheus Metrics"
@@ -42,6 +44,7 @@ spec:
         remoteNamespace: vector
         remoteSelector:
           app.kubernetes.io/name: vector
+        remoteServiceAccount: vector
         ports:
           - 8080
         description: "Vector Log Storage"

--- a/src/prometheus-stack/chart/templates/uds-package.yaml
+++ b/src/prometheus-stack/chart/templates/uds-package.yaml
@@ -66,6 +66,7 @@ spec:
         remoteNamespace: grafana
         remoteSelector:
           app.kubernetes.io/name: grafana
+        remoteServiceAccount: grafana
         selector:
           app.kubernetes.io/name: prometheus
         port: 9090
@@ -75,6 +76,7 @@ spec:
         remoteNamespace: grafana
         remoteSelector:
           app.kubernetes.io/name: grafana
+        remoteServiceAccount: grafana
         selector:
           app.kubernetes.io/name: alertmanager
         description: Grafana Alerts Queries

--- a/src/vector/chart/templates/uds-package.yaml
+++ b/src/vector/chart/templates/uds-package.yaml
@@ -15,6 +15,7 @@ spec:
         remoteNamespace: monitoring
         remoteSelector:
           app.kubernetes.io/name: prometheus
+        remoteServiceAccount: kube-prometheus-stack-prometheus
         port: 9090
         description: "Prometheus Metrics"
 
@@ -29,6 +30,7 @@ spec:
         remoteNamespace: loki
         remoteSelector:
           app.kubernetes.io/name: loki
+        remoteServiceAccount: vector
         port: 8080
         description: "Write Logs to Loki"
 

--- a/src/vector/chart/templates/uds-package.yaml
+++ b/src/vector/chart/templates/uds-package.yaml
@@ -30,7 +30,6 @@ spec:
         remoteNamespace: loki
         remoteSelector:
           app.kubernetes.io/name: loki
-        remoteServiceAccount: vector
         port: 8080
         description: "Write Logs to Loki"
 

--- a/src/velero/chart/templates/uds-package.yaml
+++ b/src/velero/chart/templates/uds-package.yaml
@@ -33,6 +33,7 @@ spec:
         remoteNamespace: monitoring
         remoteSelector:
           app: prometheus
+        remoteServiceAccount: kube-prometheus-stack-prometheus
         selector:
           app.kubernetes.io/name: velero
         port: 8085


### PR DESCRIPTION
## Description
Went through and identified the service accounts for each application and added the `remoteServiceAccount` to the UDSPackage Spec.Allow rules for ingress rules.

This is in addition to the existing `selectors`, `remoteNamespace`, `remoteSelector` fields. In the ambient authpols operator implementation the `remoteServiceAccount` would take precedent for the from.source block of the authorizationpolicy.

## Related Issue

Fixes #1399

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Not much here other than deploying uds-core and checking the authorization policies that are generated utilize the new remoteServiceAccount to create the `from.source` block rather than existing selectors.
- `uds run test:uds-core-e2e`
- use `k9s` to search through the `authorizationpolicies` for the following policies:

| policy name | original `from.source` value | new `from.source` value |
|---|---|---|
| `protect-keycloak-ingress-uds-operator` | `Namespace:pepr-system` | `Principals:cluster.local/ns/pepr-system/sa/pepr-uds-core` |
| `protect-loki-ingress-grafana-log-queries` | `Namespace:grafana` | `Principals:cluster.local/ns/grafana/sa/grafana` |
| `protect-loki-ingress-prometheus-metrics` | `Namespaces:monitoring` | `Principals:cluster.local/ns/monitoring/sa/kube-prometheus-stack-prometheus` |
| `protect-loki-ingress-vector-log-storage` | `Namespace:vector` | `Principals:cluster.local/ns/vector/sa/vector` |
| `protect-prometheus-stack-ingress-grafana-alerts-queries` | `Namespace:grafana` | `Principals:cluster.local/ns/grafana/sa/grafana` |
| `protect-prometheus-stack-ingress-grafana-metrics-queries` | `Namespaces:grafana` | `Principals:cluster.local/ns/grafana/sa/grafana` |
| `protect-velero-ingress-prometheus-metrics` | `Namespaces:monitoring` | `Principals:cluster.local/ns/monitoring/sa/kube-prometheus-stack-prometheus` |
| `protect-vector-ingress-prometheus-metrics` | `Namespaces:monitoring` | `Principals:cluster.local/ns/monitoring/sa/kube-prometheus-stack-prometheus` |

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed