### PR TITLE
Revert "chore(deps): update neuvector to 5.4.3"

### DIFF
--- a/src/neuvector/common/zarf.yaml
+++ b/src/neuvector/common/zarf.yaml
@@ -14,7 +14,7 @@ components:
     charts:
       - name: crd
         url: https://neuvector.github.io/neuvector-helm/
-        version: 2.8.5
+        version: 2.8.4
         namespace: neuvector
         gitPath: charts/crd
       - name: uds-neuvector-config
@@ -25,14 +25,14 @@ components:
           - ../chart/values.yaml
       - name: core
         url: https://neuvector.github.io/neuvector-helm/
-        version: 2.8.5
+        version: 2.8.4
         namespace: neuvector
         gitPath: charts/core
         valuesFiles:
           - ../values/values.yaml
       # - name: monitor
       #   url: https://neuvector.github.io/neuvector-helm/
-      #   version: 2.8.5
+      #   version: 2.8.4
       #   namespace: neuvector
       #   gitPath: charts/monitor
       #   valuesFiles:

--- a/src/neuvector/values/registry1-values.yaml
+++ b/src/neuvector/values/registry1-values.yaml
@@ -3,7 +3,7 @@
 
 registry: registry1.dso.mil
 # renovate: datasource=docker depName=registry1.dso.mil/ironbank/neuvector/neuvector/controller versioning=docker
-tag: "5.4.3"
+tag: "5.4.2"
 manager:
   image:
     repository: ironbank/neuvector/neuvector/manager

--- a/src/neuvector/values/unicorn-values.yaml
+++ b/src/neuvector/values/unicorn-values.yaml
@@ -6,7 +6,7 @@ autoGenerateCert: true
 
 registry: cgr.dev
 # renovate: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/neuvector-controller-fips versioning=docker
-tag: "5.4.3"
+tag: "5.4.2"
 manager:
   image:
     repository: du-uds-defenseunicorns/neuvector-manager

--- a/src/neuvector/values/upstream-values.yaml
+++ b/src/neuvector/values/upstream-values.yaml
@@ -3,7 +3,7 @@
 
 registry: docker.io
 # renovate: datasource=docker depName=docker.io/neuvector/controller versioning=docker
-tag: "5.4.3"
+tag: "5.4.2"
 manager:
   image:
     repository: neuvector/manager

--- a/src/neuvector/zarf.yaml
+++ b/src/neuvector/zarf.yaml
@@ -28,11 +28,11 @@ components:
         valuesFiles:
           - values/upstream-values.yaml
     images:
-      - docker.io/neuvector/controller:5.4.3
-      - docker.io/neuvector/manager:5.4.3
+      - docker.io/neuvector/controller:5.4.2
+      - docker.io/neuvector/manager:5.4.2
       - docker.io/neuvector/updater:latest
       - docker.io/neuvector/scanner:latest
-      - docker.io/neuvector/enforcer:5.4.3
+      - docker.io/neuvector/enforcer:5.4.2
 
   - name: neuvector
     description: "Deploy Neuvector"
@@ -46,11 +46,11 @@ components:
         valuesFiles:
           - values/registry1-values.yaml
     images:
-      - registry1.dso.mil/ironbank/neuvector/neuvector/controller:5.4.3
-      - registry1.dso.mil/ironbank/neuvector/neuvector/manager:5.4.3
+      - registry1.dso.mil/ironbank/neuvector/neuvector/controller:5.4.2
+      - registry1.dso.mil/ironbank/neuvector/neuvector/manager:5.4.2
       - registry1.dso.mil/ironbank/redhat/ubi/ubi9-minimal:9.5
       - registry1.dso.mil/ironbank/neuvector/neuvector/scanner:6
-      - registry1.dso.mil/ironbank/neuvector/neuvector/enforcer:5.4.3
+      - registry1.dso.mil/ironbank/neuvector/neuvector/enforcer:5.4.2
 
   - name: neuvector
     description: "Deploy Neuvector"
@@ -67,8 +67,8 @@ components:
         valuesFiles:
           - values/unicorn-values.yaml
     images:
-      - cgr.dev/du-uds-defenseunicorns/neuvector-manager:5.4.3
-      - cgr.dev/du-uds-defenseunicorns/neuvector-enforcer-fips:5.4.3
-      - cgr.dev/du-uds-defenseunicorns/neuvector-controller-fips:5.4.3
+      - cgr.dev/du-uds-defenseunicorns/neuvector-manager:5.4.2
+      - cgr.dev/du-uds-defenseunicorns/neuvector-enforcer-fips:5.4.2
+      - cgr.dev/du-uds-defenseunicorns/neuvector-controller-fips:5.4.2
       - docker.io/neuvector/scanner:latest
       - cgr.dev/du-uds-defenseunicorns/neuvector-updater-fips:8.12.1-dev


### PR DESCRIPTION
Reverts defenseunicorns/uds-core#1368

This new NeuVector version has several issues we've encountered with the registry1/unicorn images that need to be resolved. Issues only seem to appear on the IAC clusters (RKE2, AKS, EKS).