### PR TITLE
fix: register crds in `dev-setup` task

### DIFF
--- a/src/istio/common/chart/templates/exemptions.yaml
+++ b/src/istio/common/chart/templates/exemptions.yaml
@@ -1,6 +1,6 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
-
+{{- if eq .Values.exemptions.enabled true }}
 apiVersion: uds.dev/v1alpha1
 kind: Exemption
 metadata:
@@ -35,3 +35,4 @@ spec:
        name: "ztunnel.*"
      title: "Istio ztunnel exemptions"
      description: "Exemptions necessary for ztunnel to manage network traffic and ensure secure data plane operations"
+{{ end }}

--- a/src/istio/common/chart/templates/exemptions.yaml
+++ b/src/istio/common/chart/templates/exemptions.yaml
@@ -1,6 +1,5 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
-{{- if eq .Values.exemptions.enabled true }}
 apiVersion: uds.dev/v1alpha1
 kind: Exemption
 metadata:
@@ -35,4 +34,3 @@ spec:
        name: "ztunnel.*"
      title: "Istio ztunnel exemptions"
      description: "Exemptions necessary for ztunnel to manage network traffic and ensure secure data plane operations"
-{{ end }}

--- a/src/istio/common/chart/values.yaml
+++ b/src/istio/common/chart/values.yaml
@@ -11,5 +11,3 @@ classificationBanner:
 domain: "###ZARF_VAR_DOMAIN###"
 # Note: This does not handle an empty admin domain zarf var
 adminDomain: "###ZARF_VAR_ADMIN_DOMAIN###"
-exemptions:
-  enabled: ###ZARF_VAR_CREATE_EXEMPTIONS###

--- a/src/istio/common/chart/values.yaml
+++ b/src/istio/common/chart/values.yaml
@@ -8,7 +8,8 @@ classificationBanner:
   # - keycloak.{{ .Values.adminDomain }}
   # - sso.{{ .Values.domain }}
   # - grafana.admin.uds.dev
-
 domain: "###ZARF_VAR_DOMAIN###"
 # Note: This does not handle an empty admin domain zarf var
 adminDomain: "###ZARF_VAR_ADMIN_DOMAIN###"
+exemptions:
+  enabled: ###ZARF_VAR_CREATE_EXEMPTIONS###

--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -13,9 +13,6 @@ variables:
   - name: CNI_BIN_DIR
     description: "CNI binary directory"
     default: ""
-  - name: CREATE_EXEMPTIONS
-    description: "Whether or not to create exemptions for istio."
-    default: "true"
 
 components:
   - name: istio-controlplane

--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -13,6 +13,9 @@ variables:
   - name: CNI_BIN_DIR
     description: "CNI binary directory"
     default: ""
+  - name: CREATE_EXEMPTIONS
+    description: "Whether or not to create exemptions for istio."
+    default: "true"
 
 components:
   - name: istio-controlplane

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -30,7 +30,7 @@ tasks:
         cmd: npx ts-node -e "import { registerCRDs } from './src/pepr/operator/crd/register'; registerCRDs()"
         env:
           - "PEPR_MODE=dev"
-        
+
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
         cmd: "uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --no-progress"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -28,7 +28,7 @@ tasks:
 
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
-        cmd: "uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --no-progress"
+        cmd: "uds zarf dev deploy src/istio --deploy-set CREATE_EXEMPTIONS=false --flavor upstream --registry-url docker.io --no-progress"
 
       # Note: Since this is a dev deploy without any `--flavor` it only deploys the CRDs (other components are flavored)
       - description: "Deploy the Prometheus-Stack source package with Zarf Dev to only install the CRDs"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -26,9 +26,14 @@ tasks:
       - description: "Create the dev cluster"
         task: setup:create-k3d-cluster
 
+      - description: "Register CRDs in cluster"
+        cmd: npx ts-node -e "import { registerCRDs } from './src/pepr/operator/crd/register'; registerCRDs()"
+        env:
+          - "PEPR_MODE=dev"
+        
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
-        cmd: "uds zarf dev deploy src/istio --deploy-set CREATE_EXEMPTIONS=false --flavor upstream --registry-url docker.io --no-progress"
+        cmd: "uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --no-progress"
 
       # Note: Since this is a dev deploy without any `--flavor` it only deploys the CRDs (other components are flavored)
       - description: "Deploy the Prometheus-Stack source package with Zarf Dev to only install the CRDs"


### PR DESCRIPTION
## Description
After https://github.com/defenseunicorns/uds-core/pull/1428 was introduced, I noticed that `uds run dev-setup` began to fail due to the `Exemptions` Custom Resource not yet being registered on the target cluster. This PR introduces an additional step to `dev-setup` that calls the `registerCRDs` function to create the `Exemptions` CRD.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
```
$ uds run dev-setup
```

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed