### PR TITLE
chore: remove watch and conditional logic around ambient component

### DIFF
--- a/src/pepr/config.ts
+++ b/src/pepr/config.ts
@@ -44,9 +44,6 @@ export const UDSConfig = {
 
   // Track if UDS Core identity-authorization layer is deployed
   isIdentityDeployed: false,
-
-  // Track if Istio Ambient optional components are deployed
-  isAmbientDeployed: false,
 };
 
 // configure subproject logger

--- a/src/pepr/operator/controllers/istio/namespace.spec.ts
+++ b/src/pepr/operator/controllers/istio/namespace.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { K8s, kind } from "pepr";
-import { UDSConfig } from "../../../config";
 import { UDSPackage } from "../../crd";
 import { Mode } from "../../crd/generated/package-v1alpha1";
 import { cleanupNamespace, enableIstio, IstioState, killPods } from "./namespace";

--- a/src/pepr/operator/controllers/istio/namespace.spec.ts
+++ b/src/pepr/operator/controllers/istio/namespace.spec.ts
@@ -48,7 +48,6 @@ describe("enableIstio", () => {
       }
       return { Get: jest.fn() };
     });
-    UDSConfig.isAmbientDeployed = true;
   });
 
   test("should not update when labels have same content but different order", async () => {
@@ -245,49 +244,6 @@ describe("enableIstio", () => {
 
     // This is a cheap way to check if killPods was called
     expect(mockPodGet).toHaveBeenCalled();
-  });
-
-  // Test that ambient mode falls back to sidecar when ambient is not deployed
-  test("ambient package falls back to sidecar when ambient is not available", async () => {
-    // Temporarily set ambient mode to unavailable
-    UDSConfig.isAmbientDeployed = false;
-
-    mockGet.mockResolvedValue({ metadata: { labels: {}, annotations: {}, name: "test-ns" } });
-    const pkg: UDSPackage = {
-      metadata: { namespace: "test-ns", name: "test-pkg" },
-      spec: { network: { serviceMesh: { mode: Mode.Ambient } } },
-    };
-
-    await enableIstio(pkg);
-
-    // Should apply sidecar mode instead of ambient
-    expect(mockApply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          labels: { "istio-injection": "enabled" },
-          annotations: expect.objectContaining({
-            "uds.dev/pkg-test-pkg": "true",
-            "uds.dev/original-istio-state": IstioState.None,
-          }),
-        }),
-      }),
-      { force: true },
-    );
-
-    // Verify warning event was written
-    expect(jest.requireMock("../../reconcilers").writeEvent).toHaveBeenCalledWith(
-      pkg,
-      expect.objectContaining({
-        reason: "AmbientUnavailable",
-        type: "Warning",
-      }),
-    );
-
-    // This is a cheap way to check if killPods was called
-    expect(mockPodGet).toHaveBeenCalled();
-
-    // Restore the original value for other tests
-    UDSConfig.isAmbientDeployed = true;
   });
 
   test("should handle namespace without metadata.labels", async () => {

--- a/src/pepr/operator/controllers/istio/namespace.ts
+++ b/src/pepr/operator/controllers/istio/namespace.ts
@@ -4,11 +4,9 @@
  */
 
 import { K8s, kind, R } from "pepr";
-import { UDSConfig } from "../../../config";
 import { Component, setupLogger } from "../../../logger";
 import { UDSPackage } from "../../crd";
 import { Mode } from "../../crd/generated/package-v1alpha1";
-import { writeEvent } from "../../reconcilers";
 
 // configure subproject logger
 const log = setupLogger(Component.OPERATOR_ISTIO);
@@ -52,25 +50,8 @@ export async function enableIstio(pkg: UDSPackage) {
 
   // Handle labels based on ambient opt-in or sidecar default
   if (pkg.spec?.network?.serviceMesh?.mode === Mode.Ambient) {
-    // Check if ambient mode is available
-    if (!UDSConfig.isAmbientDeployed) {
-      // Ambient mode requested but not available, fall back to sidecar mode
-      log.warn(
-        `Ambient mode requested for package ${pkg.metadata.name} but Ambient is not deployed. Falling back to sidecar mode.`,
-      );
-      await writeEvent(pkg, {
-        message:
-          "Ambient mode requested but Ambient is not deployed. Falling back to sidecar mode.",
-        reason: "AmbientUnavailable",
-        type: "Warning",
-      });
-
-      // Fall back to sidecar mode
-      targetIstioState = IstioState.Sidecar;
-    } else {
-      // Ambient mode is available and requested
-      targetIstioState = IstioState.Ambient;
-    }
+    // Ambient mode requested
+    targetIstioState = IstioState.Ambient;
   } else {
     // Sidecar mode requested/by default
     targetIstioState = IstioState.Sidecar;

--- a/src/pepr/operator/index.ts
+++ b/src/pepr/operator/index.ts
@@ -103,24 +103,6 @@ When(UDSPackage)
     UDSConfig.isIdentityDeployed = false;
   });
 
-// Watch for optional Ambient mode and update config (temporary while ambient components are optional)
-When(a.DaemonSet)
-  .IsCreatedOrUpdated()
-  .InNamespace("istio-system")
-  .WithName("ztunnel")
-  .Watch(() => {
-    log.info("Istio Ambient deployed, operator configured to handle ambient packages.");
-    UDSConfig.isAmbientDeployed = true;
-  });
-When(a.DaemonSet)
-  .IsDeleted()
-  .InNamespace("istio-system")
-  .WithName("ztunnel")
-  .Watch(() => {
-    log.info("Istio Ambient removed, operator will run all packages in sidecar mode.");
-    UDSConfig.isAmbientDeployed = false;
-  });
-
 // Watch for changes to the Nodes and update the Node CIDR list
 if (!UDSConfig.kubeNodeCidrs) {
   When(a.Node).IsCreatedOrUpdated().Reconcile(updateKubeNodesFromCreateUpdate);

--- a/src/pepr/operator/reconcilers/package-reconciler.ts
+++ b/src/pepr/operator/reconcilers/package-reconciler.ts
@@ -72,25 +72,15 @@ export async function packageReconciler(pkg: UDSPackage) {
     await updateStatus(pkg, { phase: Phase.Pending, conditions: getReadinessConditions(false) });
 
     // Get the requested service mesh mode, default to sidecar if not specified
-    const requestedMode = pkg.spec?.network?.serviceMesh?.mode || Mode.Sidecar;
-
-    // Check if ambient mode is requested but not available
-    let effectiveMode = requestedMode;
-    if (requestedMode === Mode.Ambient && !UDSConfig.isAmbientDeployed) {
-      log.warn(
-        `Ambient mode requested for package ${name} but Ambient is not deployed. Using sidecar mode for network policies.`,
-      );
-      effectiveMode = Mode.Sidecar;
-    }
+    const istioMode = pkg.spec?.network?.serviceMesh?.mode || Mode.Sidecar;
 
     // Pass the effective Istio mode to the networkPolicies function
-    const netPol = await networkPolicies(pkg, namespace!, effectiveMode);
+    const netPol = await networkPolicies(pkg, namespace!, istioMode);
 
     const authPol = await generateAuthorizationPolicies(pkg, namespace!);
 
     let endpoints: string[] = [];
     // Update the namespace to enable the expected Istio mode (sidecar or ambient)
-    // Note: enableIstio will also check UDSConfig.isAmbientDeployed and fall back if needed
     await enableIstio(pkg);
 
     let ssoClients = new Map<string, Client>();


### PR DESCRIPTION
## Description

As a result of https://github.com/defenseunicorns/uds-core/pull/1428, we are now guaranteed that the ambient component is deployed with the base layer. The PR removes code that handled "conditional ambient components" with a fallback to sidecar mode if the component was not deployed.

Note: If we did require a revert of the required ambient component for any reason, this PR should be reverted as well (to re-add the handling of conditional ambient).

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [c] Other (security config, docs update, etc)

## Steps to Validate

Tests should adequately cover this change (noting that the fallback test was deleted).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed