### PR TITLE
chore(ci): create additional node for all `single-layer` tests

### DIFF
--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -1,13 +1,17 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
+variables:
+  - name: K3D_EXTRA_ARGS
+    description: "Optionally pass k3d arguments to the default"
+    default: "--servers 2"
 
 tasks:
   - name: create-k3d-cluster
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=github-tags depName=defenseunicorns/uds-k3d versioning=semver
-        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.12.2 --confirm --no-progress"
+        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.12.2 --confirm --no-progress --set k3d_extra_args=\"${K3D_EXTRA_ARGS}\""
 
   - name: k3d-test-cluster
     actions:

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -4,7 +4,7 @@
 variables:
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"
-    default: "--servers 2"
+    default: "--agents 1"
 
 tasks:
   - name: create-k3d-cluster


### PR DESCRIPTION
## Description
We're hitting [CPU constraints](https://github.com/defenseunicorns/uds-core/actions/runs/14375841775/job/40311570748?pr=1448#step:7:11035) in our CI runs. By default, we provision a single node cluster with 4 CPU. This PR changes the default configuration to a two server node k3d cluster. This would add approximately 20 seconds to cluster provisioning time.

Note: This only impacts the clusters used for single layer tests. Tests using the `k3d-slim-dev` or `k3d-standard` bundle will not be impacted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
```
# for default option of one server and one agent
$ uds run -f ./tasks/setup.yaml create-k3d-cluster
# to set additional k3d args
$ uds run -f ./tasks/setup.yaml create-k3d-cluster --set K3D_EXTRA_ARGS="--servers 2 --agents 1"
```

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed