### PR TITLE
chore: reduce sidecar cpu/memory requests for CI single-layer testing

### DIFF
--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -28,6 +28,13 @@ components:
         namespace: istio-system
         valuesFiles:
           - "../values/base-istiod.yaml"
+        variables:
+          - name: PROXY_MEMORY_REQUEST
+            description: "Memory requests for sidecars in cluster"
+            path: "global.proxy.resources.requests.memory"
+          - name: PROXY_CPU_REQUEST
+            description: "CPU requests for sidecars in cluster"
+            path: "global.proxy.resources.requests.cpu"
       - name: uds-global-istio-config
         namespace: istio-system
         version: 0.1.0

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -45,9 +45,9 @@ tasks:
         default: base
         description: The UDS Core layer to deploy
     actions:
-      - description: "Deploy UDS Core Base Layer without Ambient (must set UDS_LAYER environment variable)"
+      - description: "Deploy UDS Core Base Layer"
         if: ${{ eq .inputs.layer "base"}}
-        cmd: uds zarf package deploy build/zarf-package-core-${{ index .inputs "layer" }}-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress --components '*'
+        cmd: uds zarf package deploy build/zarf-package-core-${{ index .inputs "layer" }}-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress --components '*' --set PROXY_MEMORY_REQUEST=40Mi --set PROXY_CPU_REQUEST=10m
       - description: "Deploy a single UDS Core Layer (must set UDS_LAYER environment variable)"
         if: ${{ ne .inputs.layer "base"}}
         cmd: uds zarf package deploy build/zarf-package-core-${{ index .inputs "layer" }}-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress --components '*'


### PR DESCRIPTION
## Description

Adds new zarf vars for the proxy cpu and memory requests. These are overridden in the single-layer testing to ensure these tests still fit on the smaller runners used.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
Run a single layer test, for example:
```console
uds run test-single-layer --set LAYER=runtime-security --set FLAVOR=unicorn
```

Then validate that each pod (that is istio injected) has lower sidecar requests for resources.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed