### PR TITLE
fix: update prometheus-operator to allow TLS 1.2 healthprobes

### DIFF
--- a/src/prometheus-stack/values/values.yaml
+++ b/src/prometheus-stack/values/values.yaml
@@ -56,6 +56,9 @@ prometheus-node-exporter:
   podAnnotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 prometheusOperator:
+  # Kubelet healthprobes on FIPS nodes fail when this is set to 1.3
+  tls:
+    tlsMinVersion: VersionTLS12
   admissionWebhooks:
     patch:
       resources:


### PR DESCRIPTION
## Description

Changes the TLS min protocol version for the operator to 1.2. This is required on some clusters, specifically when the node is in FIPS mode.

While this is environment specific, 1.2 is still an active/valid version and FIPS/most system requirements are 1.2+. If an environment requires 1.3 this could be overridden, however the kubelet would need to support 1.3 healthprobes.

## Related Issue

Issue reported by @joelmccoy when testing 0.40.0 (unicorn and upstream) on FIPS EKS cluster.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed