### PR TITLE
feat: operator ambient mode

### DIFF
--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -90,37 +90,24 @@ components:
             setVariables:
               - name: CNI_BIN_DIR
         after:
-          - description: "Ensure istio-injection is enabled for Pepr"
-            mute: true
-            cmd: "./zarf tools kubectl label namespace pepr-system istio-injection=enabled --overwrite"
-          - description: "Cycle Pepr to ensure enrollment in Istio"
+          - description: "Ensure istio ambient is enabled for Pepr"
+            cmd: "./zarf tools kubectl label namespace pepr-system istio.io/dataplane-mode=ambient --overwrite"
+          - description: "Ensure istio-injection is disabled for Pepr"
+            cmd: "./zarf tools kubectl label namespace pepr-system istio-injection=disabled --overwrite"
+          - description: "Cycle Pepr to refresh connections post-ambient"
             cmd: |
-              # Check if Istio is enabled. The pepr-system namespace should exist because that is added when istio is configured
-              if ! ./zarf tools kubectl get pods -n pepr-system -o jsonpath="{range .items[*]}{.metadata.name}:{range .spec.initContainers[*]}{.name} {end}{range .spec.containers[*]}{.name} {end}{'\n'}{end}" | grep -q 'istio-proxy'; then
-                  # Check if the "pepr-uds-core-watcher" deployment exists before restarting
-                  if ./zarf tools kubectl get deploy -n pepr-system pepr-uds-core-watcher > /dev/null 2>&1; then
-                      ./zarf tools kubectl rollout restart -n pepr-system deploy/pepr-uds-core-watcher
-                  else
-                      echo "Deployment 'pepr-uds-core-watcher' does not exist. Skipping restart."
-                  fi
-
-                  # Check if the "pepr-uds-core" deployment exists before restarting
-                  if ./zarf tools kubectl get deploy -n pepr-system pepr-uds-core > /dev/null 2>&1; then
-                      ./zarf tools kubectl rollout restart -n pepr-system deploy/pepr-uds-core
-                  else
-                      echo "Deployment 'pepr-uds-core' does not exist. Skipping restart."
-                  fi
+              echo "Checking if Pepr pods have sidecars and need restart..."
+              if ./zarf tools kubectl get pods -n pepr-system -o jsonpath="{range .items[*]}{.metadata.name}:{range .spec.initContainers[*]}{.name} {end}{range .spec.containers[*]}{.name} {end}{'\n'}{end}" | grep -q 'istio-proxy'; then
+                echo "Istio sidecar detected, restarting Pepr deployments..."
+                if ./zarf tools kubectl get deploy -n pepr-system pepr-uds-core-watcher > /dev/null 2>&1; then
+                  ./zarf tools kubectl rollout restart -n pepr-system deploy/pepr-uds-core-watcher
+                fi
+                if ./zarf tools kubectl get deploy -n pepr-system pepr-uds-core > /dev/null 2>&1; then
+                  ./zarf tools kubectl rollout restart -n pepr-system deploy/pepr-uds-core
+                fi
+              else
+                echo "No sidecars detected. Pepr pods are already Ambient-compatible. Skipping restart."
               fi
-    # Enable this when ready to switch Core components to use ambient
-    #     after:
-    #       - description: "Ensure istio ambient is enabled for Pepr"
-    #         cmd: "./zarf tools kubectl label namespace pepr-system istio.io/dataplane-mode=ambient --overwrite"
-    #       - description: "Ensure istio-injection is disabled for Pepr"
-    #         cmd: "./zarf tools kubectl label namespace pepr-system istio-injection=disabled --overwrite"
-    #       - description: "Cycle Pepr to refresh connections post-ambient"
-    #         cmd: |
-    #           ./zarf tools kubectl rollout restart -n pepr-system deploy/pepr-uds-core-watcher
-    #           ./zarf tools kubectl rollout restart -n pepr-system deploy/pepr-uds-core
 
   - name: gateway-api-crds
     required: true


### PR DESCRIPTION
## Description
Move operator over to using Ambient Mode. Since there is no package for pepr, this means using actions for configuring the labels of the namespace, specifically setting the `istio-injection=disabled` and `istio.io/dataplane-mode=ambient`. If the namespace is sidecar enabled (cluster upgrades), then we should cycle the pepr pods to utilize Ambient.

Tested:
1. upgrade existing cluster and deploy new cluster
2. setting [this value](https://github.com/defenseunicorns/uds-core/blob/main/src/pepr/uds-operator-config/values.yaml#L21) to explicitly use dynamic_client_registration since we still have that present until next release
3. let cluster sit and do its thing for 3 hours and no kupeapi issues

## Related Issue

Fixes #1420 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- To test upgrade process `uds run test-uds-core-upgrade`
  - check the `pepr-system` namespace before upgrade to make sure its label is still `istio-injection=enabled`
  - on upgrade, namespace should have `istio-injection=disabled`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed