### PR TITLE
fix: update loki images to fips images

### DIFF
--- a/src/loki/values/unicorn-values.yaml
+++ b/src/loki/values/unicorn-values.yaml
@@ -4,7 +4,7 @@
 loki:
   image:
     registry: cgr.dev
-    repository: du-uds-defenseunicorns/loki
+    repository: du-uds-defenseunicorns/loki-fips
     tag: 3.4.3
 gateway:
   image:
@@ -13,5 +13,5 @@ gateway:
     tag: 1.27.5
 memcached:
   image:
-    repository: cgr.dev/du-uds-defenseunicorns/memcached
+    repository: cgr.dev/du-uds-defenseunicorns/memcached-fips
     tag: 1.6.38

--- a/src/loki/zarf.yaml
+++ b/src/loki/zarf.yaml
@@ -51,6 +51,6 @@ components:
         valuesFiles:
           - ./values/unicorn-values.yaml
     images:
-      - cgr.dev/du-uds-defenseunicorns/loki:3.4.3
+      - cgr.dev/du-uds-defenseunicorns/loki-fips:3.4.3
       - cgr.dev/du-uds-defenseunicorns/nginx-fips:1.27.5
-      - cgr.dev/du-uds-defenseunicorns/memcached:1.6.38
+      - cgr.dev/du-uds-defenseunicorns/memcached-fips:1.6.38


### PR DESCRIPTION
## Description
we noticed that chainguard has loki fips images, so updating those to default to fips enabled images.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed