### PR TITLE
fix(ci): permissions on release workflow

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -57,5 +57,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: write
     uses: ./.github/workflows/checkpoint.yaml
     secrets: inherit


### PR DESCRIPTION
## Description

Checkpoint requires PR write for renovate readiness, so any calling workflows also need that - https://github.com/defenseunicorns/uds-core/actions/runs/14716497538

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Should run tag/release when this hits main.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed