### PR TITLE
fix: unconditionally mutate neuvector probes

### DIFF
--- a/src/pepr/patches/index.ts
+++ b/src/pepr/patches/index.ts
@@ -53,7 +53,7 @@ When(a.DaemonSet)
       container => container.name === "neuvector-enforcer-pod",
     );
 
-    if (enforcerContainer && enforcerContainer.livenessProbe === undefined) {
+    if (enforcerContainer) {
       log.debug("Patching NeuVector Enforcer Daemonset to add livenessProbe");
       const livenessProbe = {
         tcpSocket: { port: 8500 },
@@ -63,7 +63,7 @@ When(a.DaemonSet)
       enforcerContainer.livenessProbe = livenessProbe;
     }
 
-    if (enforcerContainer && enforcerContainer.readinessProbe === undefined) {
+    if (enforcerContainer) {
       log.debug("Patching NeuVector Enforcer Daemonset to add readinessProbe");
       const readinessProbe = {
         tcpSocket: { port: 8500 },
@@ -88,7 +88,7 @@ When(a.Deployment)
       container => container.name === "neuvector-controller-pod",
     );
 
-    if (controllerContainer && controllerContainer.readinessProbe) {
+    if (controllerContainer) {
       log.debug("Patching NeuVector Controller deployment to modify readinessProbe");
       const readinessProbe = {
         // Probe default port for controller REST API server


### PR DESCRIPTION
## Description

Core 0.41.0 made a change to the mutated probes on the NeuVector enforcer and controller, however these changes were not showing up as expected in upgrades - with the older probes sometimes showing up.

This changes ensures that probes are always mutated/set to the expected contents. This is OK since these probes are not exposed upstream as values, so the only way they would get set is by Pepr.

## Related Issue

Reported issue in Slack.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
Test the upgrade path:
```console
# Deploy 0.40.0
uds deploy ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-demo:0.40.0 --confirm
# Create from this branch
uds run -f tasks/create.yaml standard-package
uds run -f tasks/create.yaml k3d-standard-bundle
# Deploy the core package from the bundle
uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-*-0.41.0.tar.zst --packages core
```

Validate the probes post-upgrade (they should be as follows):
```console
❯ k get ds -n neuvector neuvector-enforcer-pod -o jsonpath='{.spec.template.spec.containers[].livenessProbe}'
{"failureThreshold":3,"periodSeconds":30,"successThreshold":1,"tcpSocket":{"port":8500},"timeoutSeconds":1}                                                                     
❯ k get ds -n neuvector neuvector-enforcer-pod -o jsonpath='{.spec.template.spec.containers[].readinessProbe}'
{"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":30,"successThreshold":1,"tcpSocket":{"port":8500},"timeoutSeconds":1}                                            
```

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed