### PR TITLE
feat!: enable Keycloak FIPS mode by default

### DIFF
--- a/.github/bundles/rke2/uds-bundle.yaml
+++ b/.github/bundles/rke2/uds-bundle.yaml
@@ -98,3 +98,44 @@ packages:
             - name: LOKI_IRSA_ROLE_ARN
               description: "The irsa role annotation"
               path: serviceAccount.annotations.irsa/role-arn
+      grafana:
+        grafana:
+          variables:
+            - name: GRAFANA_HA
+              description: Enable HA Grafana
+              path: autoscaling.enabled
+        uds-grafana-config:
+          variables:
+            - name: GRAFANA_PG_HOST
+              description: Grafana postgresql host
+              path: postgresql.host
+            - name: GRAFANA_PG_PORT
+              description: Grafana postgresql port
+              path: postgresql.port
+            - name: GRAFANA_PG_DATABASE
+              description: Grafana postgresql database
+              path: postgresql.database
+            - name: GRAFANA_PG_PASSWORD
+              description: Grafana postgresql password
+              path: postgresql.password
+              sensitive: true
+            - name: GRAFANA_PG_USER
+              description: Grafana postgresql username
+              path: postgresql.user
+      keycloak:
+        keycloak:
+          values:
+            - path: devMode
+              value: false
+            - path: autoscaling.enabled
+              value: true
+          variables:
+            - name: KEYCLOAK_DB_HOST
+              path: postgresql.host
+            - name: KEYCLOAK_DB_USERNAME
+              path: postgresql.username
+            - name: KEYCLOAK_DB_DATABASE
+              path: postgresql.database
+            - name: KEYCLOAK_DB_PASSWORD
+              path: postgresql.password
+              sensitive: true

--- a/.github/test-infra/aws/rke2/data.tf
+++ b/.github/test-infra/aws/rke2/data.tf
@@ -24,3 +24,10 @@ data "aws_ami" "rhel_rke2" {
   owners      = [var.uds_images_aws_account_id]
 }
 
+data "aws_subnets" "rds_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.vpc.id]
+  }
+}
+

--- a/.github/test-infra/aws/rke2/main.tf
+++ b/.github/test-infra/aws/rke2/main.tf
@@ -61,6 +61,11 @@ resource "aws_kms_key" "s3_encryption_key" {
   deletion_window_in_days = 7
 }
 
+# RDS random secret name
+resource "random_id" "unique_id" {
+  byte_length = 4
+}
+
 #######################################
 # Compute Resources
 #######################################

--- a/.github/test-infra/aws/rke2/outputs.tf
+++ b/.github/test-infra/aws/rke2/outputs.tf
@@ -49,6 +49,46 @@ output "velero_irsa_role_arn" {
   value     = module.storage.irsa["velero"].bucket_role.arn
 }
 
-output "grafana_ha" {
-  value = false
+output "grafana_pg_host" {
+  sensitive   = true
+  description = "RDS Endpoint for Grafana"
+  value       = element(split(":", module.dbs["grafana"].db_instance_endpoint), 0)
+}
+
+output "grafana_pg_database" {
+  description = "Database name for Grafana"
+  value       = var.databases["grafana"].name
+}
+
+output "grafana_pg_user" {
+  description = "Database username for Grafana"
+  value       = var.databases["grafana"].username
+}
+
+output "grafana_pg_password" {
+  description = "RDS Password for Grafana"
+  value       = random_password.db_passwords["grafana"].result
+  sensitive   = true
+}
+
+output "keycloak_db_host" {
+  sensitive   = true
+  description = "RDS Endpoint for Keycloak"
+  value       = element(split(":", module.dbs["keycloak"].db_instance_endpoint), 0)
+}
+
+output "keycloak_db_database" {
+  description = "Database name for Keycloak"
+  value       = var.databases["keycloak"].name
+}
+
+output "keycloak_db_username" {
+  description = "Database username for Keycloak"
+  value       = var.databases["keycloak"].username
+}
+
+output "keycloak_db_password" {
+  description = "RDS Password for Keycloak"
+  value       = random_password.db_passwords["keycloak"].result
+  sensitive   = true
 }

--- a/.github/test-infra/aws/rke2/rds.tf
+++ b/.github/test-infra/aws/rke2/rds.tf
@@ -1,0 +1,87 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+resource "random_password" "db_passwords" {
+  for_each = var.databases
+
+  length  = 16
+  special = true
+  upper = true
+  lower = true
+  override_special = "#$"
+}
+
+resource "aws_secretsmanager_secret" "db_secrets" {
+  for_each = var.databases
+
+  name                    = "${each.value.name}-db-secret-${random_id.unique_id.hex}"
+  description             = "DB authentication token for ${each.value.name}"
+  recovery_window_in_days = var.recovery_window
+}
+
+resource "aws_secretsmanager_secret_version" "db_secret_values" {
+  for_each = var.databases
+
+  depends_on    = [aws_secretsmanager_secret.db_secrets]
+  secret_id     = aws_secretsmanager_secret.db_secrets[each.key].id
+  secret_string = random_password.db_passwords[each.key].result
+}
+
+module "dbs" {
+  source  = "terraform-aws-modules/rds/aws"
+  version = "6.12.0"
+
+  for_each = var.databases
+
+  identifier                     = "${var.name}-${each.value.name}-db"
+  instance_use_identifier_prefix = true
+
+  allocated_storage       = each.value.allocated_storage
+  backup_retention_period = 1
+  backup_window           = "03:00-06:00"
+  maintenance_window      = "Mon:00:00-Mon:03:00"
+  skip_final_snapshot     = true
+
+  engine               = "postgres"
+  engine_version       = each.value.engine_version
+  major_engine_version = split(".", each.value.engine_version)[0]
+  family               = each.value.family
+  instance_class       = each.value.instance_class
+
+  db_name  = each.value.name
+  username = each.value.username
+  port     = each.value.port
+
+  subnet_ids                  = data.aws_subnets.rds_subnets.ids
+  create_db_subnet_group      = true
+  create_db_parameter_group   = false
+  manage_master_user_password = false
+  password                    = random_password.db_passwords[each.key].result
+
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+
+  depends_on = [
+    aws_security_group.rds_sg
+  ]
+}
+
+resource "aws_security_group" "rds_sg" {
+  vpc_id = data.aws_vpc.vpc.id
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_ingress" {
+  security_group_id = aws_security_group.rds_sg.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = "tcp"
+  from_port   = 0
+  to_port     = 5432
+}

--- a/.github/test-infra/aws/rke2/uds-config.tf
+++ b/.github/test-infra/aws/rke2/uds-config.tf
@@ -22,11 +22,15 @@ resource "local_sensitive_file" "uds_config" {
         "velero_bucket_credential_name" : "",
         "velero_bucket_credential_key" : "",
         "grafana_ha" : false,
-        "grafana_pg_host" : "\"\"",
-        "grafana_pg_port" : "\"\"",
-        "grafana_pg_database" : "\"\"",
-        "grafana_pg_password" : "\"\"",
-        "grafana_pg_user" : "\"\"",
+        "grafana_pg_host" : element(split(":", module.dbs["grafana"].db_instance_endpoint), 0),
+        "grafana_pg_port" : var.databases["grafana"].port,
+        "grafana_pg_database" : var.databases["grafana"].name,
+        "grafana_pg_password" : random_password.db_passwords["grafana"].result,
+        "grafana_pg_user" : var.databases["grafana"].username,
+        "keycloak_db_host" : element(split(":", module.dbs["keycloak"].db_instance_endpoint), 0),
+        "keycloak_db_username" : var.databases["keycloak"].username,
+        "keycloak_db_database" : var.databases["keycloak"].name,
+        "keycloak_db_password" : random_password.db_passwords["keycloak"].result
       }
       "init" : {
         # Disabled to prevent scaling timing issues with image pushes

--- a/.github/test-infra/aws/rke2/variables.tf
+++ b/.github/test-infra/aws/rke2/variables.tf
@@ -6,6 +6,11 @@ variable "environment" {
   default     = "ci"
 }
 
+variable "name" {
+  description = "Name for cluster"
+  type        = string
+}
+
 variable "vpc_name" {
   type        = string
   description = "VPC ID to deploy into"
@@ -86,6 +91,39 @@ variable "use_permissions_boundary" {
 
 variable "permissions_boundary_name" {
   description = "The name of the permissions boundary for IAM resources.  This will be used for tagging and to build out the ARN."
+}
+
+variable "databases" {
+  description = "Map of database configurations"
+  type = map(object({
+    name              = string
+    port              = number
+    username          = string
+    engine_version    = string
+    family            = string
+    allocated_storage = number
+    instance_class    = string
+  }))
+  default = {
+    grafana = {
+      name              = "grafana"
+      port              = 5432
+      username          = "grafana"
+      engine_version    = "16.8"
+      family            = "postgres16"
+      allocated_storage = 20
+      instance_class    = "db.t4g.large"
+    },
+    keycloak = {
+      name              = "keycloak"
+      port              = 5432
+      username          = "keycloak"
+      engine_version    = "16.8"
+      family            = "postgres16"
+      allocated_storage = 20
+      instance_class    = "db.t4g.large"
+    }
+  }
 }
 
 variable "recovery_window" {

--- a/.github/workflows/test-nightly.yaml
+++ b/.github/workflows/test-nightly.yaml
@@ -1,0 +1,50 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+name: Test Nightly
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Every night at Midnight (UTC)
+  pull_request:
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    # labeled is added to support renovate-ready labelling on PRs
+    types: [milestoned, labeled, opened, reopened, synchronize]
+    paths:
+      - src/keycloak/**
+      - src/grafana/**
+
+permissions:
+  contents: read
+  id-token: write # This is needed for OIDC federation.
+  packages: read # Allows reading the published GHCR packages
+
+jobs:
+  test-nightly:
+    runs-on: uds-ubuntu-big-boy-8-core
+    timeout-minutes: 40
+    name: Test Nightly
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Environment setup
+        uses: ./.github/actions/setup
+        with:
+          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
+          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
+          ghToken: ${{ secrets.GITHUB_TOKEN }}
+          chainguardIdentity: ${{ secrets.CHAINGUARD_IDENTITY }}
+
+      - name: Test UDS Core Upgrade
+        run: uds run test-uds-core-ha-upgrade --set FLAVOR=upstream --no-progress
+
+      - name: Debug Output
+        if: ${{ always() }}
+        uses: ./.github/actions/debug-output
+
+      - name: Save logs
+        if: always()
+        uses: ./.github/actions/save-logs
+        with:
+          suffix: -nightly-upstream

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -48,6 +48,7 @@ jobs:
           echo "UDS_CLUSTER_NAME=uds-ci-${{ matrix.flavor }}-${SHA:0:7}" >> $GITHUB_ENV
           echo "UDS_STATE_KEY="tfstate/ci/install/${SHA:0:7}-rke2-core-${{ matrix.flavor }}-aws.tfstate >> $GITHUB_ENV
           echo "TF_VAR_region=${UDS_REGION}" >> $GITHUB_ENV
+          echo "TF_VAR_name=uds-ci-${{ matrix.flavor }}-${SHA:0:7}" >> $GITHUB_ENV
           echo "TF_VAR_run_id=$GITHUB_RUN_ID" >> $GITHUB_ENV
           echo "TF_VAR_use_permissions_boundary=true" >> $GITHUB_ENV
           echo "TF_VAR_permissions_boundary_name=${UDS_PERMISSIONS_BOUNDARY_NAME}" >> $GITHUB_ENV

--- a/docs/dev/ci-testing.md
+++ b/docs/dev/ci-testing.md
@@ -23,16 +23,6 @@ Where: k3d
 
 What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled
 
-### "Full Core" HA Install
-
-This tests validates an install of the `k3d-core-demo` bundle in HA mode. The demo bundles includes all functional layers and components in Core, so this test provides full coverage of all applications.
-
-When: Nightly (2AM UTC)
-
-Where: k3d
-
-What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled using [HA Config](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-ha-config.yaml)
-
 ### "Full Core" Upgrade
 
 In order to ensure we catch any breaking changes across upgrades we also run an upgrade test of Core. This test deploys the latest release of the `k3d-core-demo` bundle, then upgrades to the version of core built from the PR branch. This test includes all functional layers and components in Core.
@@ -42,16 +32,6 @@ When: On all PRs
 Where: k3d
 
 What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled, upgrade tested from latest release
-
-### "Full Core" HA Upgrade
-
-In order to ensure we catch any breaking changes across upgrades with HA we also run an upgrade test of Core in HA mode. This test deploys the latest release of the `k3d-core-demo` HA bundle, then upgrades to the version of core built from the PR branch. This test includes all functional layers and components in Core.
-
-When: Nightly (2AM UTC)
-
-Where: k3d
-
-What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled, using [HA Config](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-ha-config.yaml), upgrade tested from latest release
 
 ### "Single Layer"
 

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -123,7 +123,7 @@ smtp:
   port: 587
 
 # Configure FIPS mode for Keycloak
-fips: false
+fips: true
 # By default, Keycloak requires 14+ character passwords in FIPS mode. This switch disables this requirement.
 fipsAllowWeakPasswords: false
 


### PR DESCRIPTION
## Description

This Pull Request enables Keycloak FIPS mode by default.

In addition, this Pull Request introduces the RKE2 tests with Keycloak HA testing

## Related Issue

Fixes https://github.com/defenseunicorns/uds-identity-config/issues/36
Fixes https://github.com/defenseunicorns/uds-core/issues/1549
Relates to https://github.com/defenseunicorns/uds-core/issues/728

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Tested automatically 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed

BEGIN_COMMIT_OVERRIDE
feat!: enable Keycloak FIPS mode by default (#1518)

BREAKING CHANGE: UDS Core now uses Keycloak in FIPS (STRICT) mode by default (the `fips` Helm Chart flag is set to `true` by default). In some environments, this may be a breaking change that could result in the Keycloak Administrator account being locked out. Before upgrading, please ensure you have read and followed the [UDS Identity v0.14.0 upgrade guide](https://uds.defenseunicorns.com/reference/uds-core/idam/upgrading-versions/#v0140).
END_COMMIT_OVERRIDE