### PR TITLE
chore(doc): remove keycloak prereq

### DIFF
--- a/docs/reference/UDS Core/prerequisites.md
+++ b/docs/reference/UDS Core/prerequisites.md
@@ -122,35 +122,6 @@ uds zarf package deploy uds-core --set CNI_CONF_DIR=/etc/cni/net.d --set CNI_BIN
 
 If you are using Cilium you will also need to make some additional configuration changes and add a cluster wide network policy to prevent Cilium's CNI from interfering with the Istio CNI plugin (part of the ambient stack). See the [upstream documentation](https://istio.io/latest/docs/ambient/install/platform-prerequisites/#cilium) for these required changes.
 
-#### Keycloak
-
-It has been reported that some versions of Keycloak crash on Apple M4 Macbooks (the issue is tracked by [#1309](https://github.com/defenseunicorns/uds-core/issues/1309)). In order to apply a workaround for both [`K3d Slim Dev`](https://github.com/defenseunicorns/uds-core/tree/main/bundles/k3d-slim-dev) and [`k3d Core`](https://github.com/defenseunicorns/uds-core/tree/main/bundles/k3d-standard) bundles, you have to override the `KEYCLOAK_HEAP_OPTIONS` variable and apply the `-XX:UseSVE=0 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G` value, for example:
-
-```console
-uds deploy k3d-core-slim-dev:0.37.0 --set KEYCLOAK_HEAP_OPTIONS="-XX:UseSVE=0 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G" --confirm
-```
-
-Similar overrides might be applied to the UDS Bundle overrides section. Please note that `-XX:MaxRAM` should be equal to the memory limits as this workaround leverages a very similar approach to overriding Keycloak Java Heap settings. Here's an example:
-
-```yaml
-packages:
-  - name: core
-    repository: oci://ghcr.io/defenseunicorns/packages/uds/core
-    ref: x.x.x
-    overrides:
-      keycloak:
-        keycloak:
-          values:
-            # Override Java memory settings
-            - path: env
-              value:
-                - name: JAVA_OPTS_KC_HEAP
-                  value: "-XX:UseSVE=0 -XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=2G"
-            # Override limits - both figures need to match!
-            - path: resources.limits.memory
-              value: "2Gi"
-```
-
 #### NeuVector
 
 NeuVector historically has functioned best when the host is using cgroup v2. Cgroup v2 is enabled by default on many modern Linux distributions, but you may need to enable it depending on your operating system. Enabling this tends to be OS specific, so you will need to evaluate this for your specific hosts.


### PR DESCRIPTION
## Description
Validated that newer releases of uds-core that include keycloak 26.2 or later no longer cause JAVA HEAP issues.

## Related Issue

Fixes #1309 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed