### PR TITLE
fix: errors on re-creating checkpoint cluster due to leftover files

### DIFF
--- a/packages/checkpoint-dev/zarf.yaml
+++ b/packages/checkpoint-dev/zarf.yaml
@@ -37,6 +37,13 @@ components:
             description: "Destroy the cluster"
           - cmd: |
               sudo rm -rf data
+          - cmd: |
+              if [ -z "$TMPDIR" ]; then
+                #  macOS sets TMPDIR to a user temp directory - this also provides more options to linux
+                TMPDIR="/tmp"
+              fi
+              DATA_DIR="${TMPDIR}/uds-checkpoint-data"
+              sudo rm -rf "$DATA_DIR"
 
   - name: create-cluster
     required: true


### PR DESCRIPTION
## Description

On linux, sometimes when redeploying checkpoint an error will be thrown by tar like:

```sh
     tar: ./k3s_data/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/54/fs/sbin: Cannot create symlink to ‘usr/bin’: File exists                                                                                                                                          
     tar: ./k3s_data/agent/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/54/fs/bin: Cannot create symlink to ‘usr/bin’: File exists                                                                                                                                           
     tar: Exiting with failure status due to previous errors
```

I've been manually running `rm -rf /tmp/uds-checkpoint-data/` on my machine but it seems like this is just something that should be run on deploy regardless. The logic was already there for onCreate so I'm not sure if that was intentional or not so I just also added it to an onDeploy step.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed