### PR TITLE
fix: keycloak clustering

### DIFF
--- a/src/keycloak/chart/templates/istio-peer-auth.yaml
+++ b/src/keycloak/chart/templates/istio-peer-auth.yaml
@@ -10,4 +10,43 @@ metadata:
 spec:
   mtls:
     mode: STRICT
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+  portLevelMtls:
+    # Keycloak 26.2.0 introduced transport layer encryption for cache (Infinispan) connections. This requires
+    # to disable mTLS at Istio layer
+    # See:
+    # - https://www.keycloak.org/server/caching#_running_inside_a_service_mesh
+    # - https://github.com/keycloak/keycloak/issues/39454
+    "7800":
+      mode: PERMISSIVE
+    # Below array of ports is required as JGroups probe the entire range of Transport Ports with DNS_PING.
+    # Other cluster members might listen on any of them.
+    # See:
+    # - https://github.com/belaban/JGroups/blob/master/src/org/jgroups/protocols/dns/DNS_PING.java#L168-L169
+    # - Trace logs from a living cluster:
+    #   2025-05-06 07:34:23,226 DEBUG [org.jgroups.protocols.dns.DNS_PING] () keycloak-2-51586: sending discovery requests to hosts [10.42.0.71:0, 10.42.0.72:0, 10.42.0.73:0] on ports [7800 .. 7810]
+    # This will go away once we switch to JDBC_PING2
+    "7801":
+      mode: PERMISSIVE
+    "7802":
+      mode: PERMISSIVE
+    "7803":
+      mode: PERMISSIVE
+    "7804":
+      mode: PERMISSIVE
+    "7805":
+      mode: PERMISSIVE
+    "7806":
+      mode: PERMISSIVE
+    "7807":
+      mode: PERMISSIVE
+    "7808":
+      mode: PERMISSIVE
+    "7809":
+      mode: PERMISSIVE
+    "7810":
+      mode: PERMISSIVE
+
 {{- end }}

--- a/src/keycloak/chart/templates/istio-peer-auth.yaml
+++ b/src/keycloak/chart/templates/istio-peer-auth.yaml
@@ -21,32 +21,4 @@ spec:
     # - https://github.com/keycloak/keycloak/issues/39454
     "7800":
       mode: PERMISSIVE
-    # Below array of ports is required as JGroups probe the entire range of Transport Ports with DNS_PING.
-    # Other cluster members might listen on any of them.
-    # See:
-    # - https://github.com/belaban/JGroups/blob/master/src/org/jgroups/protocols/dns/DNS_PING.java#L168-L169
-    # - Trace logs from a living cluster:
-    #   2025-05-06 07:34:23,226 DEBUG [org.jgroups.protocols.dns.DNS_PING] () keycloak-2-51586: sending discovery requests to hosts [10.42.0.71:0, 10.42.0.72:0, 10.42.0.73:0] on ports [7800 .. 7810]
-    # This will go away once we switch to JDBC_PING2
-    "7801":
-      mode: PERMISSIVE
-    "7802":
-      mode: PERMISSIVE
-    "7803":
-      mode: PERMISSIVE
-    "7804":
-      mode: PERMISSIVE
-    "7805":
-      mode: PERMISSIVE
-    "7806":
-      mode: PERMISSIVE
-    "7807":
-      mode: PERMISSIVE
-    "7808":
-      mode: PERMISSIVE
-    "7809":
-      mode: PERMISSIVE
-    "7810":
-      mode: PERMISSIVE
-
 {{- end }}

--- a/src/keycloak/chart/templates/uds-package.yaml
+++ b/src/keycloak/chart/templates/uds-package.yaml
@@ -79,11 +79,39 @@ spec:
         remoteGenerated: IntraNamespace
         ports:
           - 7800
+          # Below array of ports is required as JGroups probe the entire range of Transport Ports with DNS_PING.
+          # Other cluster members might listen on any of them.
+          # See:
+          # - https://github.com/belaban/JGroups/blob/master/src/org/jgroups/protocols/dns/DNS_PING.java#L168-L169
+          # - Trace logs from a living cluster:
+          #   2025-05-06 07:34:23,226 DEBUG [org.jgroups.protocols.dns.DNS_PING] () keycloak-2-51586: sending discovery requests to hosts [10.42.0.71:0, 10.42.0.72:0, 10.42.0.73:0] on ports [7800 .. 7810]
+          # This will go away once we switch to JDBC_PING2
+          - 7801
+          - 7802
+          - 7803
+          - 7804
+          - 7805
+          - 7806
+          - 7807
+          - 7808
+          - 7809
+          - 7810
           - 57800
       - direction: Egress
         remoteGenerated: IntraNamespace
         ports:
           - 7800
+          # Below array of ports is required as JGroups probe the entire range of Transport Ports with DNS_PING.
+          - 7801
+          - 7802
+          - 7803
+          - 7804
+          - 7805
+          - 7806
+          - 7807
+          - 7808
+          - 7809
+          - 7810
           - 57800
       {{- end }}
 


### PR DESCRIPTION
## Description

This Pull Request fixes Keycloak clustering. 

The solution has been on https://www.keycloak.org/server/caching#_running_inside_a_service_mesh and incorporates additional ports that are used by DNS_PING while probing other cluster members. They need to be added to the allow list to prevent failures in FIPS mode. 

This issue is also tested in parallel in FIPS mode here: https://github.com/defenseunicorns/uds-core/pull/1518

The implementation details have been also discussed here: https://github.com/keycloak/keycloak/issues/39454#issuecomment-2854194344

## Related Issue

Fixes #1525

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

1. Run `uds run test-uds-core-ha`
2. Ensure the tests are passing
3. Check the output of `kubectl logs keycloak-2 -n keycloak -f | grep -i "view"`. It should contain 3 members.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed