### PR TITLE
fix: add support for client name in pepr types

### DIFF
--- a/src/grafana/chart/templates/uds-package.yaml
+++ b/src/grafana/chart/templates/uds-package.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   sso:
-    - name: Grafana Dashboard
+    - name: Grafana
       clientId: uds-core-admin-grafana
       redirectUris:
         {{- if .Values.adminDomain }}

--- a/src/neuvector/chart/templates/uds-package.yaml
+++ b/src/neuvector/chart/templates/uds-package.yaml
@@ -19,7 +19,7 @@ spec:
   #     description: "Metrics"
 
   sso:
-    - name: Neuvector
+    - name: NeuVector
       clientId: uds-core-admin-neuvector
       redirectUris:
         {{- if .Values.adminDomain }}

--- a/src/pepr/operator/controllers/keycloak/authservice/authservice.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/authservice.spec.ts
@@ -19,6 +19,7 @@ describe("authservice", () => {
 
     mockClient = {
       clientId: "test-client",
+      name: "test",
       redirectUris: ["https://foo.uds.dev/login"],
       secret: "test-secret",
       alwaysDisplayInConsole: false,

--- a/src/pepr/operator/controllers/keycloak/client-sync.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/client-sync.spec.ts
@@ -27,6 +27,7 @@ const mockClient: Client = {
   frontchannelLogout: true,
   fullScopeAllowed: true,
   implicitFlowEnabled: true,
+  name: "Test Client",
   nodeReRegistrationTimeout: 1,
   notBefore: 1,
   optionalClientScopes: [],
@@ -56,6 +57,7 @@ const mockClientStringified: Record<string, string> = {
   frontchannelLogout: "true",
   fullScopeAllowed: "true",
   implicitFlowEnabled: "true",
+  name: "Test Client",
   nodeReRegistrationTimeout: "1",
   notBefore: "1",
   optionalClientScopes: "[]",
@@ -152,6 +154,7 @@ describe("convertSsoToClient function", () => {
 
     const expectedClient: Partial<Client> = {
       clientId: "test-client",
+      name: "Test Client",
       attributes: { "uds.core.groups": "" },
     };
 
@@ -190,6 +193,7 @@ describe("convertSsoToClient function", () => {
       },
       defaultClientScopes: ["scope1", "scope2"],
       enabled: true,
+      name: "Test Client",
       publicClient: true,
       redirectUris: ["https://example.com/callback"],
       secret: "secret",
@@ -211,6 +215,7 @@ describe("convertSsoToClient function", () => {
 
     const expectedClient: Partial<Client> = {
       clientId: "test-client",
+      name: "Test Client",
       attributes: { "uds.core.groups": '{"anyOf":[]}' },
       registrationAccessToken: undefined,
       samlIdpCertificate: undefined,
@@ -228,6 +233,7 @@ describe("convertSsoToClient function", () => {
 
     const expectedClient: Partial<Client> = {
       clientId: "test-client",
+      name: "Test Client",
       attributes: { "uds.core.groups": "" },
     };
 
@@ -266,6 +272,7 @@ describe("convertSsoToClient function", () => {
       },
       defaultClientScopes: ["scope1", "scope2"],
       enabled: true,
+      name: "Test Client",
       publicClient: true,
       redirectUris: ["https://example.com/callback"],
       secret: "secret",

--- a/src/pepr/operator/controllers/keycloak/types.ts
+++ b/src/pepr/operator/controllers/keycloak/types.ts
@@ -20,6 +20,7 @@ export interface Client {
   frontchannelLogout: boolean;
   fullScopeAllowed: boolean;
   implicitFlowEnabled: boolean;
+  name: string;
   nodeReRegistrationTimeout: number;
   notBefore: number;
   optionalClientScopes: string[];
@@ -53,6 +54,7 @@ export const clientKeys = [
   "frontchannelLogout",
   "fullScopeAllowed",
   "implicitFlowEnabled",
+  "name",
   "nodeReRegistrationTimeout",
   "notBefore",
   "optionalClientScopes",


### PR DESCRIPTION
## Description

Name has been supported in the SSO spec, but was missing from our client types in the pepr code.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Deploy with a package CR using sso.name and validate that the name is populated in Keycloak.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed