### PR TITLE
feat: add saml_idp_initiated_sso_url_name to allowed keycloak attributes

### DIFF
--- a/docs/reference/configuration/Single Sign-On/sso-client-validation.md
+++ b/docs/reference/configuration/Single Sign-On/sso-client-validation.md
@@ -19,3 +19,4 @@ The `sso.attributes` part of the [UDS Package CR](/reference/configuration/custo
 - saml_assertion_consumer_url_redirect
 - saml_single_logout_service_url_post
 - saml_single_logout_service_url_redirect
+- saml_idp_initiated_sso_url_name

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -142,7 +142,7 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
     "saml_assertion_consumer_url_redirect",
     "saml_single_logout_service_url_post",
     "saml_single_logout_service_url_redirect",
-    "saml_idp_initiated_sso_url_name"
+    "saml_idp_initiated_sso_url_name",
   ]);
 
   for (const client of ssoClients) {

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -142,6 +142,7 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
     "saml_assertion_consumer_url_redirect",
     "saml_single_logout_service_url_post",
     "saml_single_logout_service_url_redirect",
+    "saml_idp_initiated_sso_url_name"
   ]);
 
   for (const client of ssoClients) {


### PR DESCRIPTION
## Description
Add `saml_idp_initiated_sso_url_name` to allowed keycloak attributes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed