### PR TITLE
fix: keycloak sts devmode db settings

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -163,6 +163,8 @@ spec:
               value: TRACE
             - name: QUARKUS_LOG_CATEGORY__ORG_KEYCLOAK_CRYPTO__LEVEL
               value: TRACE
+          {{- end }}
+          {{- if .Values.devMode }}
             # https://github.com/keycloak/keycloak/issues/39046
             # Starting from 26.2.0, Keycloak doesn't use password for the internal H2 database.
             # This breaks upgrade scenarios, so we need to use the same password as in 26.1.x


### PR DESCRIPTION
## Description

The DB overrides mistakenly were getting set when debugMode was on, causing issues with postgres/non-devmode setups.

This moves the `KC_DB` overrides to a separate conditional ONLY for devMode to ensure that they do not cause issues if `KC_DB` overrides are set separately (non dev mode, postgres).

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed