### PR TITLE
chore: switch gateway crd install to release artifacts

### DIFF
--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -114,8 +114,4 @@ components:
     manifests:
       - name: gateway-api-crds
         files:
-          - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-          - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-          - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-          - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-          - https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.3.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+          - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml


### PR DESCRIPTION
## Description

Switches from the 5 independent manifests (from github raw) to the single release artifact for standard install.

May help mitigate some of the issues with https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/

Already captured by renovate via https://github.com/defenseunicorns/uds-common/blob/main/config/renovate.json5#L89-L101

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

CI should validate install/upgrade. Can also "manually" validate the same CRDs are present in cluster.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed