### PR TITLE
chore: change default cve scan severity to negligible

### DIFF
--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -46,7 +46,7 @@ jobs:
         run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
       - name: Scan latest unicorn package
-        # This task uses the defaults of latest version, unicorn flavor, core package, and high severity
+        # This task uses the defaults of latest version, unicorn flavor, core package, and negligible severity
         run: uds run -f tasks/scan.yaml
 
       # Only upload artifacts for PR runs

--- a/tasks/scan.yaml
+++ b/tasks/scan.yaml
@@ -16,7 +16,7 @@ variables:
     default: core
   - name: MIN_SEVERITY
     description: "The minimum severity level for CVEs to report"
-    default: "High"
+    default: "Negligible"
 
 tasks:
   - name: default


### PR DESCRIPTION
## Description

Changes the default "minimum severity" in the task to include all CVEs (negligible is the lowest). This would also change our workflow/nightly scans (and the associated github issue) since that assumes the default task variables.

Note that this would still sum the total high/critical for a quick "at a glance" review of our posture, as well as providing the per-image details (with specific severities being searchable via `ctrl-f` on the page).

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Run the scan task, validate success and that unknown/negligible vulns are shown (if they exist).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed