### PR TITLE
chore(ci): add HA install and upgrade nightly tests

### DIFF
--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+name: UDS Core Install/Upgrade HA Test
+
+on:
+  schedule:
+    # Runs every morning at 2:00 AM UTC
+    - cron: '0 2 * * *'
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+
+jobs:
+  uds-core-ha-upgrade-nightly:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flavor: [upstream, registry1, unicorn]
+
+    name: Run HA Install/Upgrade Test for ${{ matrix.flavor }}
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Environment setup
+        uses: ./.github/actions/setup
+        with:
+          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
+          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
+          ghToken: ${{ secrets.GITHUB_TOKEN }}
+          chainguardIdentity: ${{ secrets.CHAINGUARD_IDENTITY }}
+
+      - name: Run UDS Core Install HA Test
+        run: uds run uds-core-upgrade --set FLAVOR=${{ matrix.flavor }} --no-progress
+
+      - name: Run UDS Core Upgrade HA Test
+        run: uds run uds-core-ha-upgrade --set FLAVOR=${{ matrix.flavor }} --no-progress

--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -21,7 +21,7 @@ jobs:
   uds-core-ha-upgrade-nightly:
     runs-on: uds-ubuntu-big-boy-8-core
     timeout-minutes: 45
-    name: HA Install/Upgrade Test
+    name: HA Testing
     strategy:
       matrix:
         flavor: [upstream, registry1, unicorn]

--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -7,6 +7,10 @@ on:
   schedule:
     # Runs every morning at 2:00 AM UTC
     - cron: '0 2 * * *'
+  pull_request:
+    paths:
+      - '.github/workflows/upgrade-ha.yaml'
+      - 'bundles/k3d-standard/**'
 
 permissions:
   contents: read
@@ -15,16 +19,17 @@ permissions:
 
 jobs:
   uds-core-ha-upgrade-nightly:
-    runs-on: ubuntu-latest
+    runs-on: uds-ubuntu-big-boy-8-core
+    timeout-minutes: 45
+    name: HA Install/Upgrade Test
     strategy:
       matrix:
         flavor: [upstream, registry1, unicorn]
-
-    name: Run HA Install/Upgrade Test for ${{ matrix.flavor }}
+        test-type: [install, upgrade]
 
     steps:
-      - name: Checkout the code
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Environment setup
         uses: ./.github/actions/setup
@@ -35,7 +40,19 @@ jobs:
           chainguardIdentity: ${{ secrets.CHAINGUARD_IDENTITY }}
 
       - name: Run UDS Core Install HA Test
-        run: uds run uds-core-upgrade --set FLAVOR=${{ matrix.flavor }} --no-progress
+        if: ${{ matrix.test-type == 'install' }}
+        run: uds run test-uds-core-ha --set FLAVOR=${{ matrix.flavor }} --no-progress
 
       - name: Run UDS Core Upgrade HA Test
+        if: ${{ matrix.test-type == 'upgrade' }}
         run: uds run uds-core-ha-upgrade --set FLAVOR=${{ matrix.flavor }} --no-progress
+
+      - name: Debug Output
+        if: ${{ always() }}
+        uses: ./.github/actions/debug-output
+
+      - name: Save logs
+        if: always()
+        uses: ./.github/actions/save-logs
+        with:
+          suffix: -nightly-upstream-${{ matrix.flavor }}-${{ matrix.test-type }}

--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run UDS Core Upgrade HA Test
         if: ${{ matrix.test-type == 'upgrade' }}
-        run: uds run uds-core-ha-upgrade --set FLAVOR=${{ matrix.flavor }} --no-progress
+        run: uds run test-uds-core-ha-upgrade --set FLAVOR=${{ matrix.flavor }} --no-progress
 
       - name: Debug Output
         if: ${{ always() }}

--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -55,4 +55,4 @@ jobs:
         if: always()
         uses: ./.github/actions/save-logs
         with:
-          suffix: -nightly-upstream-${{ matrix.flavor }}-${{ matrix.test-type }}
+          suffix: -nightly-${{ matrix.flavor }}-${{ matrix.test-type }}

--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-name: UDS Core Install/Upgrade HA Test
+name: Nightly
 
 on:
   schedule:

--- a/docs/dev/ci-testing.md
+++ b/docs/dev/ci-testing.md
@@ -23,6 +23,16 @@ Where: k3d
 
 What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled
 
+### "Full Core" HA Install
+
+This tests validates an install of the `k3d-core-demo` bundle in HA mode. The demo bundles includes all functional layers and components in Core, so this test provides full coverage of all applications.
+
+When: Nightly (2AM UTC)
+
+Where: k3d
+
+What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled using [HA Config](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-ha-config.yaml)
+
 ### "Full Core" Upgrade
 
 In order to ensure we catch any breaking changes across upgrades we also run an upgrade test of Core. This test deploys the latest release of the `k3d-core-demo` bundle, then upgrades to the version of core built from the PR branch. This test includes all functional layers and components in Core.
@@ -32,6 +42,16 @@ When: On all PRs
 Where: k3d
 
 What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled, upgrade tested from latest release
+
+### "Full Core" HA Upgrade
+
+In order to ensure we catch any breaking changes across upgrades with HA we also run an upgrade test of Core in HA mode. This test deploys the latest release of the `k3d-core-demo` HA bundle, then upgrades to the version of core built from the PR branch. This test includes all functional layers and components in Core.
+
+When: Nightly (2AM UTC)
+
+Where: k3d
+
+What: [Standard k3d bundle](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-bundle.yaml), all `optionalComponents` enabled, using [HA Config](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/uds-ha-config.yaml), upgrade tested from latest release
 
 ### "Single Layer"
 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -105,66 +105,14 @@ tasks:
   - name: test-uds-core-ha
     description: "Build and test UDS Core"
     actions:
-      - description: "Cleanup previous PostgreSQL runs"
-        cmd: |
-          docker kill postgres || true
-          docker rm postgres || true
-      - description: "Create a network for the PostgreSQL container"
-        cmd: docker network create k3d-uds || true
-      - description: "Generate PostgreSQL certs"
-        cmd: |
-          mkdir -p build/certs
-          openssl req -x509 -newkey rsa:4096 -sha256 -nodes \
-            -keyout build/certs/server.key \
-            -out build/certs/server.crt \
-            -days 365 -subj "/CN=postgres" > /dev/null 2>&1 || {
-              echo "Error: Failed to generate PostgreSQL certs"
-              exit 1
-            }
-          chmod 600 build/certs/server.key
-          chmod 644 build/certs/server.crt
-      - description: "Prepare PostgreSQL certs inside a temp container"
-        cmd: |
-          docker run --rm \
-            -v $(pwd)/build/certs:/certs \
-            --entrypoint bash postgres:16 \
-            -c "cp /certs/server.key /certs/fixed.key && \
-                cp /certs/server.crt /certs/fixed.crt && \
-                chown 999:999 /certs/fixed.key /certs/fixed.crt && \
-                chmod 600 /certs/fixed.key && chmod 644 /certs/fixed.crt"
-      - description: "Start PostgreSQL Docker container"
-        cmd: |
-          CONTAINER_NAME=postgres
-          # We're using Postgres 16 as this is the compatibility version for RDS
-          POSTGRES_VERSION=16
-          # RDS (Postgres 16) supports only TLS 1.2 only
-          TLS_VERSION=TLSv1.2
-          docker run -p 5432:5432 --network=k3d-uds --rm --name $CONTAINER_NAME \
-            -e POSTGRES_DB=keycloak \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD='unicorn123!@#UN' \
-            -v $(pwd)/build/certs/fixed.crt:/var/lib/postgresql/server.crt:ro \
-            -v $(pwd)/build/certs/fixed.key:/var/lib/postgresql/server.key:ro \
-            -d postgres:$POSTGRES_VERSION \
-            -c ssl=on \
-            -c ssl_cert_file=/var/lib/postgresql/server.crt \
-            -c ssl_key_file=/var/lib/postgresql/server.key \
-            -c ssl_min_protocol_version=$TLS_VERSION \
-            -c ssl_max_protocol_version=$TLS_VERSION \
-            -c log_connections=on \
-            -c log_disconnections=on \
-            -c log_min_messages=debug1 \
-            -c log_line_prefix='%m [%p] %q%u@%d ' \
-            -c log_statement=all
-      - description: "Wait for PostgreSQL to be ready"
-        cmd: |
-          for i in {1..10}; do
-            docker exec postgres pg_isready -U postgres && break
-            sleep 1
-          done
-      - description: "Add Grafana database to PostgreSQL"
-        cmd: docker exec postgres psql -U postgres -c "CREATE DATABASE grafana;"
+      - task: setup:ha-postgres
       - task: test:uds-core-ha
+
+  - name: test-uds-core-ha-upgrade
+    description: "Test an upgrade from the latest released UDS Core package with HA to current branch with HA"
+    actions:
+      - task: setup:ha-postgres
+      - task: test:uds-core-ha-upgrade
 
   - name: test-uds-core-upgrade
     description: "Test an upgrade from the latest released UDS Core package to current branch"

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -65,6 +65,13 @@ tasks:
       - description: "Deploy the latest UDS Core package release"
         cmd: uds zarf package deploy oci://${TARGET_REPO}/core:${LATEST_VERSION} --confirm --no-progress --components '*' --set CNI_BIN_DIR="/var/lib/rancher/k3s/data/cni"
 
+  - name: latest-bundle-release-ha
+    actions:
+      - description: "Deploy the latest UDS Core bundle release with HA config"
+        cmd: uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-demo:latest --confirm --no-progress
+        env:
+          - UDS_CONFIG=bundles/k3d-standard/uds-ha-config.yaml
+
   - name: latest-slim-bundle-release
     actions:
       - description: "Deploy the latest UDS Core package release"

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -19,3 +19,65 @@ tasks:
       - description: "Initialize the cluster with Zarf"
         # renovate: datasource=github-tags depName=zarf-dev/zarf versioning=semver
         cmd: "uds zarf package deploy oci://ghcr.io/zarf-dev/packages/init:v0.54.0 --confirm --no-progress"
+
+  - name: ha-postgres
+    actions:
+      - description: "Cleanup previous PostgreSQL runs"
+        cmd: |
+          docker kill postgres || true
+          docker rm postgres || true
+      - description: "Create a network for the PostgreSQL container"
+        cmd: docker network create k3d-uds || true
+      - description: "Generate PostgreSQL certs"
+        cmd: |
+          mkdir -p build/certs
+          openssl req -x509 -newkey rsa:4096 -sha256 -nodes \
+            -keyout build/certs/server.key \
+            -out build/certs/server.crt \
+            -days 365 -subj "/CN=postgres" > /dev/null 2>&1 || {
+              echo "Error: Failed to generate PostgreSQL certs"
+              exit 1
+            }
+          chmod 600 build/certs/server.key
+          chmod 644 build/certs/server.crt
+      - description: "Prepare PostgreSQL certs inside a temp container"
+        cmd: |
+          docker run --rm \
+            -v $(pwd)/build/certs:/certs \
+            --entrypoint bash postgres:16 \
+            -c "cp /certs/server.key /certs/fixed.key && \
+                cp /certs/server.crt /certs/fixed.crt && \
+                chown 999:999 /certs/fixed.key /certs/fixed.crt && \
+                chmod 600 /certs/fixed.key && chmod 644 /certs/fixed.crt"
+      - description: "Start PostgreSQL Docker container"
+        cmd: |
+          CONTAINER_NAME=postgres
+          # We're using Postgres 16 as this is the compatibility version for RDS
+          POSTGRES_VERSION=16
+          # RDS (Postgres 16) supports only TLS 1.2 only
+          TLS_VERSION=TLSv1.2
+          docker run -p 5432:5432 --network=k3d-uds --rm --name $CONTAINER_NAME \
+            -e POSTGRES_DB=keycloak \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD='unicorn123!@#UN' \
+            -v $(pwd)/build/certs/fixed.crt:/var/lib/postgresql/server.crt:ro \
+            -v $(pwd)/build/certs/fixed.key:/var/lib/postgresql/server.key:ro \
+            -d postgres:$POSTGRES_VERSION \
+            -c ssl=on \
+            -c ssl_cert_file=/var/lib/postgresql/server.crt \
+            -c ssl_key_file=/var/lib/postgresql/server.key \
+            -c ssl_min_protocol_version=$TLS_VERSION \
+            -c ssl_max_protocol_version=$TLS_VERSION \
+            -c log_connections=on \
+            -c log_disconnections=on \
+            -c log_min_messages=debug1 \
+            -c log_line_prefix='%m [%p] %q%u@%d ' \
+            -c log_statement=all
+      - description: "Wait for PostgreSQL to be ready"
+        cmd: |
+          for i in {1..10}; do
+            docker exec postgres pg_isready -U postgres && break
+            sleep 1
+          done
+      - description: "Add Grafana database to PostgreSQL"
+        cmd: docker exec postgres psql -U postgres -c "CREATE DATABASE grafana;"

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -162,6 +162,20 @@ tasks:
       - task: deploy:k3d-standard-bundle-ha
       - task: validate-packages
 
+  - name: uds-core-ha-upgrade
+    description: "Test an upgrade from the latest released UDS Core package with HA to current branch with HA"
+    actions:
+      - task: deploy:latest-bundle-release-ha
+      - task: create:standard-package
+        with:
+          create_options: "--skip-sbom"
+      - task: create:k3d-standard-bundle
+      - cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages core --confirm --no-progress
+        env:
+          - UDS_CONFIG=bundles/k3d-standard/uds-ha-config.yaml
+      - task: validate-packages
+      - task: e2e-tests
+
   - name: uds-core-upgrade
     description: "Test an upgrade from the latest released UDS Core package to current branch"
     actions:


### PR DESCRIPTION
## Description
To help address upgrade issues we've seen lately, adding a nightly HA install and upgrade test to CI. This will test all flavors against install and upgrade (from latest release).

## Related Issue

Fixes #1007 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- Run new task locally with `uds run test-uds-core-ha-upgrade`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed