### PR TITLE
fix(ci): add maru auth for remote tasks

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -63,3 +63,8 @@ runs:
         GH_TOKEN: ${{ inputs.ghToken }}
       run: echo "${{ env.GH_TOKEN }}" | uds zarf tools registry login -u "dummy" --password-stdin ghcr.io
       shell: bash
+
+    - name: Maru Login
+      if: ${{ inputs.ghToken != '' }}
+      run: echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ inputs.ghToken }}\"}\"" >> "GITHUB_ENV"
+      shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -66,5 +66,6 @@ runs:
 
     - name: Maru Login
       if: ${{ inputs.ghToken != '' }}
-      run: echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ inputs.ghToken }}\"}\"" >> "GITHUB_ENV"
+      run: |
+        echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ inputs.ghToken }}\"}\"" >> "GITHUB_ENV"
       shell: bash


### PR DESCRIPTION
## Description

Adds MARU_AUTH to our setup action to ensure that remote task inclusion doesn't run the risk of getting rate limited.

Related to https://github.com/defenseunicorns/uds-common/pull/488

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Validate that no 429s are seen in CI or locally.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed