### PR TITLE
fix: allow OIDC logout from NeuVector

### DIFF
--- a/src/neuvector/chart/templates/neuvector-deny.yaml
+++ b/src/neuvector/chart/templates/neuvector-deny.yaml
@@ -17,4 +17,6 @@ spec:
     - operation:
         paths: ["/auth"]
         ports: ["8443"]
+        # Don't block DELETE which is used for OIDC logout
+        methods: ["POST","GET","PUT","CONNECT"]
 {{- end }}


### PR DESCRIPTION
## Description

Updates authpol on NeuVector to block certain methods used for local login, while allowing `DELETE` which is used for logout.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/1305

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Login to neuvector with SSO, then logout and confirm it works.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed