### PR TITLE
chore: switch to vector fips image

### DIFF
--- a/src/vector/values/unicorn-values.yaml
+++ b/src/vector/values/unicorn-values.yaml
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 image:
-  repository: cgr.dev/du-uds-defenseunicorns/vector
+  repository: cgr.dev/du-uds-defenseunicorns/vector-fips
   tag: 0.46.1

--- a/src/vector/zarf.yaml
+++ b/src/vector/zarf.yaml
@@ -48,4 +48,4 @@ components:
         valuesFiles:
           - values/unicorn-values.yaml
     images:
-      - cgr.dev/du-uds-defenseunicorns/vector:0.46.1
+      - cgr.dev/du-uds-defenseunicorns/vector-fips:0.46.1


### PR DESCRIPTION
## Description

Switches to the FIPS image for vector in the unicorn flavor.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/1550

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Validate that all vector functionality is working as expected still (e2e tests should generally cover this).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed