### PR TITLE
chore(ci): add renovate-readiness to HA workflow

### DIFF
--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -19,12 +19,14 @@ permissions:
   contents: read
   id-token: write
   packages: read
+  pull-requests: write # Allows writing to pull requests (needed for renovate-readiness)
 
 jobs:
   uds-core-ha-upgrade-nightly:
     runs-on: uds-ubuntu-big-boy-8-core
     timeout-minutes: 45
     name: HA Testing
+
     strategy:
       matrix:
         flavor: [upstream, registry1, unicorn]

--- a/.github/workflows/upgrade-ha.yaml
+++ b/.github/workflows/upgrade-ha.yaml
@@ -8,6 +8,9 @@ on:
     # Runs every morning at 2:00 AM UTC
     - cron: '0 2 * * *'
   pull_request:
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    # labeled is added to support renovate-ready labelling on PRs
+    types: [milestoned, labeled, opened, reopened, synchronize]
     paths:
       - '.github/workflows/upgrade-ha.yaml'
       - 'bundles/k3d-standard/**'
@@ -30,6 +33,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check renovate readiness
+        if: startsWith(github.event.pull_request.head.ref, 'renovate/') # Only call for Renovate PRs
+        uses: ./.github/actions/renovate-readiness
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Description

Adds the renovate readiness action to the upgrade-ha workflow, along with the triggers for labelling/milestoning.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed