### PR TITLE
feat: enable keycloak user event metrics

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -121,6 +121,8 @@ spec:
               value: "true"
             - name: KC_METRICS_ENABLED
               value: "true"
+            - name: KC_EVENT_METRICS_USER_ENABLED
+              value: "true"
 
             # Enable access log
             - name: QUARKUS_HTTP_ACCESS_LOG_ENABLED


### PR DESCRIPTION
## Description

This enables keycloak user event metrics by default.  Ref: https://www.keycloak.org/observability/event-metrics#_enable_event_metrics.

I performed very basic local load testing by simulating 100 failed login events and noticed no noticeable difference CPU/Mem usage.

Without User Metrics
![image](https://github.com/user-attachments/assets/e6b22462-8840-4014-9d50-923693b8eda1)


With User Metrics Enabled
![image2](https://github.com/user-attachments/assets/5e4b69e7-63aa-43cf-b651-ddd8cd516cd9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Deploy standard bundle `uds run test-uds-core`
- Verify `keycloak_user_events_total` metric is populating in grafana [here](https://grafana.admin.uds.dev/explore?schemaVersion=1&panes=%7B%22gyp%22%3A%7B%22datasource%22%3A%22PBFA97CFB590B2093%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22keycloak_user_events_total%22%2C%22range%22%3Atrue%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22PBFA97CFB590B2093%22%7D%2C%22editorMode%22%3A%22builder%22%2C%22legendFormat%22%3A%22__auto%22%2C%22useBackend%22%3Afalse%2C%22disableTextWrap%22%3Afalse%2C%22fullMetaSearch%22%3Afalse%2C%22includeNullMetadata%22%3Atrue%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D%7D&orgId=1)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed