### PR TITLE
chore: switch to rapidfort vector fips image

### DIFF
--- a/src/vector/values/unicorn-values.yaml
+++ b/src/vector/values/unicorn-values.yaml
@@ -3,4 +3,4 @@
 
 image:
   repository: quay.io/rfcurated/vector
-  tag: 0.47.0-jammy-rfcurated-rfhardened
+  tag: 0.47.0-jammy-fips-rfcurated-rfhardened

--- a/src/vector/zarf.yaml
+++ b/src/vector/zarf.yaml
@@ -48,4 +48,4 @@ components:
         valuesFiles:
           - values/unicorn-values.yaml
     images:
-      - quay.io/rfcurated/vector:0.47.0-jammy-rfcurated-rfhardened
+      - quay.io/rfcurated/vector:0.47.0-jammy-fips-rfcurated-rfhardened


### PR DESCRIPTION
## Description
Rapidfort released their Vector FIPS image. This switches over to using that image. Local testing was good with this image.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed