### PR TITLE
chore: reorganize test packages

### DIFF
--- a/src/test/app-admin-package.yaml
+++ b/src/test/app-admin-package.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-admin-app
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: httpbin
+  namespace: test-admin-app
+spec:
+  network:
+    expose:
+      - service: httpbin
+        selector:
+          app: httpbin
+        gateway: admin
+        host: demo
+        port: 8000
+        targetPort: 80
+        advancedHTTP:
+          match:
+            - name: test-get-and-prefix
+              method:
+                # Only allow GET requests
+                regex: GET
+              uri:
+                # Only allow routing to /status/2*, everything else should 404
+                prefix: /status/2
+            - name: test-exact
+              uri:
+                # Only allow routing to /status/410
+                exact: /status/410
+    allow:
+      - direction: Egress
+        selector:
+          app: httpbin
+        remoteGenerated: Anywhere
+        ports:
+          - 443
+          - 8080
+          - 80

--- a/src/test/app-admin.yaml
+++ b/src/test/app-admin.yaml
@@ -2,49 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: test-admin-app
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: httpbin
-  namespace: test-admin-app
-spec:
-  network:
-    expose:
-      - service: httpbin
-        selector:
-          app: httpbin
-        gateway: admin
-        host: demo
-        port: 8000
-        targetPort: 80
-        advancedHTTP:
-          match:
-            - name: test-get-and-prefix
-              method:
-                # Only allow GET requests
-                regex: GET
-              uri:
-                # Only allow routing to /status/2*, everything else should 404
-                prefix: /status/2
-            - name: test-exact
-              uri:
-                # Only allow routing to /status/410
-                exact: /status/410
-    allow:
-      - direction: Egress
-        selector:
-          app: httpbin
-        remoteGenerated: Anywhere
-        ports:
-          - 443
-          - 8080
-          - 80
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: httpbin

--- a/src/test/app-authservice-tenant-package.yaml
+++ b/src/test/app-authservice-tenant-package.yaml
@@ -1,0 +1,39 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: authservice-test-app
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: httpbin-other
+  namespace: authservice-test-app
+spec:
+  sso:
+    - name: Demo SSO
+      clientId: uds-core-httpbin
+      redirectUris:
+        - "https://protected.uds.dev/login"
+      enableAuthserviceSelector:
+        app: httpbin
+      groups:
+        anyOf:
+          - "/UDS Core/Admin"
+  network:
+    expose:
+      - service: httpbin
+        selector:
+          app: httpbin
+        gateway: tenant
+        host: protected
+        port: 8000
+        targetPort: 80
+    allow:
+      - direction: Ingress
+        selector:
+          app: httpbin
+        ports:
+          - 80

--- a/src/test/app-authservice-tenant.yaml
+++ b/src/test/app-authservice-tenant.yaml
@@ -2,43 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: authservice-test-app
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: httpbin-other
-  namespace: authservice-test-app
-spec:
-  sso:
-    - name: Demo SSO
-      clientId: uds-core-httpbin
-      redirectUris:
-        - "https://protected.uds.dev/login"
-      enableAuthserviceSelector:
-        app: httpbin
-      groups:
-        anyOf:
-          - "/UDS Core/Admin"
-  network:
-    expose:
-      - service: httpbin
-        selector:
-          app: httpbin
-        gateway: tenant
-        host: protected
-        port: 8000
-        targetPort: 80
-    allow:
-      - direction: Ingress
-        selector:
-          app: httpbin
-        ports:
-          - 80
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: httpbin

--- a/src/test/app-curl-packages.yaml
+++ b/src/test/app-curl-packages.yaml
@@ -1,0 +1,144 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    uds: curl-testing-namespace
+  name: curl-ns-deny-all-1
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: curl-pkg-deny-all-1
+  namespace: curl-ns-deny-all-1
+spec:
+  network:
+    allow: []
+    expose: []
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    uds: curl-testing-namespace
+  name: curl-ns-deny-all-2
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: curl-pkg-deny-all-2
+  namespace: curl-ns-deny-all-2
+spec:
+  network:
+    allow: []
+    expose: []
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    uds: curl-testing-namespace
+  name: curl-ns-allow-all
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: curl-pkg-allow-all
+  namespace: curl-ns-allow-all
+spec:
+  network:
+    allow:
+      - direction: Ingress
+        selector:
+          app: curl-pkg-allow-all
+        ports:
+          - 8080
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    uds: curl-testing-namespace
+  name: curl-ns-remote-ns-1
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: curl-pkg-remote-ns-egress
+  namespace: curl-ns-remote-ns-1
+spec:
+  network:
+    allow:
+      - direction: Egress
+        remoteNamespace: curl-ns-remote-ns-2
+        selector:
+          app: curl-pkg-remote-ns-egress
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    uds: curl-testing-namespace
+  name: curl-ns-remote-ns-2
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: curl-pkg-remote-ns-ingress
+  namespace: curl-ns-remote-ns-2
+spec:
+  network:
+    allow:
+      - direction: Ingress
+        remoteNamespace: curl-ns-remote-ns-1
+        remoteSelector:
+          app: curl-pkg-remote-ns-egress
+        selector:
+          app: curl-pkg-remote-ns-ingress
+        ports:
+          - 443
+          - 8080
+          - 80
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    uds: curl-testing-namespace
+  name: curl-ns-kube-api
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: curl-pkg-kube-api
+  namespace: curl-ns-kube-api
+spec:
+  network:
+    allow:
+      - direction: Egress
+        remoteGenerated: KubeAPI
+        selector:
+          app: curl-pkg-kube-api
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    uds: curl-testing-namespace
+  name: curl-ns-remote-cidr
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: curl-pkg-remote-cidr
+  namespace: curl-ns-remote-cidr
+spec:
+  network:
+    allow:
+      - direction: Ingress
+        remoteCidr: 0.0.0.0/0
+        selector:
+          app: curl-pkg-remote-cidr
+---

--- a/src/test/app-curl.yaml
+++ b/src/test/app-curl.yaml
@@ -2,23 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    uds: curl-testing-namespace
-  name: curl-ns-deny-all-1
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: curl-pkg-deny-all-1
-  namespace: curl-ns-deny-all-1
-spec:
-  network:
-    allow: []
-    expose: []
----
-apiVersion: v1
 kind: Service
 metadata:
   name: curl-pkg-deny-all-1
@@ -68,23 +51,6 @@ spec:
             - containerPort: 8080
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    uds: curl-testing-namespace
-  name: curl-ns-deny-all-2
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: curl-pkg-deny-all-2
-  namespace: curl-ns-deny-all-2
-spec:
-  network:
-    allow: []
-    expose: []
----
-apiVersion: v1
 kind: Service
 metadata:
   name: curl-pkg-deny-all-2
@@ -132,27 +98,6 @@ spec:
               memory: 16Mi
           ports:
             - containerPort: 8080
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    uds: curl-testing-namespace
-  name: curl-ns-allow-all
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: curl-pkg-allow-all
-  namespace: curl-ns-allow-all
-spec:
-  network:
-    allow:
-      - direction: Ingress
-        selector:
-          app: curl-pkg-allow-all
-        ports:
-          - 8080
 ---
 apiVersion: v1
 kind: Service
@@ -212,26 +157,6 @@ spec:
             - containerPort: 8081
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    uds: curl-testing-namespace
-  name: curl-ns-remote-ns-1
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: curl-pkg-remote-ns-egress
-  namespace: curl-ns-remote-ns-1
-spec:
-  network:
-    allow:
-      - direction: Egress
-        remoteNamespace: curl-ns-remote-ns-2
-        selector:
-          app: curl-pkg-remote-ns-egress
----
-apiVersion: v1
 kind: Service
 metadata:
   name: curl-pkg-remote-ns-egress
@@ -281,32 +206,6 @@ spec:
             - containerPort: 8080
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    uds: curl-testing-namespace
-  name: curl-ns-remote-ns-2
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: curl-pkg-remote-ns-ingress
-  namespace: curl-ns-remote-ns-2
-spec:
-  network:
-    allow:
-      - direction: Ingress
-        remoteNamespace: curl-ns-remote-ns-1
-        remoteSelector:
-          app: curl-pkg-remote-ns-egress
-        selector:
-          app: curl-pkg-remote-ns-ingress
-        ports:
-          - 443
-          - 8080
-          - 80
----
-apiVersion: v1
 kind: Service
 metadata:
   name: curl-pkg-remote-ns-ingress
@@ -350,26 +249,6 @@ spec:
             - "-listen=:8080"
           ports:
             - containerPort: 8080
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    uds: curl-testing-namespace
-  name: curl-ns-kube-api
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: curl-pkg-kube-api
-  namespace: curl-ns-kube-api
-spec:
-  network:
-    allow:
-      - direction: Egress
-        remoteGenerated: KubeAPI
-        selector:
-          app: curl-pkg-kube-api
 ---
 apiVersion: v1
 kind: Service
@@ -419,26 +298,6 @@ spec:
               memory: 16Mi
           ports:
             - containerPort: 8080
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    uds: curl-testing-namespace
-  name: curl-ns-remote-cidr
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: curl-pkg-remote-cidr
-  namespace: curl-ns-remote-cidr
-spec:
-  network:
-    allow:
-      - direction: Ingress
-        remoteCidr: 0.0.0.0/0
-        selector:
-          app: curl-pkg-remote-cidr
 ---
 apiVersion: v1
 kind: Service

--- a/src/test/app-tenant-package.yaml
+++ b/src/test/app-tenant-package.yaml
@@ -1,0 +1,28 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-tenant-app
+---
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: test-tenant-app
+  namespace: test-tenant-app
+spec:
+  network:
+    expose:
+      - service: test-tenant-app
+        selector:
+          app: test-tenant-app
+        gateway: tenant
+        host: demo-8080
+        port: 8080
+      - service: test-tenant-app
+        selector:
+          app: test-tenant-app
+        gateway: tenant
+        host: demo-8081
+        port: 8081

--- a/src/test/app-tenant.yaml
+++ b/src/test/app-tenant.yaml
@@ -2,32 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: test-tenant-app
----
-apiVersion: uds.dev/v1alpha1
-kind: Package
-metadata:
-  name: test-tenant-app
-  namespace: test-tenant-app
-spec:
-  network:
-    expose:
-      - service: test-tenant-app
-        selector:
-          app: test-tenant-app
-        gateway: tenant
-        host: demo-8080
-        port: 8080
-      - service: test-tenant-app
-        selector:
-          app: test-tenant-app
-        gateway: tenant
-        host: demo-8081
-        port: 8081
----
-apiVersion: v1
 kind: Service
 metadata:
   name: test-tenant-app

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -42,36 +42,6 @@ tasks:
       - description: Deploy the test resources
         cmd: "uds zarf package deploy build/zarf-package-uds-core-test-apps-*.zst --confirm --no-progress"
 
-      - description: Wait for the admin app to be ready
-        wait:
-          cluster:
-            kind: Deployment
-            name: httpbin
-            namespace: test-admin-app
-
-      - description: Verify admin package CR is ready
-        wait:
-          cluster:
-            kind: Package
-            name: httpbin
-            namespace: test-admin-app
-            condition: "'{.status.phase}'=Ready"
-
-      - description: Wait for the tenant app to be ready
-        wait:
-          cluster:
-            kind: Deployment
-            name: http-echo-multi-port
-            namespace: test-tenant-app
-
-      - description: Verify tenant package CR is ready
-        wait:
-          cluster:
-            kind: Package
-            name: test-tenant-app
-            namespace: test-tenant-app
-            condition: "'{.status.phase}'=Ready"
-
       - description: Verify the admin app is accessible
         wait:
           network:
@@ -107,27 +77,12 @@ tasks:
             address: demo-8081.uds.dev
             code: 200
 
-      - description: Verify authservice app package CR is ready
-        wait:
-          cluster:
-            kind: Package
-            name: httpbin-other
-            namespace: authservice-test-app
-            condition: "'{.status.phase}'=Ready"
-
       - description: Verify the authservice tenant app is accessible
         wait:
           network:
             protocol: https
             address: protected.uds.dev
             code: 200
-
-      - description: Wait for authservice to reload configuration
-        wait:
-          cluster:
-            kind: Deployment
-            name: authservice
-            namespace: authservice
 
       - description: Verify the authservice tenant app is protected by checking redirect
         maxRetries: 3
@@ -148,22 +103,6 @@ tasks:
               ;;
           esac
 
-      - description: Verify podinfo is healthy
-        wait:
-          cluster:
-            kind: Pod
-            name: app.kubernetes.io/name=podinfo
-            namespace: podinfo
-            condition: Ready
-
-      - description: Verify podinfo package CR is ready
-        wait:
-          cluster:
-            kind: Package
-            name: podinfo
-            namespace: podinfo
-            condition: "'{.status.phase}'=Ready"
-
       - description: Verify podinfo podmonitor exists
         wait:
           cluster:
@@ -177,62 +116,6 @@ tasks:
             kind: ServiceMonitor
             name: podinfo-svcmonitor
             namespace: podinfo
-
-      - description: "Wait for Deny All Package 1 to be Ready"
-        wait:
-          cluster:
-            kind: Pod
-            name: app=curl-pkg-deny-all-1
-            namespace: curl-ns-deny-all-1
-            condition: Ready
-
-      - description: "Wait for Deny All Package 2 to be Ready"
-        wait:
-          cluster:
-            kind: Pod
-            name: app=curl-pkg-deny-all-2
-            namespace: curl-ns-deny-all-2
-            condition: Ready
-
-      - description: "Wait for Allow All Package to be Ready"
-        wait:
-          cluster:
-            kind: Pod
-            name: app=curl-pkg-allow-all
-            namespace: curl-ns-allow-all
-            condition: Ready
-
-      - description: "Wait for Remote Namespace Egress Package to be Ready"
-        wait:
-          cluster:
-            kind: Pod
-            name: app=curl-pkg-remote-ns-egress
-            namespace: curl-ns-remote-ns-1
-            condition: Ready
-
-      - description: "Wait for Remote Namespace Ingress Package to be Ready"
-        wait:
-          cluster:
-            kind: Pod
-            name: app=curl-pkg-remote-ns-ingress
-            namespace: curl-ns-remote-ns-2
-            condition: Ready
-
-      - description: "Wait for Kube Api Package to be Ready"
-        wait:
-          cluster:
-            kind: Pod
-            name: app=curl-pkg-kube-api
-            namespace: curl-ns-kube-api
-            condition: Ready
-
-      - description: "Wait for Remote Cidr Package to be Ready"
-        wait:
-          cluster:
-            kind: Pod
-            name: app=curl-pkg-remote-cidr
-            namespace: curl-ns-remote-cidr
-            condition: Ready
 
   - name: remove
     actions:

--- a/src/test/zarf.yaml
+++ b/src/test/zarf.yaml
@@ -8,6 +8,18 @@ metadata:
   url: https://github.com/defenseunicorns/uds-core
 
 components:
+  # Deploy package CRs
+  - name: test-app-packages
+    required: true
+    manifests:
+      - name: test-app-packages
+        files:
+          - "app-admin-package.yaml"
+          - "app-authservice-tenant-package.yaml"
+          - "app-tenant-package.yaml"
+          - "app-curl-packages.yaml"
+
+  # Deploy test workloads
   - name: test-apps
     required: true
     manifests:

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -212,6 +212,7 @@ tasks:
         with:
           validate_passthrough: "false"
       - task: idam-layer:validate
+      - task: test-resources:e2e-test
 
   - name: local-compliance-compose
     description: "compose oscal component definitions"

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -212,7 +212,6 @@ tasks:
         with:
           validate_passthrough: "false"
       - task: idam-layer:validate
-      - task: test-resources:e2e-test
 
   - name: local-compliance-compose
     description: "compose oscal component definitions"


### PR DESCRIPTION
## Description

This PR reorganizes our test package resources splitting them into:
- Package CRs/namespaces in one component
- Workloads in a second component

By doing this we can remove a number of the boilerplate wait conditions in the tasks (since zarf/helm/kstatus waits are in place for all resources) and improve speed on deploy time (no need to cycle pods to inject sidecar since the Package CR is created/ready first).

This should also resolve some intermittent issues we've seen in CI with the pod waits.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

CI should cover this change, but you could validate locally as well with the e2e-test task for the test packages.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed