### PR TITLE
fix(ci): dynamic nodeport for podinfo

### DIFF
--- a/src/test/podinfo-values.yaml
+++ b/src/test/podinfo-values.yaml
@@ -10,5 +10,4 @@ securityContext:
 service:
   enabled: true
   type: NodePort
-  nodePort: 31123
   hostPort: 1000


### PR DESCRIPTION
## Description

Fixes a test flakiness cause. By explicitly specifying a nodeport (rather than leaving it dynamic) we sometimes hit conflicts with the dynamic ports of the Istio gateways - https://github.com/defenseunicorns/uds-core/actions/runs/15497516118/job/43637686813?pr=1631

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed