### PR TITLE
feat: vector sidecar optionality

### DIFF
--- a/src/vector/chart/templates/uds-package.yaml
+++ b/src/vector/chart/templates/uds-package.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   network:
     serviceMesh:
-      mode: ambient
+      mode: {{ if .Values.ambient }}ambient{{ else }}sidecar{{ end }}
     allow:
       - direction: Ingress
         selector:

--- a/src/vector/chart/values.yaml
+++ b/src/vector/chart/values.yaml
@@ -1,6 +1,8 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
+ambient: true
+
 additionalNetworkAllow: []
 # ref: https://uds.defenseunicorns.com/reference/configuration/custom-resources/packages-v1alpha1-cr/#allow
 # Examples:


### PR DESCRIPTION
## Description

Gap-filler request to allow vector to work in sidecar-mode to support delivery use case.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
Tested by modifying the UDS Standard Bundle with an `ambient: false` override value. Vector and Loki appear to be working normally.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed