### PR TITLE
chore(ci): update to node 24

### DIFF
--- a/.github/actions/lint-check/action.yaml
+++ b/.github/actions/lint-check/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Use Node.js latest
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 20
+        node-version: 24
     - name: Install UDS CLI
       uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
       with:

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,13 +6,13 @@ name: "Setup Environment"
 description: "UDS Environment Setup"
 inputs:
   ghToken:
-    description: 'GITHUB_TOKEN'
+    description: "GITHUB_TOKEN"
     required: true
   registry1Username:
-    description: 'IRON_BANK_ROBOT_USERNAME'
+    description: "IRON_BANK_ROBOT_USERNAME"
     required: true
   registry1Password:
-    description: 'IRON_BANK_ROBOT_PASSWORD'
+    description: "IRON_BANK_ROBOT_PASSWORD"
     required: true
   rapidfortUsername:
     description: "RAPIDFORT_USERNAME"
@@ -27,7 +27,7 @@ runs:
     - name: Use Node.js latest
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Install k3d
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Before starting, ensure that you have the following installed:
 
 - **Git**: [Install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - **K3d**: [Install K3d](https://k3d.io/#installation)
-- **Node.js** (for building and running Pepr): [Install Node.js](https://nodejs.org/en/download/)
+- **Node.js** (for building and running Pepr): [Install Node.js](https://nodejs.org/en/download/) (we recommend Node 24 to align with what CI tests/builds with)
 - **UDS CLI** (for running tasks and deploying): [Install UDS](https://uds.defenseunicorns.com/cli/quickstart-and-usage/)
 
 ### 2. Clone the Repository and Make a Branch


### PR DESCRIPTION
## Description

Updates to Node 24 for CI, aligning with what Pepr uses for most CI.

Also updates docs to recommend this version since users on v22 of Node have reported issues similar to https://github.com/defenseunicorns/uds-core/pull/1644.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

N/A, this is purely a CI change so if CI completes this should be validated.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed