### PR TITLE
feat: set keycloak `KC_SPI_X509CERT_LOOKUP` vars from x509 lookup provider

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -154,10 +154,10 @@ spec:
             - name: KC_SPI_X509CERT_LOOKUP_PROVIDER
               value: {{ .Values.x509LookupProvider }}
             # Set nginx provider header name
-            - name: KC_SPI_X509CERT_LOOKUP_NGINX_SSL_CLIENT_CERT
+            - name: KC_SPI_X509CERT_LOOKUP_{{ .Values.x509LookupProvider | upper }}_SSL_CLIENT_CERT
               value: istio-mtls-client-certificate
             # Dumb value (not used in the nginx provider, but required by the SPI)
-            - name: KC_SPI_X509CERT_LOOKUP_NGINX_SSL_CLIENT_CERT_CHAIN_PREFIX
+            - name: KC_SPI_X509CERT_LOOKUP_{{ .Values.x509LookupProvider | upper }}_SSL_CLIENT_CERT_CHAIN_PREFIX
               value: UNUSED
           {{- if .Values.fips }}
             # This is a workaround for https://github.com/keycloak/keycloak/issues/39454


### PR DESCRIPTION
## Description
Currently, the environment variables `KC_SPI_X509CERT_LOOKUP_NGINX_SSL_CLIENT_CERT` and `KC_SPI_X509CERT_LOOKUP_NGINX_SSL_CLIENT_CERT_CHAIN_PREFIX` have `NGINX` hardcoded in the variable name. This has been updated to use the `x509LookupProvider` value, so that the environment variable will work with any configured x509 lookup provider.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed