### PR TITLE
feat: make k3d-core-slim-dev work without internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Deploy Istio, Keycloak and Pepr:
 uds deploy k3d-core-slim-dev:0.45.1
 ```
 
-> [!NOTE]
+> [!IMPORTANT]
 > The k3d-core-slim-dev bundle is intended for dev/test/demo environments and should not be used for production use.
 
-> [!NOTE]
+> [!TIP]
 > While the k3d-core-slim-dev bundle will work without internet, DNS will likely not resolve. If you are in an airgapped environment you may need to configure your /etc/hosts file such as:
 > ```
 > 127.0.0.1 localhost yourAppNameHere.uds.dev sso.uds.dev keycloak.admin.uds.dev

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Deploy Istio, Keycloak and Pepr:
 uds deploy k3d-core-slim-dev:0.45.1
 ```
 
+> [!NOTE]
+> The k3d-core-slim-dev bundle is intended for dev/test/demo environments and should not be used for production use.
+
+> [!NOTE]
+> While the k3d-core-slim-dev bundle will work without internet, DNS will likely not resolve. If you are in an airgapped environment you may need to configure your /etc/hosts file such as:
+> ```
+> 127.0.0.1 localhost yourAppNameHere.uds.dev sso.uds.dev keycloak.admin.uds.dev
+> ```
+
 <!-- x-release-please-end -->
 
 #### Developing UDS Core

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -13,7 +13,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.14.2
+    ref: 0.14.2-airgap
     overrides:
       uds-dev-stack:
         minio:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.14.2
+    ref: 0.14.2-airgap
     overrides:
       uds-dev-stack:
         minio:


### PR DESCRIPTION
## Description

Makes k3d-core-slim-dev work without internet

## Related Issue

Fixes #1677

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Run `uds run create:k3d-slim-dev-bundle`
- Turn off wifi
- Run `uds deploy <TheBundleFileName>`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed