### PR TITLE
chore: update versioning for aws provider

### DIFF
--- a/.github/test-infra/aws/eks/versions.tf
+++ b/.github/test-infra/aws/eks/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 5.0"
     }
 
     random = {

--- a/.github/test-infra/aws/eks/versions.tf
+++ b/.github/test-infra/aws/eks/versions.tf
@@ -18,17 +18,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~= 6.0"
+      version = "~> 6.0"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "3.7.2"
+      version = "~> 3.0"
     }
 
     local = {
       source  = "hashicorp/local"
-      version = "2.5.3"
+      version = "~> 2.0"
     }
   }
 }

--- a/.github/test-infra/aws/eks/versions.tf
+++ b/.github/test-infra/aws/eks/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~= 6.0"
     }
 
     random = {

--- a/.github/test-infra/aws/rke2/versions.tf
+++ b/.github/test-infra/aws/rke2/versions.tf
@@ -6,13 +6,13 @@ terraform {
   }
   required_providers {
     aws = {
-      version = "~= 6.0"
+      version = "~> 6.0"
     }
     random = {
-      version = "~> 3.7.0"
+      version = "~> 3.0"
     }
     tls = {
-      version = "~> 4.1.0"
+      version = "~> 4.0"
     }
   }
   required_version = ">= 1.8.0"

--- a/.github/test-infra/aws/rke2/versions.tf
+++ b/.github/test-infra/aws/rke2/versions.tf
@@ -6,7 +6,7 @@ terraform {
   }
   required_providers {
     aws = {
-      version = "~> 6.1.0"
+      version = "~= 6.0"
     }
     random = {
       version = "~> 3.7.0"


### PR DESCRIPTION
## Description

Fixes some version constraints to ensure we don't bump major versions (EKS) and don't pull in 6.1.0 which got deleted (see https://www.github.com/hashicorp/terraform-provider-aws/issues/43213).

Also makes most provider versions more flexible (any minor bumps) to reduce maintenance on these updates.