### PR TITLE
fix: grafana logout with refresh token

### DIFF
--- a/src/grafana/chart/templates/uds-package.yaml
+++ b/src/grafana/chart/templates/uds-package.yaml
@@ -71,13 +71,13 @@ spec:
         description: "Alertmanager Datasource"
         port: 9093
 
-      # Egress allowed to Keycloak
+      # Egress must be allowed to the external facing Keycloak endpoint
       - direction: Egress
         selector:
           app.kubernetes.io/name: grafana
-        remoteNamespace: keycloak
         remoteSelector:
-          app.kubernetes.io/name: keycloak
+          app: tenant-ingressgateway
+        remoteNamespace: istio-tenant-gateway
         description: "SSO Provider"
 
       # Egress allowed to KubeAPI

--- a/src/grafana/chart/templates/uds-package.yaml
+++ b/src/grafana/chart/templates/uds-package.yaml
@@ -13,8 +13,10 @@ spec:
       redirectUris:
         {{- if .Values.adminDomain }}
         - "https://grafana.{{ .Values.adminDomain }}/login/generic_oauth"
+        - "https://grafana.{{ .Values.adminDomain }}/login"
         {{- else }}
         - "https://grafana.admin.{{ .Values.domain }}/login/generic_oauth"
+        - "https://grafana.admin.{{ .Values.domain }}/login"
         {{- end }}
 
   monitor:

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -37,14 +37,15 @@ grafana.ini:
     enabled: true
     client_id: $__file{/etc/secrets/auth_generic_oauth/clientId}
     client_secret: $__file{/etc/secrets/auth_generic_oauth/secret}
-    scopes: openid profile
+    scopes: openid profile offline_access
     email_attribute_path: email
     login_attribute_path: preferred_username
     name_attribute_path: name
     name: UDS Identity Service
     auth_url: https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/auth
     token_url: http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/openid-connect/token
-    signout_redirect_url: https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/logout?post_logout_redirect_uri=https%3A%2F%2Fgrafana.admin.###ZARF_VAR_DOMAIN###%2Flogin%2Fgeneric_oauth
+    signout_redirect_url: https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/logout?post_logout_redirect_uri=https%3A%2F%2Fgrafana.admin.###ZARF_VAR_DOMAIN###%2Flogin
+    use_refresh_token: true
     allow_sign_up: true
     # Require a UDS Core group to access Grafana
     role_attribute_path: "contains(groups[], '/UDS Core/Admin') && 'Admin' || contains(groups[], '/UDS Core/Auditor') && 'Viewer' || 'Unauthorized'"

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -37,13 +37,14 @@ grafana.ini:
     enabled: true
     client_id: $__file{/etc/secrets/auth_generic_oauth/clientId}
     client_secret: $__file{/etc/secrets/auth_generic_oauth/secret}
-    scopes: openid profile offline_access
+    scopes: openid profile
     email_attribute_path: email
     login_attribute_path: preferred_username
     name_attribute_path: name
     name: UDS Identity Service
     auth_url: https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/auth
-    token_url: http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/openid-connect/token
+    # Note: this has to be the external URL to ensure that the token issuer checks in Grafana line up with this URL
+    token_url: https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/token
     signout_redirect_url: https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/logout?post_logout_redirect_uri=https%3A%2F%2Fgrafana.admin.###ZARF_VAR_DOMAIN###%2Flogin
     use_refresh_token: true
     allow_sign_up: true

--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -72,3 +72,20 @@ test("validate loki dashboard", async ({ page }) => {
     await expect(page.getByTestId('data-testid Panel header Logs Panel').getByTestId('data-testid panel content')).toBeVisible();
   });
 });
+
+// Test the logout functionality
+test("validate logout functionality", async ({ page }) => {
+  await test.step("perform logout", async () => {
+    await page.goto(`/`);
+
+    await page.locator('button[aria-label="Profile"]').click();
+    await page.locator('span').filter({ hasText: 'Sign out' }).click();
+
+    // After logout, we should be redirected through a series of redirects
+    // First to /login/generic_oauth, then to SSO
+    await page.waitForURL(/.*sso\.uds\.dev.*/, { timeout: 15000 });
+
+    // Verify we're at the Keycloak login page
+    await expect(page.getByRole('heading').filter({ hasText: 'Sign in' })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -86,6 +86,6 @@ test("validate logout functionality", async ({ page }) => {
     await page.waitForURL(/.*sso\.uds\.dev.*/, { timeout: 15000 });
 
     // Verify we're at the Keycloak login page
-    await expect(page.getByRole('heading').filter({ hasText: 'Sign in' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('h3:has-text("Sign in")')).toBeVisible({ timeout: 10000 });
   });
 });


### PR DESCRIPTION
## Description

Updates to grafana SSO setup to align with [the documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/keycloak/) and fix some behaviors around logout/session expiration.

This primarily includes:
- Updating the redirect uris + post-logout uri to align (removing generic_oauth)
- Add ability to use refresh tokens, and switch token url to external address to support this

There is some problematic behavior with logging out where tokens are expired and not sent as the id_token_hint. By adding/using refresh tokens this appears to be resolved.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Deploy core (or just monitoring layer + slim-dev) and ensure that logging in/out all behaves as expected. It may be worth testing at various "timeouts" (logging in/out immediately; logging in, waiting a few minutes, logging out; etc). Also validate that normal session timeout works as expected.

With debug logging enabled you can also observe the exact behavior when Grafana refreshes your token (and can observe your session in the KC admin console).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed