### PR TITLE
feat: add lifecycleHooks value to keycloak chart

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -117,6 +117,10 @@ spec:
             {{- if .Values.jsonLogFormat }}
             - "--log-console-output=json"
             {{- end }}
+          {{- with .Values.lifecycleHooks }}
+          lifecycle:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "keycloak.fullname" . }}-realm-env

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -182,6 +182,10 @@
     "jsonLogFormat": {
       "type": "boolean"
     },
+    "lifecycleHooks": {
+      "type": "object",
+      "properties": {}
+    },
     "nodeSelector": {
       "type": "object",
       "properties": {}

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -107,6 +107,9 @@ updateStrategy: RollingUpdate
 # Pod restart policy. One of `Always`, `OnFailure`, or `Never`
 restartPolicy: Always
 
+# Lifecycle hooks for the Keycloak container
+lifecycleHooks: {}
+
 # Termination grace period in seconds for Keycloak shutdown. Clusters with a large cache might need to extend this to give Infinispan more time to rebalance
 terminationGracePeriodSeconds: 5
 


### PR DESCRIPTION
## Description

This adds an additional value to the keycloak helm chart to configure lifecycle hooks on the keycloak pods.  

Relevant internal slack thread on why this value is needed: https://defense-unicorns.slack.com/archives/C06QJAUHWFN/p1751387433787979

## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Add the following override to the k3d-slim-dev bundle for keycloak:
```yaml
          values:
            - path: lifecycleHooks
              value:
                preStop:
                  exec:
                    command:
                      - "sleep"
                      - "15"
```
- Deploy k3d-slim-dev bundle and ensure lifecyclehook from above is applied to the keycloak pods in the statefulset

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed