### PR TITLE
chore(deps): update uds-core-identity-config to 0.15.2

### DIFF
--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.15.1
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.15.2
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"

--- a/src/keycloak/tasks.yaml
+++ b/src/keycloak/tasks.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
-  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.15.1/tasks.yaml
+  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.15.2/tasks.yaml
 
 tasks:
   - name: validate
@@ -29,7 +29,7 @@ tasks:
     actions:
       - cmd: |
           # renovate: datasource=docker depName=ghcr.io/defenseunicorns/uds/identity-config versioning=semver
-          IMAGE_TAG="0.15.1"
+          IMAGE_TAG="0.15.2"
           # Pre-pull image to simplify output
           docker pull ghcr.io/defenseunicorns/uds/identity-config:${IMAGE_TAG} -q
           # This is written to a file because it is larger than the max env size in the shell

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -27,7 +27,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.2.5
-      - ghcr.io/defenseunicorns/uds/identity-config:0.15.1
+      - ghcr.io/defenseunicorns/uds/identity-config:0.15.2
 
   - name: keycloak
     required: true
@@ -41,7 +41,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:26.2.5
-      - ghcr.io/defenseunicorns/uds/identity-config:0.15.1
+      - ghcr.io/defenseunicorns/uds/identity-config:0.15.2
 
   - name: keycloak
     required: true
@@ -59,4 +59,4 @@ components:
       # and Keycloak is no exception. Again, this effort doesn't change anything in terms of UDS Security and FIPS compliance posture.
       # The switch is tracked via https://github.com/defenseunicorns/uds-core/issues/1541
       - quay.io/rfcurated/keycloak:26.2.5-jammy-rfcurated
-      - ghcr.io/defenseunicorns/uds/identity-config:0.15.1
+      - ghcr.io/defenseunicorns/uds/identity-config:0.15.2


### PR DESCRIPTION
## Description

Updates identity config to 0.15.2 - https://github.com/defenseunicorns/uds-identity-config/releases/tag/v0.15.2

Primarily includes theme updates.