### PR TITLE
fix: update rke2 aws-cli install

### DIFF
--- a/.github/test-infra/aws/rke2/irsa.tf
+++ b/.github/test-infra/aws/rke2/irsa.tf
@@ -36,7 +36,7 @@ resource "aws_secretsmanager_secret_version" "private_key" {
 # Public bucket to host OIDC files
 module "oidc_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.1.0"
+  version = "5.2.0"
 
   bucket        = "${var.environment}-oidc-${random_string.ssm.result}"
   force_destroy = var.force_destroy


### PR DESCRIPTION
## Description

With the new RHEL9 install AWS CLI needs to be installed from dnf rather than the old script based method we were trying (this seems to be due to SELinux constraints - possible to get passed but easier to just install from dnf).

## Related Issue

Replaces https://github.com/defenseunicorns/uds-core/pull/1696

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Will be validated in CI. Also validated end to end locally.