### PR TITLE
chore: enable linting on test dirs and address eslint/formatting issues

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-  globalIgnores(["**/node_modules", "**/dist"]),
+  globalIgnores(["**/node_modules", "**/dist", "**/uds-docs/"]),
   {
     extends: compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-  globalIgnores(["**/node_modules", "**/dist", "test/playwright/", "**/scripts/", "**/uds-docs/"]),
+  globalIgnores(["**/node_modules", "**/dist"]),
   {
     extends: compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
 
@@ -39,7 +39,12 @@ export default defineConfig([
       sourceType: "script",
 
       parserOptions: {
-        project: ["./tsconfig.json", "test/vitest/tsconfig.json", "test/playwright/tsconfig.json"],
+        project: [
+          "./tsconfig.json",
+          "test/vitest/tsconfig.json",
+          "test/playwright/tsconfig.json",
+          "scripts/renovate/tsconfig.json",
+        ],
       },
     },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,50 +15,43 @@ import { FlatCompat } from "@eslint/eslintrc";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
 
-export default defineConfig([globalIgnores([
-    "**/node_modules",
-    "**/dist",
-    "**/vitest.*.js",
-    "test/playwright/",
-    "test/vitest/",
-    "**/scripts/",
-    "**/uds-docs/",
-]), {
+export default defineConfig([
+  globalIgnores(["**/node_modules", "**/dist", "test/playwright/", "**/scripts/", "**/uds-docs/"]),
+  {
     extends: compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
 
     plugins: {
-        "@typescript-eslint": typescriptEslint,
+      "@typescript-eslint": typescriptEslint,
     },
 
     languageOptions: {
-        globals: {
-            ...Object.fromEntries(Object.entries(globals.browser).map(([key]) => [key, "off"])),
-        },
+      globals: {
+        ...Object.fromEntries(Object.entries(globals.browser).map(([key]) => [key, "off"])),
+      },
 
-        parser: tsParser,
-        ecmaVersion: 2022,
-        sourceType: "script",
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: "script",
 
-        parserOptions: {
-            project: ["./tsconfig.json"],
-        },
+      parserOptions: {
+        project: ["./tsconfig.json", "test/vitest/tsconfig.json", "test/playwright/tsconfig.json"],
+      },
     },
 
     rules: {
-        "@typescript-eslint/no-floating-promises": ["error"],
+      "@typescript-eslint/no-floating-promises": ["error"],
     },
-}, {
-    files: [
-        "src/pepr/operator/crd/generated/**/*.ts",
-        "src/pepr/operator/crd/generated/*.ts",
-    ],
+  },
+  {
+    files: ["src/pepr/operator/crd/generated/**/*.ts", "src/pepr/operator/crd/generated/*.ts"],
 
     rules: {
-        "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "off",
     },
-}]);
+  },
+]);

--- a/scripts/renovate/compareImagesAndCharts.spec.ts
+++ b/scripts/renovate/compareImagesAndCharts.spec.ts
@@ -3,28 +3,28 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it, Mock, MockInstance, vi } from 'vitest';
-import * as yaml from 'yaml';
-import { compareImagesAndCharts } from './compareImagesAndCharts';
+import * as fs from "fs";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, Mock, MockInstance, vi } from "vitest";
+import * as yaml from "yaml";
+import { compareImagesAndCharts } from "./compareImagesAndCharts";
 
 // Mock fs and path modules
-vi.mock('fs');
-vi.mock('path');
-vi.mock('yaml');
+vi.mock("fs");
+vi.mock("path");
+vi.mock("yaml");
 
-describe('compareImagesAndCharts', () => {
+describe("compareImagesAndCharts", () => {
   let consoleLogSpy: MockInstance;
   let consoleErrorSpy: MockInstance;
 
   beforeEach(() => {
     // Mock path.join to return the input path
-    (path.join as Mock).mockImplementation((...args) => args.join('/'));
+    (path.join as Mock).mockImplementation((...args) => args.join("/"));
 
     // Mock console.log and console.error to prevent output during tests
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -33,884 +33,863 @@ describe('compareImagesAndCharts', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('should detect image updates', async () => {
+  it("should detect image updates", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock yaml.parse to return different content based on the input
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '2.0.0'
+          chart1: "1.0.0",
+          chart2: "2.0.0",
         };
       }
-      if (content === 'charts-new') {
+      if (content === "charts-new") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '2.0.0'
+          chart1: "1.0.0",
+          chart2: "2.0.0",
         };
       }
-      if (content === 'images-old') {
+      if (content === "images-old") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
           ],
-          '8.12.1': [
-            'docker.io/curlimages/curl:8.12.1',
-            'registry1.dso.mil/ironbank/curl:8.12.1',
-            'quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated'
-          ]
+          "8.12.1": [
+            "docker.io/curlimages/curl:8.12.1",
+            "registry1.dso.mil/ironbank/curl:8.12.1",
+            "quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated",
+          ],
         };
       }
-      if (content === 'images-new') {
+      if (content === "images-new") {
         return {
-          '1.25.3': [
-            'docker.io/library/nginx:1.25.3',
-            'registry1.dso.mil/ironbank/nginx:1.25.3',
-            'quay.io/rfcurated/nginx:1.25.3-slim-jammy-fips-rfcurated-rfhardened'
+          "1.25.3": [
+            "docker.io/library/nginx:1.25.3",
+            "registry1.dso.mil/ironbank/nginx:1.25.3",
+            "quay.io/rfcurated/nginx:1.25.3-slim-jammy-fips-rfcurated-rfhardened",
           ],
-          '8.12.1': [
-            'docker.io/curlimages/curl:8.12.1',
-            'registry1.dso.mil/ironbank/curl:8.12.1',
-            'quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated'
-          ]
+          "8.12.1": [
+            "docker.io/curlimages/curl:8.12.1",
+            "registry1.dso.mil/ironbank/curl:8.12.1",
+            "quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated",
+          ],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
     // We should have needs-review since all images are updated properly
-    expect(result.labels).toEqual(['needs-review']);
+    expect(result.labels).toEqual(["needs-review"]);
   });
 
-  it('should detect major image updates', async () => {
+  it("should detect major image updates", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock yaml.parse to return different content based on the input
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '2.0.0'
+          chart1: "1.0.0",
+          chart2: "2.0.0",
         };
       }
-      if (content === 'charts-new') {
+      if (content === "charts-new") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '2.0.0'
+          chart1: "1.0.0",
+          chart2: "2.0.0",
         };
       }
-      if (content === 'images-old') {
+      if (content === "images-old") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
           ],
-          '8.12.1': [
-            'docker.io/curlimages/curl:8.12.1',
-            'registry1.dso.mil/ironbank/curl:8.12.1',
-            'quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated'
-          ]
+          "8.12.1": [
+            "docker.io/curlimages/curl:8.12.1",
+            "registry1.dso.mil/ironbank/curl:8.12.1",
+            "quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated",
+          ],
         };
       }
-      if (content === 'images-new') {
+      if (content === "images-new") {
         return {
-          '2.0.0': [
-            'docker.io/library/nginx:2.0.0',
-            'registry1.dso.mil/ironbank/nginx:2.0.0',
-            'quay.io/rfcurated/nginx:2.0.0-slim-jammy-fips-rfcurated-rfhardened'
+          "2.0.0": [
+            "docker.io/library/nginx:2.0.0",
+            "registry1.dso.mil/ironbank/nginx:2.0.0",
+            "quay.io/rfcurated/nginx:2.0.0-slim-jammy-fips-rfcurated-rfhardened",
           ],
-          '8.12.1': [
-            'docker.io/curlimages/curl:8.12.1',
-            'registry1.dso.mil/ironbank/curl:8.12.1',
-            'quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated'
-          ]
+          "8.12.1": [
+            "docker.io/curlimages/curl:8.12.1",
+            "registry1.dso.mil/ironbank/curl:8.12.1",
+            "quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated",
+          ],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['major-image-update', 'needs-review']);
-    expect(result.changes).toContain('Major image update detected: 1.21.6 to 2.0.0');
+    expect(result.labels).toEqual(["major-image-update", "needs-review"]);
+    expect(result.changes).toContain("Major image update detected: 1.21.6 to 2.0.0");
   });
 
-  it('should detect chart updates', async () => {
+  it("should detect chart updates", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock yaml.parse to return different content based on the input
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '2.0.0'
+          chart1: "1.0.0",
+          chart2: "2.0.0",
         };
       }
-      if (content === 'charts-new') {
+      if (content === "charts-new") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '2.1.0'
+          chart1: "1.0.0",
+          chart2: "2.1.0",
         };
       }
-      if (content === 'images-old') {
+      if (content === "images-old") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ]
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+          ],
         };
       }
-      if (content === 'images-new') {
+      if (content === "images-new") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ]
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+          ],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['helm-chart-only']);
-    expect(result.changes).toContain('Chart chart2 updated from 2.0.0 to 2.1.0');
-    expect(result.changes).toContain('PR contains only helm chart updates');
+    expect(result.labels).toEqual(["helm-chart-only"]);
+    expect(result.changes).toContain("Chart chart2 updated from 2.0.0 to 2.1.0");
+    expect(result.changes).toContain("PR contains only helm chart updates");
   });
 
-  it('should detect major chart updates', async () => {
+  it("should detect major chart updates", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock yaml.parse to return different content based on the input
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '2.0.0'
+          chart1: "1.0.0",
+          chart2: "2.0.0",
         };
       }
-      if (content === 'charts-new') {
+      if (content === "charts-new") {
         return {
-          'chart1': '1.0.0',
-          'chart2': '3.0.0'
+          chart1: "1.0.0",
+          chart2: "3.0.0",
         };
       }
-      if (content === 'images-old') {
+      if (content === "images-old") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ]
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+          ],
         };
       }
-      if (content === 'images-new') {
+      if (content === "images-new") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ]
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+          ],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['major-helm-update', 'helm-chart-only']);
-    expect(result.changes).toContain('Chart chart2 updated from 2.0.0 to 3.0.0');
-    expect(result.changes).toContain('Major helm chart update detected for chart2');
-    expect(result.changes).toContain('PR contains only helm chart updates');
+    expect(result.labels).toEqual(["major-helm-update", "helm-chart-only"]);
+    expect(result.changes).toContain("Chart chart2 updated from 2.0.0 to 3.0.0");
+    expect(result.changes).toContain("Major helm chart update detected for chart2");
+    expect(result.changes).toContain("PR contains only helm chart updates");
   });
 
-  it('should detect waiting on ironbank', async () => {
+  it("should detect waiting on ironbank", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock yaml.parse to return different content based on the input
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
         return {
-          'chart1': '1.0.0'
+          chart1: "1.0.0",
         };
       }
-      if (content === 'charts-new') {
+      if (content === "charts-new") {
         return {
-          'chart1': '1.0.0'
+          chart1: "1.0.0",
         };
       }
-      if (content === 'images-old') {
+      if (content === "images-old") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ]
-        };
-      }
-      if (content === 'images-new') {
-        return {
-          '1.25.3': [
-            'docker.io/library/nginx:1.25.3',
-            'quay.io/rfcurated/nginx:1.25.3-slim-jammy-fips-rfcurated-rfhardened',
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
           ],
-          '1.22.6': [
-            'registry1.dso.mil/ironbank/nginx:1.22.6'
-          ]
+        };
+      }
+      if (content === "images-new") {
+        return {
+          "1.25.3": [
+            "docker.io/library/nginx:1.25.3",
+            "quay.io/rfcurated/nginx:1.25.3-slim-jammy-fips-rfcurated-rfhardened",
+          ],
+          "1.22.6": ["registry1.dso.mil/ironbank/nginx:1.22.6"],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['waiting on ironbank']);
-    expect(result.changes).toContain('Waiting on Ironbank image update: registry1.dso.mil/ironbank/nginx:1.21.6');
+    expect(result.labels).toEqual(["waiting on ironbank"]);
+    expect(result.changes).toContain(
+      "Waiting on Ironbank image update: registry1.dso.mil/ironbank/nginx:1.21.6",
+    );
   });
 
-  it('should detect waiting on rapidfort', async () => {
+  it("should detect waiting on rapidfort", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock yaml.parse to return different content based on the input
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
         return {
-          'chart1': '1.0.0'
+          chart1: "1.0.0",
         };
       }
-      if (content === 'charts-new') {
+      if (content === "charts-new") {
         return {
-          'chart1': '1.0.0'
+          chart1: "1.0.0",
         };
       }
-      if (content === 'images-old') {
+      if (content === "images-old") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ]
-        };
-      }
-      if (content === 'images-new') {
-        return {
-          '1.25.3': [
-            'docker.io/library/nginx:1.25.3',
-            'registry1.dso.mil/ironbank/nginx:1.25.3',
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
           ],
-          '1.21.6': [
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ]
+        };
+      }
+      if (content === "images-new") {
+        return {
+          "1.25.3": ["docker.io/library/nginx:1.25.3", "registry1.dso.mil/ironbank/nginx:1.25.3"],
+          "1.21.6": ["quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened"],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['waiting on rapidfort']);
-    expect(result.changes).toContain('Waiting on Rapidfort image update: quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened');
+    expect(result.labels).toEqual(["waiting on rapidfort"]);
+    expect(result.changes).toContain(
+      "Waiting on Rapidfort image update: quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+    );
   });
 
-  it('should handle mixed image updates with some waiting', async () => {
+  it("should handle mixed image updates with some waiting", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock yaml.parse to return different content based on the input
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
         return {
-          'chart1': '1.0.0'
+          chart1: "1.0.0",
         };
       }
-      if (content === 'charts-new') {
+      if (content === "charts-new") {
         return {
-          'chart1': '1.0.0'
+          chart1: "1.0.0",
         };
       }
-      if (content === 'images-old') {
+      if (content === "images-old") {
         return {
-          '1.21.6': [
-            'docker.io/library/nginx:1.21.6',
-            'registry1.dso.mil/ironbank/nginx:1.21.6',
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
+          "1.21.6": [
+            "docker.io/library/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
           ],
-          '8.12.1': [
-            'docker.io/curlimages/curl:8.12.1',
-            'registry1.dso.mil/ironbank/curl:8.12.1',
-            'quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated'
-          ]
+          "8.12.1": [
+            "docker.io/curlimages/curl:8.12.1",
+            "registry1.dso.mil/ironbank/curl:8.12.1",
+            "quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated",
+          ],
         };
       }
-      if (content === 'images-new') {
+      if (content === "images-new") {
         return {
-          '1.25.3': [
-            'docker.io/library/nginx:1.25.3',
+          "1.25.3": ["docker.io/library/nginx:1.25.3"],
+          "1.22.6": ["registry1.dso.mil/ironbank/nginx:1.22.6"],
+          "1.21.6": ["quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened"],
+          "8.12.1": [
+            "docker.io/curlimages/curl:8.12.1",
+            "registry1.dso.mil/ironbank/curl:8.12.1",
+            "quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated",
           ],
-          '1.22.6': [
-            'registry1.dso.mil/ironbank/nginx:1.22.6'
-          ],
-          '1.21.6': [
-            'quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened'
-          ],
-          '8.12.1': [
-            'docker.io/curlimages/curl:8.12.1',
-            'registry1.dso.mil/ironbank/curl:8.12.1',
-            'quay.io/rfcurated/curl:8.12.1-jammy-scratch-fips-rfcurated'
-          ]
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['waiting on ironbank', 'waiting on rapidfort']);
-    expect(result.changes).toContain('Waiting on Ironbank image update: registry1.dso.mil/ironbank/nginx:1.21.6');
-    expect(result.changes).toContain('Waiting on Rapidfort image update: quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened');
+    expect(result.labels).toEqual(["waiting on ironbank", "waiting on rapidfort"]);
+    expect(result.changes).toContain(
+      "Waiting on Ironbank image update: registry1.dso.mil/ironbank/nginx:1.21.6",
+    );
+    expect(result.changes).toContain(
+      "Waiting on Rapidfort image update: quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+    );
   });
 
-  it('should handle empty files gracefully', async () => {
+  it("should handle empty files gracefully", async () => {
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock fs.readFileSync to return empty content for new/images.yaml
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return '   '; // Empty file with whitespace
+      if (filePath === "new/images.yaml") {
+        return "   "; // Empty file with whitespace
       }
-      return '';
+      return "";
     });
 
     // Mock yaml.parse to return valid content for non-empty files
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old' || content === 'charts-new') {
-        return { 'chart1': '1.0.0' };
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old" || content === "charts-new") {
+        return { chart1: "1.0.0" };
       }
-      if (content === 'images-old') {
-        return { '1.21.6': ['docker.io/library/nginx:1.21.6'] };
+      if (content === "images-old") {
+        return { "1.21.6": ["docker.io/library/nginx:1.21.6"] };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['needs-review']);
+    expect(result.labels).toEqual(["needs-review"]);
   });
 
-  it('should throw an error if old images file is missing', async () => {
+  it("should throw an error if old images file is missing", async () => {
     // Mock fs.existsSync to return false for old/images.yaml
-    (fs.existsSync as Mock).mockImplementation((filePath) => {
-      return filePath !== 'old/images.yaml';
+    (fs.existsSync as Mock).mockImplementation(filePath => {
+      return filePath !== "old/images.yaml";
     });
 
     // Mock fs.readFileSync to return content for other files
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock yaml.parse to return valid content
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old' || content === 'charts-new') {
-        return { 'chart1': '1.0.0' };
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old" || content === "charts-new") {
+        return { chart1: "1.0.0" };
       }
-      if (content === 'images-new') {
-        return { '1.21.6': ['docker.io/library/nginx:1.21.6'] };
+      if (content === "images-new") {
+        return { "1.21.6": ["docker.io/library/nginx:1.21.6"] };
       }
       return {};
     });
 
-    await expect(compareImagesAndCharts('old', 'new')).rejects.toThrow('File does not exist: old/images.yaml');
+    await expect(compareImagesAndCharts("old", "new")).rejects.toThrow(
+      "File does not exist: old/images.yaml",
+    );
   });
 
-  it('should throw an error if new images file is missing', async () => {
+  it("should throw an error if new images file is missing", async () => {
     // Mock fs.existsSync to return false for new/images.yaml
-    (fs.existsSync as Mock).mockImplementation((filePath) => {
-      return filePath !== 'new/images.yaml';
+    (fs.existsSync as Mock).mockImplementation(filePath => {
+      return filePath !== "new/images.yaml";
     });
 
     // Mock fs.readFileSync to return content for other files
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      return '';
+      return "";
     });
 
     // Mock yaml.parse to return valid content
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old' || content === 'charts-new') {
-        return { 'chart1': '1.0.0' };
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old" || content === "charts-new") {
+        return { chart1: "1.0.0" };
       }
-      if (content === 'images-old') {
-        return { '1.21.6': ['docker.io/library/nginx:1.21.6'] };
+      if (content === "images-old") {
+        return { "1.21.6": ["docker.io/library/nginx:1.21.6"] };
       }
       return {};
     });
 
-    await expect(compareImagesAndCharts('old', 'new')).rejects.toThrow('File does not exist: new/images.yaml');
+    await expect(compareImagesAndCharts("old", "new")).rejects.toThrow(
+      "File does not exist: new/images.yaml",
+    );
   });
 
-  it('should throw an error if old charts file is missing', async () => {
+  it("should throw an error if old charts file is missing", async () => {
     // Mock fs.existsSync to return false for old/charts.yaml
-    (fs.existsSync as Mock).mockImplementation((filePath) => {
-      return filePath !== 'old/charts.yaml';
+    (fs.existsSync as Mock).mockImplementation(filePath => {
+      return filePath !== "old/charts.yaml";
     });
 
     // Mock fs.readFileSync to return content for other files
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock yaml.parse to return valid content
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-new') {
-        return { 'chart1': '1.0.0' };
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-new") {
+        return { chart1: "1.0.0" };
       }
-      if (content === 'images-old' || content === 'images-new') {
-        return { '1.21.6': ['docker.io/library/nginx:1.21.6'] };
+      if (content === "images-old" || content === "images-new") {
+        return { "1.21.6": ["docker.io/library/nginx:1.21.6"] };
       }
       return {};
     });
 
-    await expect(compareImagesAndCharts('old', 'new')).rejects.toThrow('File does not exist: old/charts.yaml');
+    await expect(compareImagesAndCharts("old", "new")).rejects.toThrow(
+      "File does not exist: old/charts.yaml",
+    );
   });
 
-  it('should throw an error if new charts file is missing', async () => {
+  it("should throw an error if new charts file is missing", async () => {
     // Mock fs.existsSync to return false for new/charts.yaml
-    (fs.existsSync as Mock).mockImplementation((filePath) => {
-      return filePath !== 'new/charts.yaml';
+    (fs.existsSync as Mock).mockImplementation(filePath => {
+      return filePath !== "new/charts.yaml";
     });
 
     // Mock fs.readFileSync to return content for other files
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock yaml.parse to return valid content
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old') {
-        return { 'chart1': '1.0.0' };
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
+        return { chart1: "1.0.0" };
       }
-      if (content === 'images-old' || content === 'images-new') {
-        return { '1.21.6': ['docker.io/library/nginx:1.21.6'] };
+      if (content === "images-old" || content === "images-new") {
+        return { "1.21.6": ["docker.io/library/nginx:1.21.6"] };
       }
       return {};
     });
 
-    await expect(compareImagesAndCharts('old', 'new')).rejects.toThrow('File does not exist: new/charts.yaml');
+    await expect(compareImagesAndCharts("old", "new")).rejects.toThrow(
+      "File does not exist: new/charts.yaml",
+    );
   });
 
-  it('should throw an error if a file contains invalid YAML', async () => {
+  it("should throw an error if a file contains invalid YAML", async () => {
     // Mock fs.existsSync to return true for all files
     (fs.existsSync as Mock).mockReturnValue(true);
 
     // Mock fs.readFileSync to return content for all files
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return 'charts-old';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
       }
-      if (filePath === 'new/charts.yaml') {
-        return 'charts-new';
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
       }
-      if (filePath === 'old/images.yaml') {
-        return 'images-old';
+      if (filePath === "old/images.yaml") {
+        return "images-old";
       }
-      if (filePath === 'new/images.yaml') {
-        return 'images-new';
+      if (filePath === "new/images.yaml") {
+        return "images-new";
       }
-      return '';
+      return "";
     });
 
     // Mock yaml.parse to throw an error for new/images.yaml
-    (yaml.parse as Mock).mockImplementation((content) => {
-      if (content === 'charts-old' || content === 'charts-new') {
-        return { 'chart1': '1.0.0' };
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old" || content === "charts-new") {
+        return { chart1: "1.0.0" };
       }
-      if (content === 'images-old') {
-        return { '1.21.6': ['docker.io/library/nginx:1.21.6'] };
+      if (content === "images-old") {
+        return { "1.21.6": ["docker.io/library/nginx:1.21.6"] };
       }
-      if (content === 'images-new') {
-        throw new Error('Invalid YAML');
+      if (content === "images-new") {
+        throw new Error("Invalid YAML");
       }
       return {};
     });
 
-    await expect(compareImagesAndCharts('old', 'new')).rejects.toThrow('Invalid YAML');
+    await expect(compareImagesAndCharts("old", "new")).rejects.toThrow("Invalid YAML");
   });
 
-  it('should handle images without matches in other flavors', async () => {
+  it("should handle images without matches in other flavors", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
-        return '';
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "";
       }
-      if (filePath === 'new/charts.yaml') {
-        return '';
+      if (filePath === "new/charts.yaml") {
+        return "";
       }
-      if (filePath === 'old/images.yaml') {
+      if (filePath === "old/images.yaml") {
         return {
-          '1.0.0': [
-            'docker.io/library/busybox:1.0.0',
-          ]
+          "1.0.0": ["docker.io/library/busybox:1.0.0"],
         };
       }
-      if (filePath === 'new/images.yaml') {
+      if (filePath === "new/images.yaml") {
         return {
-          '1.1.0': [
-            'docker.io/library/busybox:1.1.0',
-          ]
+          "1.1.0": ["docker.io/library/busybox:1.1.0"],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['needs-review']);
+    expect(result.labels).toEqual(["needs-review"]);
   });
 
-  it('should handle helm chart only update', async () => {
+  it("should handle helm chart only update", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
         return {
-          'grafana': '6.50.5',
-          'prometheus': '15.18.0'
+          grafana: "6.50.5",
+          prometheus: "15.18.0",
         };
       }
-      if (filePath === 'new/charts.yaml') {
+      if (filePath === "new/charts.yaml") {
         return {
-          'grafana': '6.50.7',
-          'prometheus': '15.18.0'
+          grafana: "6.50.7",
+          prometheus: "15.18.0",
         };
       }
-      if (filePath === 'old/images.yaml') {
+      if (filePath === "old/images.yaml") {
         return {
-          '1.0.0': [
-            'docker.io/library/nginx:1.0.0'
-          ]
+          "1.0.0": ["docker.io/library/nginx:1.0.0"],
         };
       }
-      if (filePath === 'new/images.yaml') {
+      if (filePath === "new/images.yaml") {
         return {
-          '1.0.0': [
-            'docker.io/library/nginx:1.0.0'
-          ]
+          "1.0.0": ["docker.io/library/nginx:1.0.0"],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['helm-chart-only']);
-    expect(result.changes).toContain('Chart grafana updated from 6.50.5 to 6.50.7');
-    expect(result.changes).toContain('PR contains only helm chart updates');
+    expect(result.labels).toEqual(["helm-chart-only"]);
+    expect(result.changes).toContain("Chart grafana updated from 6.50.5 to 6.50.7");
+    expect(result.changes).toContain("PR contains only helm chart updates");
   });
 
-  it('should detect major helm chart update', async () => {
+  it("should detect major helm chart update", async () => {
     // Mock fs.readFileSync to return different content based on the file path
-    (fs.readFileSync as Mock).mockImplementation((filePath) => {
-      if (filePath === 'old/charts.yaml') {
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
         return {
-          'grafana': '6.50.5',
-          'prometheus': '15.18.0'
+          grafana: "6.50.5",
+          prometheus: "15.18.0",
         };
       }
-      if (filePath === 'new/charts.yaml') {
+      if (filePath === "new/charts.yaml") {
         return {
-          'grafana': '7.0.0',
-          'prometheus': '15.18.0'
+          grafana: "7.0.0",
+          prometheus: "15.18.0",
         };
       }
-      if (filePath === 'old/images.yaml') {
+      if (filePath === "old/images.yaml") {
         return {
-          '1.0.0': [
-            'docker.io/library/nginx:1.0.0'
-          ]
+          "1.0.0": ["docker.io/library/nginx:1.0.0"],
         };
       }
-      if (filePath === 'new/images.yaml') {
+      if (filePath === "new/images.yaml") {
         return {
-          '1.0.0': [
-            'docker.io/library/nginx:1.0.0'
-          ]
+          "1.0.0": ["docker.io/library/nginx:1.0.0"],
         };
       }
       return {};
     });
 
-    const result = await compareImagesAndCharts('old', 'new');
+    const result = await compareImagesAndCharts("old", "new");
 
-    expect(result.labels).toEqual(['major-helm-update', 'helm-chart-only']);
-    expect(result.changes).toContain('Chart grafana updated from 6.50.5 to 7.0.0');
-    expect(result.changes).toContain('Major helm chart update detected for grafana');
-    expect(result.changes).toContain('PR contains only helm chart updates');
+    expect(result.labels).toEqual(["major-helm-update", "helm-chart-only"]);
+    expect(result.changes).toContain("Chart grafana updated from 6.50.5 to 7.0.0");
+    expect(result.changes).toContain("Major helm chart update detected for grafana");
+    expect(result.changes).toContain("PR contains only helm chart updates");
   });
 });
 
-it('should detect wait for loki (regression test)', async () => {
+it("should detect wait for loki (regression test)", async () => {
   // Mock fs.readFileSync to return different content based on the file path
-  (fs.readFileSync as Mock).mockImplementation((filePath) => {
-    if (filePath === 'old/charts.yaml') {
-      return 'charts-old';
+  (fs.readFileSync as Mock).mockImplementation(filePath => {
+    if (filePath === "old/charts.yaml") {
+      return "charts-old";
     }
-    if (filePath === 'new/charts.yaml') {
-      return 'charts-new';
+    if (filePath === "new/charts.yaml") {
+      return "charts-new";
     }
-    if (filePath === 'old/images.yaml') {
-      return 'images-old';
+    if (filePath === "old/images.yaml") {
+      return "images-old";
     }
-    if (filePath === 'new/images.yaml') {
-      return 'images-new';
+    if (filePath === "new/images.yaml") {
+      return "images-new";
     }
-    return '';
+    return "";
   });
 
   // Mock fs.existsSync to return true for all files
   (fs.existsSync as Mock).mockReturnValue(true);
 
   // Mock yaml.parse to return different content based on the input
-  (yaml.parse as Mock).mockImplementation((content) => {
-    if (content === 'charts-old') {
+  (yaml.parse as Mock).mockImplementation(content => {
+    if (content === "charts-old") {
       return {
-        'https://grafana.github.io/helm-charts/loki': '6.29.0'
+        "https://grafana.github.io/helm-charts/loki": "6.29.0",
       };
     }
-    if (content === 'charts-new') {
+    if (content === "charts-new") {
       return {
-        'https://grafana.github.io/helm-charts/loki': '6.29.0'
+        "https://grafana.github.io/helm-charts/loki": "6.29.0",
       };
     }
-    if (content === 'images-old') {
+    if (content === "images-old") {
       return {
-        '3.4.3': [
-          'docker.io/grafana/loki:3.4.3',
-          'registry1.dso.mil/ironbank/opensource/grafana/loki:3.4.3',
-          'quay.io/rfcurated/grafana/loki:3.4.3-jammy-fips-rfcurated-rfhardened'
+        "3.4.3": [
+          "docker.io/grafana/loki:3.4.3",
+          "registry1.dso.mil/ironbank/opensource/grafana/loki:3.4.3",
+          "quay.io/rfcurated/grafana/loki:3.4.3-jammy-fips-rfcurated-rfhardened",
         ],
-        '1.6.38': [
-          'docker.io/memcached:1.6.38-alpine',
-          'registry1.dso.mil/ironbank/opensource/memcached/memcached:1.6.38',
-          'quay.io/rfcurated/memcached:1.6.38-jammy-fips-rfcurated-rfhardened'
+        "1.6.38": [
+          "docker.io/memcached:1.6.38-alpine",
+          "registry1.dso.mil/ironbank/opensource/memcached/memcached:1.6.38",
+          "quay.io/rfcurated/memcached:1.6.38-jammy-fips-rfcurated-rfhardened",
         ],
-        '1.27': [
-          'docker.io/nginxinc/nginx-unprivileged:1.27-alpine'
-        ],
-        '1.26.3': [
-          'registry1.dso.mil/ironbank/opensource/nginx/nginx-alpine:1.26.3'
-        ],
-        '1.27.5': [
-          'quay.io/rfcurated/nginx:1.27.5-slim-jammy-fips-rfcurated-rfhardened'
-        ]
+        "1.27": ["docker.io/nginxinc/nginx-unprivileged:1.27-alpine"],
+        "1.26.3": ["registry1.dso.mil/ironbank/opensource/nginx/nginx-alpine:1.26.3"],
+        "1.27.5": ["quay.io/rfcurated/nginx:1.27.5-slim-jammy-fips-rfcurated-rfhardened"],
       };
     }
-    if (content === 'images-new') {
+    if (content === "images-new") {
       return {
-        '1.27': [
-          'docker.io/nginxinc/nginx-unprivileged:1.27-alpine'
+        "1.27": ["docker.io/nginxinc/nginx-unprivileged:1.27-alpine"],
+        "3.4.3": ["quay.io/rfcurated/grafana/loki:3.4.3-jammy-fips-rfcurated-rfhardened"],
+        "1.6.38": [
+          "docker.io/memcached:1.6.38-alpine",
+          "registry1.dso.mil/ironbank/opensource/memcached/memcached:1.6.38",
+          "quay.io/rfcurated/memcached:1.6.38-jammy-fips-rfcurated-rfhardened",
         ],
-        '3.4.3': [
-          'quay.io/rfcurated/grafana/loki:3.4.3-jammy-fips-rfcurated-rfhardened'
+        "1.26.3": ["registry1.dso.mil/ironbank/opensource/nginx/nginx-alpine:1.26.3"],
+        "1.27.5": ["quay.io/rfcurated/nginx:1.27.5-slim-jammy-fips-rfcurated-rfhardened"],
+        "3.5.0": [
+          "docker.io/grafana/loki:3.5.0",
+          "registry1.dso.mil/ironbank/opensource/grafana/loki:3.5.0",
         ],
-        '1.6.38': [
-          'docker.io/memcached:1.6.38-alpine',
-          'registry1.dso.mil/ironbank/opensource/memcached/memcached:1.6.38',
-          'quay.io/rfcurated/memcached:1.6.38-jammy-fips-rfcurated-rfhardened'
-        ],
-        '1.26.3': [
-          'registry1.dso.mil/ironbank/opensource/nginx/nginx-alpine:1.26.3'
-        ],
-        '1.27.5': [
-          'quay.io/rfcurated/nginx:1.27.5-slim-jammy-fips-rfcurated-rfhardened'
-        ],
-        '3.5.0': [
-          'docker.io/grafana/loki:3.5.0',
-          'registry1.dso.mil/ironbank/opensource/grafana/loki:3.5.0'
-        ]
       };
     }
     return {};
   });
 
-  const result = await compareImagesAndCharts('old', 'new');
+  const result = await compareImagesAndCharts("old", "new");
 
-  expect(result.labels).toEqual(['waiting on rapidfort']);
-  expect(result.changes).toContain('Waiting on Rapidfort image update: quay.io/rfcurated/grafana/loki:3.4.3-jammy-fips-rfcurated-rfhardened');
+  expect(result.labels).toEqual(["waiting on rapidfort"]);
+  expect(result.changes).toContain(
+    "Waiting on Rapidfort image update: quay.io/rfcurated/grafana/loki:3.4.3-jammy-fips-rfcurated-rfhardened",
+  );
 });

--- a/scripts/renovate/compareImagesAndCharts.ts
+++ b/scripts/renovate/compareImagesAndCharts.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as semver from 'semver';
-import * as yaml from 'yaml';
+import * as fs from "fs";
+import * as path from "path";
+import * as semver from "semver";
+import * as yaml from "yaml";
 
 interface ComparisonResult {
   changes: string[];
@@ -19,20 +19,23 @@ interface ComparisonResult {
  * @param newPath - Path to the new extract folder
  * @returns ComparisonResult with changes and labels
  */
-export async function compareImagesAndCharts(oldPath: string, newPath: string): Promise<ComparisonResult> {
+export async function compareImagesAndCharts(
+  oldPath: string,
+  newPath: string,
+): Promise<ComparisonResult> {
   const result: ComparisonResult = {
     changes: [],
-    labels: []
+    labels: [],
   };
 
   try {
     // Load chart data
-    const oldCharts = loadYamlFile(path.join(oldPath, 'charts.yaml'));
-    const newCharts = loadYamlFile(path.join(newPath, 'charts.yaml'));
+    const oldCharts = loadYamlFile(path.join(oldPath, "charts.yaml"));
+    const newCharts = loadYamlFile(path.join(newPath, "charts.yaml"));
 
     // Load image data
-    const oldImages = loadYamlFile(path.join(oldPath, 'images.yaml'));
-    const newImages = loadYamlFile(path.join(newPath, 'images.yaml'));
+    const oldImages = loadYamlFile(path.join(oldPath, "images.yaml"));
+    const newImages = loadYamlFile(path.join(newPath, "images.yaml"));
 
     // Compare charts
     const hasHelmUpdates = compareCharts(oldCharts, newCharts, result);
@@ -42,19 +45,23 @@ export async function compareImagesAndCharts(oldPath: string, newPath: string): 
 
     // Add helm-chart-only label if applicable
     if (hasHelmUpdates && !hasImageUpdates) {
-      result.labels.push('helm-chart-only');
-      result.changes.push('PR contains only helm chart updates');
+      result.labels.push("helm-chart-only");
+      result.changes.push("PR contains only helm chart updates");
     }
 
     // If no waiting labels were added, add needs-review
-    if (!result.labels.includes('waiting on ironbank') &&
-      !result.labels.includes('waiting on rapidfort') &&
-      !result.labels.includes('helm-chart-only')) {
-      result.labels.push('needs-review');
+    if (
+      !result.labels.includes("waiting on ironbank") &&
+      !result.labels.includes("waiting on rapidfort") &&
+      !result.labels.includes("helm-chart-only")
+    ) {
+      result.labels.push("needs-review");
     }
   } catch (error: unknown) {
     console.error(`Error comparing artifacts: ${error}`);
-    result.changes = [`Error comparing artifacts: ${error instanceof Error ? error.message : String(error)}`];
+    result.changes = [
+      `Error comparing artifacts: ${error instanceof Error ? error.message : String(error)}`,
+    ];
 
     // When running from command line, this error will be caught by the catch block
     // and will cause the process to exit with code 1
@@ -62,14 +69,14 @@ export async function compareImagesAndCharts(oldPath: string, newPath: string): 
   }
 
   // Output results
-  console.log('Changes:');
+  console.log("Changes:");
   result.changes.forEach(change => console.log(`- ${change}`));
 
-  console.log('Labels:');
+  console.log("Labels:");
   result.labels.forEach(label => console.log(`- ${label}`));
 
   // Output comma-separated labels for GitHub CLI
-  console.log(`LABELS=${result.labels.join(',')}`);
+  console.log(`LABELS=${result.labels.join(",")}`);
 
   return result;
 }
@@ -79,16 +86,19 @@ export async function compareImagesAndCharts(oldPath: string, newPath: string): 
  * @param filePath - Path to the YAML file
  * @returns Parsed YAML content
  */
-function loadYamlFile(filePath: string): any {
+// Define a type for YAML content structure
+type YamlContent = Record<string, unknown> | unknown[];
+
+function loadYamlFile(filePath: string): YamlContent {
   try {
     if (!fs.existsSync(filePath)) {
       throw new Error(`File does not exist: ${filePath}`);
     }
 
-    const content = fs.readFileSync(filePath, 'utf8');
+    const content = fs.readFileSync(filePath, "utf8");
 
     // If content is already an object (for testing), return it
-    if (typeof content !== 'string') {
+    if (typeof content !== "string") {
       return content;
     }
 
@@ -118,7 +128,11 @@ function loadYamlFile(filePath: string): any {
  * @param result - Result object to update
  * @returns Boolean indicating if there are helm updates
  */
-function compareCharts(oldCharts: any, newCharts: any, result: ComparisonResult): boolean {
+function compareCharts(
+  oldCharts: Record<string, string>,
+  newCharts: Record<string, string>,
+  result: ComparisonResult,
+): boolean {
   let hasHelmUpdates = false;
 
   // Check for chart updates
@@ -131,9 +145,12 @@ function compareCharts(oldCharts: any, newCharts: any, result: ComparisonResult)
       result.changes.push(`Chart ${chartKey} updated from ${oldVersion} to ${newVersion}`);
 
       // Check if this is a major update
-      if (semver.valid(oldVersion) && semver.valid(newVersion) &&
-        semver.diff(oldVersion, newVersion) === 'major') {
-        result.labels.push('major-helm-update');
+      if (
+        semver.valid(oldVersion) &&
+        semver.valid(newVersion) &&
+        semver.diff(oldVersion, newVersion) === "major"
+      ) {
+        result.labels.push("major-helm-update");
         result.changes.push(`Major helm chart update detected for ${chartKey}`);
       }
     }
@@ -149,7 +166,11 @@ function compareCharts(oldCharts: any, newCharts: any, result: ComparisonResult)
  * @param result - Result object to update
  * @returns Boolean indicating if there are image updates
  */
-function compareImages(oldImages: any, newImages: any, result: ComparisonResult): boolean {
+function compareImages(
+  oldImages: Record<string, string[]>,
+  newImages: Record<string, string[]>,
+  result: ComparisonResult,
+): boolean {
   let hasImageUpdates = false;
 
   // Check for image updates
@@ -164,19 +185,19 @@ function compareImages(oldImages: any, newImages: any, result: ComparisonResult)
   // Build maps of version-to-images for comparison
   const oldVersionMap: Record<string, string[]> = {};
   for (const version in oldImages) {
-    oldVersionMap[version] = oldImages[version].map((img: string) => img.split(':')[0]);
+    oldVersionMap[version] = oldImages[version].map((img: string) => img.split(":")[0]);
   }
 
   const newVersionMap: Record<string, string[]> = {};
   for (const version in newImages) {
-    newVersionMap[version] = newImages[version].map((img: string) => img.split(':')[0]);
+    newVersionMap[version] = newImages[version].map((img: string) => img.split(":")[0]);
   }
 
   // Create a map of all image base names to their versions in the new data
   const allNewImageVersions: Record<string, string[]> = {};
   for (const version in newImages) {
     for (const img of newImages[version]) {
-      const imgName = img.split(':')[0];
+      const imgName = img.split(":")[0];
       if (!allNewImageVersions[imgName]) {
         allNewImageVersions[imgName] = [];
       }
@@ -204,21 +225,23 @@ function compareImages(oldImages: any, newImages: any, result: ComparisonResult)
         foundMatch = true;
 
         // Find the images that are in old but not in new
-        const missingImageNames = oldImageNames.filter((name: string) => !newImageNames.includes(name));
+        const missingImageNames = oldImageNames.filter(
+          (name: string) => !newImageNames.includes(name),
+        );
 
         // Get the full image strings for the missing images
         const missingImageStrings = oldImages[oldVersion].filter((img: string) => {
-          const imgName = img.split(':')[0];
+          const imgName = img.split(":")[0];
           return missingImageNames.includes(imgName);
         });
 
         // Check registry prefixes and add appropriate labels
         for (const missingImg of missingImageStrings) {
-          const imgName = missingImg.split(':')[0];
+          const imgName = missingImg.split(":")[0];
 
           // Check if this image exists in any newer version
-          const existsInNewerVersion = allNewImageVersions[imgName]?.some(ver =>
-            semver.valid(ver) && semver.valid(newVersion) && semver.gt(ver, newVersion)
+          const existsInNewerVersion = allNewImageVersions[imgName]?.some(
+            ver => semver.valid(ver) && semver.valid(newVersion) && semver.gt(ver, newVersion),
           );
 
           // Skip if the image exists in a newer version
@@ -226,14 +249,14 @@ function compareImages(oldImages: any, newImages: any, result: ComparisonResult)
             continue;
           }
 
-          if (missingImg.includes('registry1.dso.mil')) {
-            if (!result.labels.includes('waiting on ironbank')) {
-              result.labels.push('waiting on ironbank');
+          if (missingImg.includes("registry1.dso.mil")) {
+            if (!result.labels.includes("waiting on ironbank")) {
+              result.labels.push("waiting on ironbank");
               result.changes.push(`Waiting on Ironbank image update: ${missingImg}`);
             }
-          } else if (missingImg.startsWith('quay.io/rfcurated')) {
-            if (!result.labels.includes('waiting on rapidfort')) {
-              result.labels.push('waiting on rapidfort');
+          } else if (missingImg.startsWith("quay.io/rfcurated")) {
+            if (!result.labels.includes("waiting on rapidfort")) {
+              result.labels.push("waiting on rapidfort");
               result.changes.push(`Waiting on Rapidfort image update: ${missingImg}`);
             }
           }
@@ -271,12 +294,14 @@ function isSubset(a: string[], b: string[]): boolean {
  * @returns Boolean indicating if a major update was detected
  */
 function checkForMajorUpdate(oldVersion: string, newVersion: string, result: ComparisonResult) {
-  if (oldVersion !== newVersion &&
+  if (
+    oldVersion !== newVersion &&
     semver.valid(oldVersion) &&
     semver.valid(newVersion) &&
-    semver.diff(oldVersion, newVersion) === 'major') {
-    if (!result.labels.includes('major-image-update')) {
-      result.labels.push('major-image-update');
+    semver.diff(oldVersion, newVersion) === "major"
+  ) {
+    if (!result.labels.includes("major-image-update")) {
+      result.labels.push("major-image-update");
     }
     result.changes.push(`Major image update detected: ${oldVersion} to ${newVersion}`);
   }
@@ -288,13 +313,13 @@ if (require.main === module) {
   const newPath = process.argv[3];
 
   if (!oldPath || !newPath) {
-    console.error('Please provide old and new paths');
+    console.error("Please provide old and new paths");
     process.exit(1);
   }
 
   compareImagesAndCharts(oldPath, newPath)
     .then(() => process.exit(0))
-    .catch((error) => {
+    .catch(error => {
       console.error(error);
       process.exit(1);
     });

--- a/scripts/renovate/getImagesAndCharts.ts
+++ b/scripts/renovate/getImagesAndCharts.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as yaml from 'yaml';
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "yaml";
 
 /**
  * Extracts images and charts from zarf.yaml files in a given directory path
@@ -13,7 +13,7 @@ import * as yaml from 'yaml';
  */
 export async function getImagesAndCharts(directoryPath: string): Promise<void> {
   // Create extract directory if it doesn't exist
-  const extractDir = path.join(directoryPath, 'extract');
+  const extractDir = path.join(directoryPath, "extract");
   if (!fs.existsSync(extractDir)) {
     fs.mkdirSync(extractDir, { recursive: true });
   }
@@ -27,7 +27,7 @@ export async function getImagesAndCharts(directoryPath: string): Promise<void> {
 
   for (const zarfFile of zarfFiles) {
     try {
-      const fileContent = fs.readFileSync(zarfFile, 'utf8');
+      const fileContent = fs.readFileSync(zarfFile, "utf8");
       const zarfConfig = yaml.parse(fileContent);
 
       // Extract charts
@@ -41,16 +41,10 @@ export async function getImagesAndCharts(directoryPath: string): Promise<void> {
   }
 
   // Write charts to file
-  fs.writeFileSync(
-    path.join(extractDir, 'charts.yaml'),
-    yaml.stringify(charts)
-  );
+  fs.writeFileSync(path.join(extractDir, "charts.yaml"), yaml.stringify(charts));
 
   // Write images to file
-  fs.writeFileSync(
-    path.join(extractDir, 'images.yaml'),
-    yaml.stringify(images)
-  );
+  fs.writeFileSync(path.join(extractDir, "images.yaml"), yaml.stringify(images));
 }
 
 /**
@@ -69,10 +63,10 @@ function findZarfYamlFiles(dir: string): string[] {
 
     if (stat.isDirectory()) {
       // Skip the extract directory and node_modules
-      if (file !== 'extract' && file !== 'node_modules' && file !== '.git') {
+      if (file !== "extract" && file !== "node_modules" && file !== ".git") {
         results = results.concat(findZarfYamlFiles(filePath));
       }
-    } else if (file === 'zarf.yaml') {
+    } else if (file === "zarf.yaml") {
       results.push(filePath);
     }
   }
@@ -85,7 +79,17 @@ function findZarfYamlFiles(dir: string): string[] {
  * @param zarfConfig - Parsed zarf.yaml configuration
  * @param charts - Record to store chart information
  */
-function extractCharts(zarfConfig: any, charts: Record<string, string>): void {
+// Define a ZarfConfig type to replace 'any'
+interface ZarfComponent {
+  charts?: Array<{ name: string; version: string; localPath?: string; url?: string }>;
+  images?: Array<{ name: string }>;
+}
+
+interface ZarfConfig {
+  components?: ZarfComponent[];
+}
+
+function extractCharts(zarfConfig: ZarfConfig, charts: Record<string, string>): void {
   if (!zarfConfig.components) return;
 
   for (const component of zarfConfig.components) {
@@ -108,13 +112,13 @@ function extractCharts(zarfConfig: any, charts: Record<string, string>): void {
  * @param zarfConfig - Parsed zarf.yaml configuration
  * @param images - Record to store image information
  */
-function extractImages(zarfConfig: any, images: Record<string, string[]>): void {
+function extractImages(zarfConfig: ZarfConfig, images: Record<string, string[]>): void {
   if (!zarfConfig.components) return;
 
   for (const component of zarfConfig.components) {
     if (component.images) {
       for (const image of component.images) {
-        if (typeof image === 'string') {
+        if (typeof image === "string") {
           processImage(image, images);
         }
       }
@@ -129,7 +133,7 @@ function extractImages(zarfConfig: any, images: Record<string, string[]>): void 
  */
 function processImage(imagePullString: string, images: Record<string, string[]>): void {
   // Split image name and tag
-  const [imageName, imageTag] = imagePullString.split(':');
+  const [imageName, imageTag] = imagePullString.split(":");
 
   if (!imageName || !imageTag) return;
 
@@ -137,7 +141,7 @@ function processImage(imagePullString: string, images: Record<string, string[]>)
   let normalizedTag = imageTag;
 
   // Remove 'v' prefix if present
-  if (normalizedTag.startsWith('v')) {
+  if (normalizedTag.startsWith("v")) {
     normalizedTag = normalizedTag.substring(1);
   }
 
@@ -161,13 +165,13 @@ function processImage(imagePullString: string, images: Record<string, string[]>)
 if (require.main === module) {
   const directoryPath = process.argv[2];
   if (!directoryPath) {
-    console.error('Please provide a directory path');
+    console.error("Please provide a directory path");
     process.exit(1);
   }
 
   getImagesAndCharts(directoryPath)
     .then(() => process.exit(0))
-    .catch((error) => {
+    .catch(error => {
       console.error(error);
       process.exit(1);
     });

--- a/test/playwright/auth.setup.ts
+++ b/test/playwright/auth.setup.ts
@@ -20,9 +20,7 @@ setup("authenticate", async ({ page, context }) => {
 
   // ensure auth cookies were set
   const cookies = await context.cookies();
-  const keycloakCookie = cookies.find(
-    (cookie) => cookie.name === "KEYCLOAK_SESSION",
-  );
+  const keycloakCookie = cookies.find(cookie => cookie.name === "KEYCLOAK_SESSION");
 
   expect(keycloakCookie).toBeDefined();
   expect(keycloakCookie?.value).not.toBe("");

--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -7,36 +7,42 @@ import { expect, test } from "@playwright/test";
 import { domain, fullCore } from "./uds.config";
 
 test.use({ baseURL: `https://grafana.admin.${domain}` });
-test.describe.configure({ mode: 'serial' });
+test.describe.configure({ mode: "serial" });
 
 test("validate loki datasource", async ({ page }) => {
   test.skip(!fullCore, "Loki is only present on full core deploys");
   await test.step("check loki", async () => {
     await page.goto(`/connections/datasources`);
-    await page.getByRole('link', { name: 'Loki' }).click();
-    await page.click('text=Save & test');
+    await page.getByRole("link", { name: "Loki" }).click();
+    await page.click("text=Save & test");
     // Allow 40 second timeout for datasource validation
-    await expect(page.locator('[data-testid="data-testid Alert success"]')).toBeVisible({ timeout: 40000 });
+    await expect(page.locator('[data-testid="data-testid Alert success"]')).toBeVisible({
+      timeout: 40000,
+    });
   });
 });
 
 test("validate prometheus datasource", async ({ page }) => {
   await test.step("check prometheus", async () => {
     await page.goto(`/connections/datasources`);
-    await page.getByRole('link', { name: 'Prometheus' }).click();
-    await page.click('text=Save & test');
+    await page.getByRole("link", { name: "Prometheus" }).click();
+    await page.click("text=Save & test");
     // Allow 20 second timeout for datasource validation
-    await expect(page.locator('[data-testid="data-testid Alert success"]')).toBeVisible({ timeout: 20000 });
+    await expect(page.locator('[data-testid="data-testid Alert success"]')).toBeVisible({
+      timeout: 20000,
+    });
   });
 });
 
 test("validate alertmanager datasource", async ({ page }) => {
   await test.step("check alertmanager", async () => {
     await page.goto(`/connections/datasources`);
-    await page.getByRole('link', { name: 'Alertmanager' }).click();
-    await page.click('text=Save & test');
+    await page.getByRole("link", { name: "Alertmanager" }).click();
+    await page.click("text=Save & test");
     // Allow 20 second timeout for datasource validation
-    await expect(page.locator('[data-testid="data-testid Alert success"]')).toBeVisible({ timeout: 20000 });
+    await expect(page.locator('[data-testid="data-testid Alert success"]')).toBeVisible({
+      timeout: 20000,
+    });
   });
 });
 
@@ -45,13 +51,17 @@ test("validate namespace dashboard", async ({ page }) => {
   await test.step("check dashboard", async () => {
     await page.goto(`/dashboards`);
     await page.click('text="Kubernetes / Compute Resources / Namespace (Pods)"');
-    await page.getByTestId('data-testid Dashboard template variables Variable Value DropDown value link text authservice').click();
+    await page
+      .getByTestId(
+        "data-testid Dashboard template variables Variable Value DropDown value link text authservice",
+      )
+      .click();
     if (!fullCore) {
       // Check grafana if not a full core deploy
-      await page.getByRole('option', { name: 'grafana' }).click();
+      await page.getByRole("option", { name: "grafana" }).click();
       return;
     }
-    await page.getByRole('option', { name: 'authservice-test-app' }).click();
+    await page.getByRole("option", { name: "authservice-test-app" }).click();
   });
 });
 
@@ -60,16 +70,24 @@ test("validate loki dashboard", async ({ page }) => {
   test.skip(!fullCore, "Loki is only present on full core deploys");
   await test.step("check dashboard", async () => {
     await page.goto(`/dashboards`);
-    await page.getByPlaceholder('Search for dashboards and folders').fill('Loki');
+    await page.getByPlaceholder("Search for dashboards and folders").fill("Loki");
     await page.click('text="Loki Dashboard quick search"');
-    await page.getByTestId('data-testid Dashboard template variables Variable Value DropDown value link text authservice').click();
+    await page
+      .getByTestId(
+        "data-testid Dashboard template variables Variable Value DropDown value link text authservice",
+      )
+      .click();
     if (!fullCore) {
       // Check grafana if not a full core deploy
-      await page.getByRole('option', { name: 'grafana' }).click();
+      await page.getByRole("option", { name: "grafana" }).click();
     } else {
-      await page.getByRole('option', { name: 'authservice-test-app' }).click();
+      await page.getByRole("option", { name: "authservice-test-app" }).click();
     }
-    await expect(page.getByTestId('data-testid Panel header Logs Panel').getByTestId('data-testid panel content')).toBeVisible();
+    await expect(
+      page
+        .getByTestId("data-testid Panel header Logs Panel")
+        .getByTestId("data-testid panel content"),
+    ).toBeVisible();
   });
 });
 
@@ -79,7 +97,7 @@ test("validate logout functionality", async ({ page }) => {
     await page.goto(`/`);
 
     await page.locator('button[aria-label="Profile"]').click();
-    await page.locator('span').filter({ hasText: 'Sign out' }).click();
+    await page.locator("span").filter({ hasText: "Sign out" }).click();
 
     // After logout, we should be redirected through a series of redirects
     // First to /login/generic_oauth, then to SSO

--- a/test/playwright/neuvector.test.ts
+++ b/test/playwright/neuvector.test.ts
@@ -8,80 +8,80 @@ import { domain } from "./uds.config";
 
 const FIFTEEN_SECONDS = 15_000;
 
-const url = `https://neuvector.admin.${domain}`
+const url = `https://neuvector.admin.${domain}`;
 test.use({ baseURL: url });
 
 test("validate system health", async ({ page }) => {
   await test.step("check sso", async () => {
-    await page.goto('/#/login');
+    await page.goto("/#/login");
     await page.waitForLoadState("domcontentloaded");
 
-    await expect(page.getByRole('button', { name: 'Login with OpenID' })).toBeVisible();
-    const termsCheckbox = await page.locator('.mat-checkbox-inner-container');
+    await expect(page.getByRole("button", { name: "Login with OpenID" })).toBeVisible();
+    const termsCheckbox = await page.locator(".mat-checkbox-inner-container");
     if (await termsCheckbox.isVisible()) {
       await termsCheckbox.click();
     }
-    await page.getByRole('button', { name: 'Login with OpenID' }).click();
-    await expect(page).toHaveURL('/#/dashboard');
-    await expect(page.locator('.navbar-header')).toBeVisible();
+    await page.getByRole("button", { name: "Login with OpenID" }).click();
+    await expect(page).toHaveURL("/#/dashboard");
+    await expect(page.locator(".navbar-header")).toBeVisible();
   });
 
   // Expect counts for scanner, controller, enforcer are based on chart defaults
   await test.step("check system components", async () => {
-    await page.goto('/#/controllers');
+    await page.goto("/#/controllers");
     await page.waitForLoadState("domcontentloaded");
 
     // Ensure at least three scanners are connected and at least one scan complete
-    await page.getByRole('tab', { name: 'Scanners' }).click();
+    await page.getByRole("tab", { name: "Scanners" }).click();
     await page.waitForLoadState("domcontentloaded");
     const scannerPromise = page.waitForResponse(`${url}/scanner`);
-    await page.getByLabel('Scanners').getByRole('button', { name: 'refresh Refresh' }).click();
+    await page.getByLabel("Scanners").getByRole("button", { name: "refresh Refresh" }).click();
     const scannerResponse = await scannerPromise;
     const scannerData = await scannerResponse.json();
 
-    expect(scannerData).toHaveProperty('scanners');
+    expect(scannerData).toHaveProperty("scanners");
     expect(Array.isArray(scannerData.scanners)).toBe(true);
     expect(scannerData.scanners.length).toBeGreaterThanOrEqual(3);
 
     // Ensure at least three controller exists and all are connected
-    await page.getByRole('tab', { name: 'Controllers' }).click();
+    await page.getByRole("tab", { name: "Controllers" }).click();
     await page.waitForLoadState("domcontentloaded");
     const controllerPromise = page.waitForResponse(`${url}/controller`);
-    await page.getByLabel('Controllers').getByRole('button', { name: 'refresh Refresh' }).click();
+    await page.getByLabel("Controllers").getByRole("button", { name: "refresh Refresh" }).click();
     const controllerResponse = await controllerPromise;
     const controllerData = await controllerResponse.json();
 
-    expect(controllerData).toHaveProperty('controllers');
+    expect(controllerData).toHaveProperty("controllers");
     expect(Array.isArray(controllerData.controllers)).toBe(true);
     expect(controllerData.controllers.length).toBeGreaterThanOrEqual(3);
     controllerData.controllers.forEach((controller: { connection_state: string }) => {
-      expect(controller.connection_state).toBe('connected');
+      expect(controller.connection_state).toBe("connected");
     });
 
     // Ensure at least one enforcer exists and all are connected
-    await page.getByRole('tab', { name: 'Enforcers' }).click();
+    await page.getByRole("tab", { name: "Enforcers" }).click();
     await page.waitForLoadState("domcontentloaded");
     const enforcerPromise = page.waitForResponse(`${url}/enforcer`);
-    await page.getByLabel('Enforcers').getByRole('button', { name: 'refresh Refresh' }).click();
+    await page.getByLabel("Enforcers").getByRole("button", { name: "refresh Refresh" }).click();
     const enforcerResponse = await enforcerPromise;
     const enforcerData = await enforcerResponse.json();
 
-    expect(enforcerData).toHaveProperty('enforcers');
+    expect(enforcerData).toHaveProperty("enforcers");
     expect(Array.isArray(enforcerData.enforcers)).toBe(true);
     expect(enforcerData.enforcers.length).toBeGreaterThanOrEqual(1);
     enforcerData.enforcers.forEach((enforcer: { connection_state: string }) => {
-      expect(enforcer.connection_state).toBe('connected');
+      expect(enforcer.connection_state).toBe("connected");
     });
   });
 
   await test.step("check scanning functionality", async () => {
-    await page.goto('/#/workloads');
+    await page.goto("/#/workloads");
     await page.waitForLoadState("domcontentloaded");
 
     // Pick the first istio-proxy image to scan
-    await page.getByText('istio-proxy').first().click();
+    await page.getByText("istio-proxy").first().click();
     const scannerPromise = page.waitForResponse(`${url}/workload/scanned*`);
-    await page.getByRole('button', { name: 'Scan action' }).click();
+    await page.getByRole("button", { name: "Scan action" }).click();
     const scannerResponse = await scannerPromise;
     expect(scannerResponse.status()).toBe(200);
   });
@@ -89,12 +89,12 @@ test("validate system health", async ({ page }) => {
 
 test("validate local login is blocked", async ({ page }) => {
   await test.step("check local login", async () => {
-    await page.goto('/#/login');
-    await page.locator('.mat-checkbox-inner-container').click();
-    await page.locator('#Email1').fill('admin');
-    await page.locator('#password1').fill('admin');
-    await page.getByRole('button', { name: 'Login', exact: true }).click();
-    await expect(page.getByText('RBAC: access denied')).toBeVisible();
+    await page.goto("/#/login");
+    await page.locator(".mat-checkbox-inner-container").click();
+    await page.locator("#Email1").fill("admin");
+    await page.locator("#password1").fill("admin");
+    await page.getByRole("button", { name: "Login", exact: true }).click();
+    await expect(page.getByText("RBAC: access denied")).toBeVisible();
   });
 });
 

--- a/test/playwright/playwright.config.ts
+++ b/test/playwright/playwright.config.ts
@@ -19,23 +19,21 @@ export default defineConfig({
   timeout: 45000, // 45 second timeout for tests
   reporter: [
     // Reporter to use. See https://playwright.dev/docs/test-reporters
-    ['html', { outputFolder: `${playwrightDir}/reports`, open: 'never' }]
+    ["html", { outputFolder: `${playwrightDir}/reports`, open: "never" }],
   ],
 
   outputDir: `${playwrightDir}/output`,
 
   use: {
-    trace: 'retain-on-failure', // save trace for failed tests. See https://playwright.dev/docs/trace-viewer#opening-the-trace
+    trace: "retain-on-failure", // save trace for failed tests. See https://playwright.dev/docs/trace-viewer#opening-the-trace
   },
 
   projects: [
-    { name: 'setup', testMatch: /.*\.setup\.ts/ }, // authentication
+    { name: "setup", testMatch: /.*\.setup\.ts/ }, // authentication
 
-    ...[
-      'Desktop Chrome',
-    ].map((p) => ({
+    ...["Desktop Chrome"].map(p => ({
       name: devices[p].defaultBrowserType,
-      dependencies: ['setup'],
+      dependencies: ["setup"],
       use: {
         ...devices[p],
         storageState: authFile,

--- a/test/playwright/uds.config.ts
+++ b/test/playwright/uds.config.ts
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
-export const domain = process.env.DOMAIN || 'uds.dev';
+export const domain = process.env.DOMAIN || "uds.dev";
 export const fullCore = process.env.FULL_CORE === "true";

--- a/test/vitest/metrics-server.spec.ts
+++ b/test/vitest/metrics-server.spec.ts
@@ -7,7 +7,6 @@ import * as k8s from "@kubernetes/client-node";
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
-const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 const metricsClient = new k8s.Metrics(kc);
 
 describe("Metrics Server", () => {

--- a/test/vitest/network.spec.ts
+++ b/test/vitest/network.spec.ts
@@ -71,14 +71,14 @@ async function execInPod(
       containerName,
       command,
       new Writable({
-        write(chunk, encoding, callback) {
-          stdoutBuffer += chunk.toString(encoding);
+        write(chunk, _encoding, callback) {
+          stdoutBuffer += chunk.toString();
           callback();
         },
       }),
       new Writable({
-        write(chunk, encoding, callback) {
-          stderrBuffer += chunk.toString(encoding);
+        write(chunk, _encoding, callback) {
+          stderrBuffer += chunk.toString();
           callback();
         },
       }),

--- a/test/vitest/prometheus.spec.ts
+++ b/test/vitest/prometheus.spec.ts
@@ -26,16 +26,17 @@ describe("Prometheus and Alertmanager", () => {
   });
 
   test("alert manager should be firing watchdog alert", async () => {
-    const response = await fetch(
-      `${alertmanagerProxy.url}/api/v2/alerts`
-    );
+    const response = await fetch(`${alertmanagerProxy.url}/api/v2/alerts`);
 
-    expect(response.status).toBe(200)
-    const body = (await response.json()) as Array<{ labels: { alertname: string }; status: { state: string } }>;
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Array<{
+      labels: { alertname: string };
+      status: { state: string };
+    }>;
 
-    expect(body.some(
-      alert => alert.labels.alertname === "Watchdog" && alert.status.state === "active"
-    )).toBe(true);
+    expect(
+      body.some(alert => alert.labels.alertname === "Watchdog" && alert.status.state === "active"),
+    ).toBe(true);
   });
 
   test("prometheus web ui should be responsive via the internal service address", async () => {

--- a/test/vitest/test-resources.spec.ts
+++ b/test/vitest/test-resources.spec.ts
@@ -31,17 +31,15 @@ describe("Test Resources Configuration", () => {
       // Check each pod for absence of istio-proxy in initContainers
       for (const pod of pods.items) {
         const initContainers = pod.spec?.initContainers || [];
-        const hasIstioNativeProxy = initContainers.some(container =>
-          container.name === "istio-proxy"
+        const hasIstioNativeProxy = initContainers.some(
+          container => container.name === "istio-proxy",
         );
 
         expect(hasIstioNativeProxy).toBe(false);
 
         // Also check regular containers to be thorough
         const containers = pod.spec?.containers || [];
-        const hasIstioProxy = containers.some(container =>
-          container.name === "istio-proxy"
-        );
+        const hasIstioProxy = containers.some(container => container.name === "istio-proxy");
 
         expect(hasIstioProxy).toBe(false);
       }


### PR DESCRIPTION
## Description

Our linting and formatting (eslint/prettier) was not running on certain dirs that it really should be running on.  This PR fixes the lint workflow and also addresses existing issues in all the new files added to this lint workflow.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- introduce an unused variable in one of the files under test/vitest
- `uds run lint-check` (this should throw an eslint error)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed