### PR TITLE
chore: keycloak fips image for unicorn and upgrade to 26.3.0

### DIFF
--- a/src/keycloak/chart/Chart.yaml
+++ b/src/keycloak/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: keycloak
 # renovate: datasource=docker depName=quay.io/keycloak/keycloak versioning=semver
-version: 26.2.5
+version: 26.3.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -5,7 +5,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.2.5"
+  tag: "26.3.0"
   # The Keycloak image pull policy
   pullPolicy: IfNotPresent
 

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -13,7 +13,7 @@ components:
       - name: keycloak
         namespace: keycloak
         # renovate: datasource=docker depName=quay.io/keycloak/keycloak versioning=semver
-        version: 26.2.5
+        version: 26.3.0
         localPath: ../chart
         valuesFiles:
           - ../chart/values.yaml

--- a/src/keycloak/values/registry1-values.yaml
+++ b/src/keycloak/values/registry1-values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: registry1.dso.mil/ironbank/opensource/keycloak/keycloak
-  tag: "26.2.5"
+  tag: "26.3.0"
 podSecurityContext:
   fsGroup: 2000
 securityContext:

--- a/src/keycloak/values/unicorn-values.yaml
+++ b/src/keycloak/values/unicorn-values.yaml
@@ -12,7 +12,7 @@ securityContext:
       - ALL
 image:
   repository: quay.io/rfcurated/keycloak
-  tag: "26.2.5-jammy-rfcurated"
+  tag: "26.3.0-jammy-fips-rfcurated"
 
 migrations:
   deleteGeneratedTrustStore: true

--- a/src/keycloak/values/upstream-values.yaml
+++ b/src/keycloak/values/upstream-values.yaml
@@ -5,4 +5,4 @@ podSecurityContext:
   fsGroup: 1000
 image:
   repository: quay.io/keycloak/keycloak
-  tag: "26.2.5"
+  tag: "26.3.0"

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -26,7 +26,7 @@ components:
         valuesFiles:
           - "values/upstream-values.yaml"
     images:
-      - quay.io/keycloak/keycloak:26.2.5
+      - quay.io/keycloak/keycloak:26.3.0
       - ghcr.io/defenseunicorns/uds/identity-config:0.15.2
 
   - name: keycloak
@@ -40,7 +40,7 @@ components:
         valuesFiles:
           - "values/registry1-values.yaml"
     images:
-      - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:26.2.5
+      - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:26.3.0
       - ghcr.io/defenseunicorns/uds/identity-config:0.15.2
 
   - name: keycloak
@@ -54,9 +54,5 @@ components:
         valuesFiles:
           - "values/unicorn-values.yaml"
     images:
-      # Keycloak doesn't require the FIPS image as it switches itself into FIPS mode when Bouncy Castle libraries are provided.
-      # This happens through the UDS Identity Config. However, in the future we aim to align all the images with their FIPS versions
-      # and Keycloak is no exception. Again, this effort doesn't change anything in terms of UDS Security and FIPS compliance posture.
-      # The switch is tracked via https://github.com/defenseunicorns/uds-core/issues/1541
-      - quay.io/rfcurated/keycloak:26.2.5-jammy-rfcurated
+      - quay.io/rfcurated/keycloak:26.3.0-jammy-fips-rfcurated
       - ghcr.io/defenseunicorns/uds/identity-config:0.15.2


### PR DESCRIPTION
## Description

This Pull Request updates Keycloak to 26.3.0, see the [Release Notes](https://www.keycloak.org/2025/07/keycloak-2630-released). It also replaces the regular RapidFort image with the FIPS one. 

## Related Issue

Fixes #1541

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Tested automatically

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed