### PR TITLE
fix: dev-setup with uds-dev-stack exemption

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -35,6 +35,35 @@ tasks:
         env:
           - "PEPR_MODE=dev"
 
+      - description: "Add Exemption for uds-dev-stack"
+        cmd: |
+          # Note: this behaves a bit differently than a normal dev/demo deploy where 'uds-dev-stack' is ignored at the webhook level
+          # Since we can't customize the 'pepr dev' setup this is a close enough approximation to work for dev locally
+          uds zarf tools kubectl create ns uds-policy-exemptions
+          uds zarf tools kubectl apply -f - <<EOF
+          apiVersion: uds.dev/v1alpha1
+          kind: Exemption
+          metadata:
+            name: dev-stack
+            namespace: uds-policy-exemptions
+          spec:
+            exemptions:
+              - policies:
+                  - DisallowHostNamespaces
+                  - DisallowPrivileged
+                  - DropAllCapabilities
+                  - RequireNonRootUser
+                  - RestrictCapabilities
+                  - RestrictHostPathWrite
+                  - RestrictHostPorts
+                  - RestrictVolumeTypes
+                matcher:
+                  namespace: uds-dev-stack
+                  name: "^.*"
+                title: "dev-stack-pods"
+                description: "The dev stack is not production-ready and can run without adhering to policies"
+          EOF
+
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
         cmd: "uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --no-progress --components=${{ .inputs.istio_components }}"


### PR DESCRIPTION
## Description

Fixes dev-setup to ensure that `uds-dev-stack` namespace is ignored from most policies. Previously this was globally true, but changed in https://github.com/defenseunicorns/uds-core/pull/1732. Due to the way `dev-setup` works, the exclusion/ignore looks a bit different than how this works for our bundles. For local dev purposes this is a close enough approximation though and ensures that pods like local-path-provisioner don't get blocked when creating PVCs.

## Related Issue

Follow on to https://github.com/defenseunicorns/uds-core/pull/1732

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

```bash
# in your "main" terminal
uds run dev-setup 
# Ensure this succeeds with the new addition

# in another terminal, normally a Javascript debug terminal
npx pepr dev --confirm

# back in your main terminal
zarf dev deploy src/keycloak --flavor upstream
# ensure this finishes/keycloak starts up, previously it would hang because the PVC could not be created
```

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed