### PR TITLE
chore(docs): update contributing guide

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "\nRunning YAML Lint Check"
 
 # Run yamllint globally, which will respect the .yamllint config, including ignores

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,17 @@ Alternatively, you can install them with `pip`:
 pip install yamllint codespell
 ```
 
+Additionally, we add and check for license headers in our files. The pre-commit check is performed by this [UDS Common task](https://github.com/defenseunicorns/uds-common/blob/main/tasks/lint.yaml#L159-L225).
+
+This task requires that `GO` and `addlicense` dependencies are installed. Install `GO` by following the [official documentation](https://go.dev/doc/install). To install `addlicense` and it's required dependencies you can run the following command:
+```bash
+uds run -f tasks/lint.yaml fix-license
+```
+
+:::note
+If you choose to forgo pre-commit checking there is a possibility that the commit will fail Github pipeline jobs that perform these checks.
+:::
+
 ## Definition of Done
 
 We apply these principles to all User Stories and contributions:
@@ -70,6 +81,7 @@ Before starting, ensure that you have the following installed:
 - **K3d**: [Install K3d](https://k3d.io/#installation)
 - **Node.js** (for building and running Pepr): [Install Node.js](https://nodejs.org/en/download/) (we recommend Node 24 to align with what CI tests/builds with)
 - **UDS CLI** (for running tasks and deploying): [Install UDS](https://uds.defenseunicorns.com/cli/quickstart-and-usage/)
+- **Go** (for development and testing): [Install Go](https://go.dev/doc/install)
 
 ### 2. Clone the Repository and Make a Branch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,8 @@ This task requires that `GO` and `addlicense` dependencies are installed. Instal
 uds run -f tasks/lint.yaml fix-license
 ```
 
-:::note
-If you choose to forgo pre-commit checking there is a possibility that the commit will fail Github pipeline jobs that perform these checks.
-:::
+> [!NOTE]
+> If you choose to forgo pre-commit checking there is a possibility that the commit will fail Github pipeline jobs that perform these checks.
 
 ## Definition of Done
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ We use [codespell](https://github.com/codespell-project/codespell) and [yamllint
 To install these tools, run:
 
 ```console
+# Setup husky pre-commit dependency
+npx husky
+
+# Install codespell and yamllint
 uds run lint-check
 ```
 
@@ -43,7 +47,7 @@ pip install yamllint codespell
 Additionally, we add and check for license headers in our files. The pre-commit check is performed by this [UDS Common task](https://github.com/defenseunicorns/uds-common/blob/main/tasks/lint.yaml#L159-L225).
 
 This task requires that `GO` and `addlicense` dependencies are installed. Install `GO` by following the [official documentation](https://go.dev/doc/install). To install `addlicense` and it's required dependencies you can run the following command:
-```bash
+```console
 uds run -f tasks/lint.yaml fix-license
 ```
 


### PR DESCRIPTION
## Description
While setting up a new mac i noticed that my pre-commit linting wasn't working. updating the contributing docs to outline the necessary steps for getting that working.

The key missing piece was needing to install `GO` and the `addlicense` dependencies.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed