### PR TITLE
chore: network policy type change adjustment

### DIFF
--- a/src/pepr/operator/controllers/network/generate.spec.ts
+++ b/src/pepr/operator/controllers/network/generate.spec.ts
@@ -22,7 +22,7 @@ describe("network policy generate", () => {
     expect(policy.spec).toEqual({
       ingress: [
         {
-          from: [
+          _from: [
             {
               namespaceSelector: {
                 matchLabels: {
@@ -58,7 +58,7 @@ describe("network policy generate", () => {
     expect(policy.spec).toEqual({
       ingress: [
         {
-          from: [
+          _from: [
             {
               namespaceSelector: {
                 matchLabels: {
@@ -157,7 +157,7 @@ describe("network policy generate with remoteCidr", () => {
     expect(policy.spec).toEqual({
       ingress: [
         {
-          from: [
+          _from: [
             {
               ipBlock: {
                 cidr: "10.0.0.0/8",

--- a/src/pepr/operator/controllers/network/generate.ts
+++ b/src/pepr/operator/controllers/network/generate.ts
@@ -9,11 +9,11 @@ import { kind } from "pepr";
 import { Allow, RemoteGenerated } from "../../crd";
 import { anywhere, anywhereInCluster } from "./generators/anywhere";
 import { cloudMetadata } from "./generators/cloudMetadata";
+import { egressGateway } from "./generators/egressGateway";
 import { intraNamespace } from "./generators/intraNamespace";
 import { kubeAPI } from "./generators/kubeAPI";
 import { kubeNodes } from "./generators/kubeNodes";
 import { remoteCidr } from "./generators/remoteCidr";
-import { egressGateway } from "./generators/egressGateway";
 
 function isWildcardNamespace(namespace: string) {
   return namespace === "" || namespace === "*";
@@ -122,7 +122,7 @@ export function generate(namespace: string, policy: Allow): kind.NetworkPolicy {
   // Add the ingress or egress rule
   switch (policy.direction) {
     case "Ingress":
-      generated.spec!.ingress = [{ from: peers, ports }];
+      generated.spec!.ingress = [{ _from: peers, ports }];
       break;
 
     case "Egress":

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.spec.ts
@@ -314,7 +314,7 @@ describe("updateKubeAPINetworkPolicies", () => {
           spec: {
             ingress: [
               {
-                from: newPeers,
+                _from: newPeers,
               },
             ],
           },
@@ -383,7 +383,7 @@ describe("updateKubeAPINetworkPolicies", () => {
           spec: {
             ingress: [
               {
-                from: oldPeers,
+                _from: oldPeers,
               },
             ],
           },
@@ -465,7 +465,7 @@ describe("updateKubeAPINetworkPolicies", () => {
           spec: {
             ingress: [
               {
-                from: undefined,
+                _from: undefined,
               },
             ],
           },

--- a/src/pepr/operator/controllers/network/generators/kubeAPI.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeAPI.ts
@@ -188,12 +188,12 @@ export async function updateKubeAPINetworkPolicies(newPeers: V1NetworkPolicyPeer
       // Handle ingress policies
     } else if (netPol.spec.ingress) {
       if (!netPol.spec.ingress[0]) {
-        netPol.spec.ingress[0] = { from: [] };
+        netPol.spec.ingress[0] = { _from: [] };
       }
-      const oldPeers = netPol.spec.ingress[0].from;
+      const oldPeers = netPol.spec.ingress[0]._from;
       if (!R.equals(oldPeers, newPeers)) {
         updateRequired = true;
-        netPol.spec.ingress[0].from = newPeers;
+        netPol.spec.ingress[0]._from = newPeers;
       }
     }
 

--- a/src/pepr/operator/controllers/network/generators/kubeNodes.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeNodes.ts
@@ -120,10 +120,10 @@ export async function updateKubeNodesNetworkPolicies() {
       }
     } else if (netPol.spec.ingress) {
       netPol.spec.ingress[0] = netPol.spec.ingress[0] || { from: [] };
-      const oldNodes = netPol.spec.ingress[0].from;
+      const oldNodes = netPol.spec.ingress[0]._from;
       if (!R.equals(oldNodes, newNodes)) {
         updateRequired = true;
-        netPol.spec.ingress[0].from = newNodes;
+        netPol.spec.ingress[0]._from = newNodes;
       }
     }
 


### PR DESCRIPTION
## Description

There was a patch in Kubernetes Fluent Client due to missing incorrect types in the upstream NetPol definition. After switching to the `@kubernetes/client-node` latest this patch was not necessary but the `from` field changed to `_from`. This is a draft and will fix the renovate PR when it comes out but just wanted to do the work first to ensure there is no block in UDS Core from Pepr. 

[Here](https://github.com/defenseunicorns/pepr/actions/runs/16421488991/job/46401067442) is the failing UDS Core test in Pepr for context.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed