### PR TITLE
chore: switch single-layer tests to use airgapped k3d

### DIFF
--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -6,10 +6,11 @@ tasks:
     inputs:
       K3D_EXTRA_ARGS:
         default: ""
+        description: "Extra args to pass to k3d"
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=github-tags depName=defenseunicorns/uds-k3d versioning=semver
-        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.14.3 --confirm --set K3D_EXTRA_ARGS='${{ .inputs.K3D_EXTRA_ARGS }}' --no-progress"
+        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.14.3-airgap --confirm --set K3D_EXTRA_ARGS='${{ .inputs.K3D_EXTRA_ARGS }}' --no-progress"
 
   - name: k3d-test-cluster
     actions:


### PR DESCRIPTION
## Description

While doing some local deployments I hit issues pulling from `quay.io`. Switching these tests to use the airgap package ensures that registry blips don't affect our testing here, and also should be slightly faster for local and CI deployments.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Deploy a single-layer test like: `uds run test-single-layer --set LAYER=metrics-server` and validate that it succeeds and is using the airgap k3d package.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed