### PR TITLE
docs: add RKE2 metrics config notes for control plane and CoreDNS

### DIFF
--- a/docs/reference/uds-core/prerequisites.md
+++ b/docs/reference/uds-core/prerequisites.md
@@ -21,7 +21,7 @@ When running Kubernetes on any type of host it is important to ensure you are fo
 
 In hardened RKE2 setups (using the CIS profile), control plane components (etcd, kube-scheduler, kube-controller-manager) bind to 127.0.0.1 by default, which prevents Prometheus from scraping them.
 
-To fix this, add the following settings to your control plane node’s config file (`/etc/rancher/rke2/config.yaml`) :
+To fix this, add the following settings to your control plane node’s config file (`/etc/rancher/rke2/config.yaml`):
 
 ```yaml
 kube-controller-manager-arg:

--- a/docs/reference/uds-core/prerequisites.md
+++ b/docs/reference/uds-core/prerequisites.md
@@ -38,9 +38,7 @@ These changes require restarting RKE2 to take effect.
 
 In hardened RKE2 setups (using the CIS profile), RKE2 applies some default network policies that [block ingress to the kube-system namespace](https://docs.rke2.io/security/hardening_guide#network-policies).  In order to enable CoreDNS metrics scraping you will need to enable an additional network policy.  UDS Core includes an option to deploy a network policy for CoreDNS metrics scraping.
 
-To enable this policy, set the value `rke2CorednsNetpol.enabled` to `true` in the `uds-prometheus-config` helm chart.  Example `uds-bundle.yaml` override:
-
-
+To enable this policy, set the value `rke2CorednsNetpol.enabled` to `true` in the `uds-prometheus-config` helm chart with the following override:
 ```yaml
 - name: uds-core
   ...

--- a/docs/reference/uds-core/prerequisites.md
+++ b/docs/reference/uds-core/prerequisites.md
@@ -17,6 +17,42 @@ When running Kubernetes on any type of host it is important to ensure you are fo
 - [Modifying NetworkManager to prevent CNI conflicts](https://docs.rke2.io/known_issues#networkmanager)
 - [Known Issues](https://docs.rke2.io/known_issues)
 
+##### Control Plane Metrics Configuration
+
+In hardened RKE2 setups (using the CIS profile), control plane components (etcd, kube-scheduler, kube-controller-manager) bind to 127.0.0.1 by default, which prevents Prometheus from scraping them.
+
+To fix this, add the following settings to your control plane node’s config file (`/etc/rancher/rke2/config.yaml`) :
+
+```yaml
+kube-controller-manager-arg:
+  - bind-address=0.0.0.0
+kube-scheduler-arg:
+  - bind-address=0.0.0.0
+etcd-arg:
+  - listen-metrics-urls=http://0.0.0.0:2381
+```
+
+These changes require restarting RKE2 to take effect.
+
+##### CoreDNS Metrics Configuration
+
+In hardened RKE2 setups (using the CIS profile), RKE2 applies some default network policies that [block ingress to the kube-system namespace](https://docs.rke2.io/security/hardening_guide#network-policies).  In order to enable CoreDNS metrics scraping you will need to enable an additional network policy.  UDS Core includes an option to deploy a network policy for CoreDNS metrics scraping.
+
+To enable this policy, set the value `rke2CorednsNetpol.enabled` to `true` in the `uds-prometheus-config` helm chart.  Example `uds-bundle.yaml` override:
+
+
+```yaml
+- name: uds-core
+  ...
+  overrides:
+    kube-prometheus-stack:
+      uds-prometheus-config:
+        values:
+          - path: rke2CorednsNetpol.enabled
+            value: true
+
+```
+
 #### K3S
 
 - [General installation requirements](https://docs.k3s.io/installation/requirements)

--- a/docs/reference/uds-core/prerequisites.md
+++ b/docs/reference/uds-core/prerequisites.md
@@ -36,7 +36,7 @@ These changes require restarting RKE2 to take effect.
 
 ##### CoreDNS Metrics Configuration
 
-In hardened RKE2 setups (using the CIS profile), RKE2 applies some default network policies that [block ingress to the kube-system namespace](https://docs.rke2.io/security/hardening_guide#network-policies).  In order to enable CoreDNS metrics scraping you will need to enable an additional network policy.  UDS Core includes an option to deploy a network policy for CoreDNS metrics scraping.
+In hardened RKE2 setups (using the CIS profile), RKE2 applies some default network policies that [block ingress to the kube-system namespace](https://docs.rke2.io/security/hardening_guide#network-policies). In order to enable CoreDNS metrics scraping you will need to enable an additional network policy. UDS Core includes an option to deploy a network policy for CoreDNS metrics scraping.
 
 To enable this policy, set the value `rke2CorednsNetpol.enabled` to `true` in the `uds-prometheus-config` helm chart with the following override:
 ```yaml


### PR DESCRIPTION
## Description

Adds some additional prerequisite docs for enabling control plane and CoreDNS metrics on RKE2. 

## Related Issue

Fixes #1140 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed