### PR TITLE
chore: revert security context change on neuvector

### DIFF
--- a/src/neuvector/chart/templates/uds-exemption.yaml
+++ b/src/neuvector/chart/templates/uds-exemption.yaml
@@ -10,8 +10,9 @@ spec:
   exemptions:
     - policies:
         - DisallowHostNamespaces
+        - DisallowPrivileged
         - RequireNonRootUser
-        - RestrictCapabilities
+        - DropAllCapabilities
         - RestrictSeccomp
         - RestrictHostPathWrite
         - RestrictVolumeTypes

--- a/src/neuvector/values/values.yaml
+++ b/src/neuvector/values/values.yaml
@@ -41,16 +41,6 @@ enforcer:
   internal:
     certificate:
       secret: neuvector-internal-cert
-  securityContext:
-    privileged: false
-    seccompProfile:
-      type: Unconfined
-    capabilities:
-      add:
-        - SYS_ADMIN
-        - NET_ADMIN
-        - SYS_PTRACE
-        - IPC_LOCK
 
 cve:
   updater:


### PR DESCRIPTION
## Description

In some PRs we noticed that AKS/RKE2 were failing on NeuVector enforcer. This appears to be due to some missing permissions with the security context changes. For the time being this PR reverts those changes, going back to the past posture.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

CI will validate that pods run. This is also the default upstream security context.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed