### PR TITLE
fix: cleanup kubenodes target policies if node ip changes

### DIFF
--- a/src/pepr/operator/controllers/network/generators/kubeNodes.spec.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeNodes.spec.ts
@@ -357,7 +357,7 @@ describe("kubeNodes module", () => {
       const updatedNode = {
         metadata: { name: "node1" },
         status: {
-          addresses: [{ type: "InternalIP", address: "10.0.0.2/32" }],
+          addresses: [{ type: "InternalIP", address: "10.0.0.2" }],
           conditions: [{ type: "Ready", status: "True" }],
         },
       };

--- a/src/pepr/operator/controllers/network/generators/kubeNodes.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeNodes.ts
@@ -82,17 +82,15 @@ export function kubeNodes(): V1NetworkPolicyPeer[] {
 export async function updateKubeNodesFromCreateUpdate(node: kind.Node) {
   const ip = getNodeInternalIP(node);
   const nodeName = node.metadata?.name;
-  if (ip) nodeSet.add(ip);
 
-  // Account for a node being updated with a new IP
-  if (nodeName && ip) {
+  if (ip && nodeName) {
     const oldIP = nodeNameToIPMap.get(nodeName);
-    if (!oldIP) {
-      // New node added
-      nodeNameToIPMap.set(nodeName, ip);
-    } else if (oldIP !== ip) {
-      // If the IP changed, remove the old IP from the set and map
-      nodeNameToIPMap.set(nodeName, ip);
+
+    nodeSet.add(ip);
+    nodeNameToIPMap.set(nodeName, ip);
+
+    // If the node's IP has changed, remove the old IP from the set
+    if (oldIP && oldIP !== ip) {
       nodeSet.delete(oldIP);
     }
   }
@@ -108,8 +106,8 @@ export async function updateKubeNodesFromCreateUpdate(node: kind.Node) {
 export async function updateKubeNodesFromDelete(node: kind.Node) {
   const ip = getNodeInternalIP(node);
   const nodeName = node.metadata?.name;
-  if (ip) nodeSet.delete(ip);
-  if (nodeName) {
+  if (ip && nodeName) {
+    nodeSet.delete(ip);
     nodeNameToIPMap.delete(nodeName);
   }
 

--- a/src/pepr/operator/controllers/network/generators/kubeNodes.ts
+++ b/src/pepr/operator/controllers/network/generators/kubeNodes.ts
@@ -46,12 +46,10 @@ export async function initAllNodesTarget() {
 
       for (const node of nodes.items) {
         const ip = getNodeInternalIP(node);
-        const nodeName = node.metadata?.name;
+        const nodeName = node.metadata!.name!;
 
         if (ip) {
           nodeSet.add(ip);
-        }
-        if (nodeName && ip) {
           nodeNameToIPMap.set(nodeName, ip);
         }
       }
@@ -81,9 +79,9 @@ export function kubeNodes(): V1NetworkPolicyPeer[] {
  */
 export async function updateKubeNodesFromCreateUpdate(node: kind.Node) {
   const ip = getNodeInternalIP(node);
-  const nodeName = node.metadata?.name;
+  const nodeName = node.metadata!.name!;
 
-  if (ip && nodeName) {
+  if (ip) {
     const oldIP = nodeNameToIPMap.get(nodeName);
 
     nodeSet.add(ip);
@@ -105,8 +103,8 @@ export async function updateKubeNodesFromCreateUpdate(node: kind.Node) {
  */
 export async function updateKubeNodesFromDelete(node: kind.Node) {
   const ip = getNodeInternalIP(node);
-  const nodeName = node.metadata?.name;
-  if (ip && nodeName) {
+  const nodeName = node.metadata!.name!;
+  if (ip) {
     nodeSet.delete(ip);
     nodeNameToIPMap.delete(nodeName);
   }


### PR DESCRIPTION
## Description

Adds logic to cleanup KubeNodes target when node ips change.  

## Related Issue

Fixes #1141 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- This is validated with a new unit test: `npx vitest src/pepr/operator/controllers/network/generators/kubeNodes.spec.ts`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed