### PR TITLE
chore(docs): fix cluster config referrence

### DIFF
--- a/docs/reference/configuration/uds-cluster-configuration.md
+++ b/docs/reference/configuration/uds-cluster-configuration.md
@@ -2,7 +2,7 @@
 title: Configuring Cluster Level Data
 ---
 
-To set and control certain cluster level configurations, UDS uses a combination of a [UDS ClusterConfig](/reference/configuration/custom-resources/clusterconfig-v1alpha1-cr.md) and Kubernetes secret, both deployed as templates from the `uds-operator-config` chart.
+To set and control certain cluster level configurations, UDS uses a combination of a [UDS ClusterConfig](/reference/configuration/custom-resources/clusterconfig-v1alpha1-cr) and Kubernetes secret, both deployed as templates from the `uds-operator-config` chart.
 
 ## Values
 


### PR DESCRIPTION
## Description
super small fix because uds-docs is sad about this link. https://github.com/defenseunicorns/uds-docs/pull/270

this also aligns with how we reference the custom-resources elsewhere in the docs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- run `npm run build` in the uds-docs branch `renovate/npm-dependencies` and see the errors
- modify this file in the `src/content/reference` of uds-docs and remove the script run from the package.json to see the difference

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed