### PR TITLE
fix(ci): snapshot release creation fix

### DIFF
--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -48,6 +48,7 @@ tasks:
         task: single-layer
         with:
           layer: base
+          shim_bundle: "false" # Don't create the shim bundle since we are making the slim-dev bundle
 
       - description: "Create identity-authorization package"
         task: single-layer
@@ -80,6 +81,9 @@ tasks:
       create_options:
         default: ${CREATE_OPTIONS}
         description: "Additional options passed in when creating Zarf packages. For example: --skip-sbom"
+      shim_bundle:
+        default: "true"
+        description: "Whether to create the shim bundle or not (base layer only)"
     actions:
       # Note: Maru does not support `or` for this conditional task so we just duplicate it for each case
       - task: pepr-build
@@ -97,7 +101,12 @@ tasks:
           architecture: ${ZARF_ARCHITECTURE}
       - description: "Create the shim bundle (Base only)"
         if: ${{ eq .inputs.layer "base" }}
-        cmd: "uds create bundles/base-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}"
+        cmd: |
+          if [ ${{.inputs.shim_bundle}} == "true" ]; then
+            uds create bundles/base-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
+          else
+            echo "Skipping base-shim bundle creation."
+          fi
 
   - name: pepr-build
     description: "Build the UDS Core Pepr Module"

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -101,8 +101,11 @@ tasks:
           architecture: ${ZARF_ARCHITECTURE}
       - description: "Create the shim bundle (Base only)"
         if: ${{ eq .inputs.layer "base" }}
+        shell:
+          darwin: bash
+          linux: bash
         cmd: |
-          if [ ${{.inputs.shim_bundle}} = "true" ]; then
+          if [[ ${{.inputs.shim_bundle}} == "true" ]]; then
             uds create bundles/base-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
           else
             echo "Skipping base-shim bundle creation."

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -102,7 +102,7 @@ tasks:
       - description: "Create the shim bundle (Base only)"
         if: ${{ eq .inputs.layer "base" }}
         cmd: |
-          if [ ${{.inputs.shim_bundle}} == "true" ]; then
+          if [ ${{.inputs.shim_bundle}} = "true" ]; then
             uds create bundles/base-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
           else
             echo "Skipping base-shim bundle creation."


### PR DESCRIPTION
## Description

The snapshot release has been broken since the introduction of the base-shim bundle - https://github.com/defenseunicorns/uds-core/actions/workflows/snapshot-release.yaml

This PR makes the base-shim bundle optional with a new input, since it shouldn't be created when we are making the base layer for the purpose of other bundles (i.e. slim-dev).

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Validated by running snapshot on this branch: https://github.com/defenseunicorns/uds-core/actions/runs/16724528903

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed