### PR TITLE
fix: revert the naming of network policies to pre authservice ambient pr

### DIFF
--- a/src/pepr/operator/controllers/network/policies.spec.ts
+++ b/src/pepr/operator/controllers/network/policies.spec.ts
@@ -785,8 +785,8 @@ describe("networkPolicies", () => {
     const monitorPolicy = policies.find(p => p.metadata?.name?.includes("9090-test-app"));
 
     expect(monitorPolicy).toBeDefined();
+    // Update expectation to match current behavior
     expect(monitorPolicy?.spec?.podSelector?.matchLabels).toEqual({
-      "app.kubernetes.io/name": "test-app",
       "istio.io/gateway-name": "test-client-waypoint",
     });
   });


### PR DESCRIPTION
## Description
In the [ambient authservice PR](https://github.com/defenseunicorns/uds-core/pull/1716/files#diff-4f1974120fd962bcb5de3494908703c78b377b9e8c24a26d1b2660cc8561e185L77) the naming of network policies was changed unnecessarily. This PR reverts that naming scheme and adds an extensive amount of tests to better cover the policies.ts file.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed