### PR TITLE
fix: renovate comments on unicorn istio values

### DIFF
--- a/src/istio/values/unicorn/istiod.yaml
+++ b/src/istio/values/unicorn/istiod.yaml
@@ -5,8 +5,8 @@ pilot:
   image: "quay.io/rfcurated/istio/pilot:1.26.2-jammy-fips-rfcurated-rfhardened"
 global:
   proxy_init:
-    # renovate: image=quay.io/rfcurated/istio/proxy
+    # renovate: image=quay.io/rfcurated/istio/proxyv2
     image: "###ZARF_REGISTRY###/rfcurated/istio/proxyv2:1.26.2-jammy-fips-rfcurated-rfhardened"
   proxy:
-    # renovate: image=quay.io/rfcurated/istio/proxy
+    # renovate: image=quay.io/rfcurated/istio/proxyv2
     image: "###ZARF_REGISTRY###/rfcurated/istio/proxyv2:1.26.2-jammy-fips-rfcurated-rfhardened"


### PR DESCRIPTION
## Description

Istio proxy comments had the wrong image name. See error on dashboard: https://github.com/defenseunicorns/uds-core/issues/400

## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/issues/400

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)
