### PR TITLE
fix: authservice config processing

### DIFF
--- a/bundles/k3d-standard/uds-ha-config.yaml
+++ b/bundles/k3d-standard/uds-ha-config.yaml
@@ -19,3 +19,6 @@ variables:
     grafana_pg_password: unicorn123!@#UN
     grafana_pg_user: postgres
     grafana_pg_ssl_mode: disable
+
+    # Authservice variables
+    AUTHSERVICE_REDIS_URI: redis://authservice:authservice@host.k3d.internal:6379

--- a/src/pepr/operator/controllers/config/config.ts
+++ b/src/pepr/operator/controllers/config/config.ts
@@ -15,12 +15,15 @@ import { initAllNodesTarget } from "../network/generators/kubeNodes";
 import { watchCfg } from "../utils";
 import { Config } from "./types";
 
+const NOT_LOADED = "##NOT_LOADED##";
+
 // Set default UDSConfig for build time compiling
 export const UDSConfig: Config = {
   domain: "",
   adminDomain: "",
   caCert: "",
-  authserviceRedisUri: "",
+  // An empty string is a valid identitifer for the Redis URI. We need a "special" value to indicate that it has not been loaded yet.
+  authserviceRedisUri: NOT_LOADED,
   allowAllNSExemptions: false,
   kubeApiCIDR: "",
   kubeNodeCIDRs: [],
@@ -50,9 +53,8 @@ function decodeSecret(secret: kind.Secret) {
 
 export async function updateCfgSecrets(cfg: kind.Secret) {
   let firstLoad = false;
-  // If the authserviceRedisUri is undefined we know we're loading the config for the first time
-  // An "empty" redis uri will be an empty string after the first load
-  if (UDSConfig.authserviceRedisUri === undefined) {
+  // This will be set to an empty string (if not provided) after the first load.
+  if (UDSConfig.authserviceRedisUri == NOT_LOADED) {
     firstLoad = true;
   }
 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -178,7 +178,7 @@ tasks:
   - name: test-uds-core-ha-upgrade
     description: "Test an upgrade from the latest released UDS Core package with HA to current branch with HA"
     actions:
-      - cmd: "Skipped. To be uncommented after the next release"
+      - cmd: echo "Skipped. To be uncommented after the next release"
 #      - task: setup:ha-postgres
 #      - task: setup:ha-redis
 #      - task: test:uds-core-ha-upgrade

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -178,9 +178,10 @@ tasks:
   - name: test-uds-core-ha-upgrade
     description: "Test an upgrade from the latest released UDS Core package with HA to current branch with HA"
     actions:
-      - task: setup:ha-postgres
-      - task: setup:ha-redis
-      - task: test:uds-core-ha-upgrade
+      - cmd: "Skipped. To be uncommented after the next release"
+#      - task: setup:ha-postgres
+#      - task: setup:ha-redis
+#      - task: test:uds-core-ha-upgrade
 
   - name: test-uds-core-upgrade
     description: "Test an upgrade from the latest released UDS Core package to current branch"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -172,12 +172,14 @@ tasks:
     description: "Build and test UDS Core"
     actions:
       - task: setup:ha-postgres
+      - task: setup:ha-redis
       - task: test:uds-core-ha
 
   - name: test-uds-core-ha-upgrade
     description: "Test an upgrade from the latest released UDS Core package with HA to current branch with HA"
     actions:
       - task: setup:ha-postgres
+      - task: setup:ha-redis
       - task: test:uds-core-ha-upgrade
 
   - name: test-uds-core-upgrade

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -77,3 +77,34 @@ tasks:
           done
       - description: "Add Grafana database to PostgreSQL"
         cmd: docker exec postgres psql -U postgres -c "CREATE DATABASE grafana;"
+
+  - name: ha-redis
+    actions:
+      - description: "Cleanup previous Redis runs"
+        cmd: |
+          docker kill redis || true
+          docker rm redis || true
+      - description: "Create a network for the Redis container"
+        cmd: docker network create k3d-uds || true
+      - description: "Generate Redis ACL file"
+        cmd: |
+          mkdir -p build/redis
+          cat > build/redis/users.acl <<'EOF'
+          user default off
+          user authservice on >authservice ~* +@all
+          EOF
+      - description: "Start Redis Docker container"
+        cmd: |
+          # renovate: datasource=docker depName=redis versioning=docker
+          REDIS_VERSION=7.4.0
+          docker run -p 6379:6379 --network=k3d-uds --rm --name redis \
+            -v $(pwd)/build/redis/users.acl:/usr/local/etc/redis/users.acl:ro \
+            -d redis:${REDIS_VERSION} \
+            --aclfile /usr/local/etc/redis/users.acl \
+            --appendonly yes
+      - description: "Wait for Redis to be ready"
+        cmd: |
+          for i in {1..10}; do
+            docker exec redis redis-cli -u redis://authservice:authservice@127.0.0.1:6379 ping && break
+            sleep 1
+          done


### PR DESCRIPTION
## ⚠️ WARNING

Please note that This Pull Request disables HA Upgrade tests. This is fully intentional as installing UDS Core v0.48.1 will fail and will block the release pipelines. This test will uncommented after the v0.48.2 release.

## Description

This Pull Request fixes the Authservice Config processing that previously failed was failing in case of specifying Redis URL with the following error:


```
{"type":"TypeError","message":"Cannot read properties of undefined (reading 'config.json')","stack":"TypeError: Cannot read properties of undefined (reading 'config.json')\n    at /app/module-237f900a8faba1288f122a879025f0a5d370227225192650359ee1d50e0b49b2.js:1:328
99\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async updateConfig (/app/module-237f900a8faba1288f122a879025f0a5d370227225192650359ee1d50e0b49b2.js:1:36699)\n    at async reconcileAuthservice (/app/module-237f900a8faba1288f122a879025f0a5d370227225192650359ee1d50e0b49b2.js:1:36375)\n    at async performAuthserviceUpdate (/app/module-237f900a8faba1
288f122a879025f0a5d370227225192650359ee1d50e0b49b2.js:1:45428)\n    at async updateCfgSecrets (/app/module-237f900a8faba1288f122a879025f0a5d370227225192650359ee1d50e0b49b2.js:1:42827)\n    at async loadUDSConfig (/app/module-237f900a8faba1288f122a879025f0a5d370227225192650359ee1d50e0b49b2.js:1:44871)\n    at async /app/module-237f900a8faba1288f122a879025f0a5d370227225192650359ee1d50e0b49b2.js
:34:32239"},"msg":"Cannot read properties of undefined (reading 'config.json')"}
```

## Related Issue

Fixes #1823

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

- Run `uds run test-uds-core-ha`
- Validate that Redis URL is used in `pepr-system/uds-operator-config`
- Validate that Redis URL is used in `authservice/authservice-uds`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed