### PR TITLE
docs: note on webhook troubleshooting

### DIFF
--- a/docs/reference/troubleshooting/pepr-istiod-webhooks.md
+++ b/docs/reference/troubleshooting/pepr-istiod-webhooks.md
@@ -5,6 +5,10 @@ sidebar:
   order: 1
 ---
 
+:::note
+The following issue should not occur in UDS Core 0.50.0+ due to changes in default webhook configuration. This troubleshooting guide is provided as a reference for older versions of UDS Core.
+:::
+
 ## Overview
 During cluster restarts or after upgrades, Istiod and Pepr pods may fail to start properly due to a circular dependency between their admission webhooks.
 


### PR DESCRIPTION
## Description

Adds a small note to the istio/pepr troubleshooting document to note that this is no longer an issue (since https://github.com/defenseunicorns/uds-core/pull/1816 was merged).

Docs preview from local deploy:
<img width="825" height="636" alt="Screenshot 2025-08-15 at 11 03 10 AM" src="https://github.com/user-attachments/assets/338361f3-ace8-4fb9-bc3b-f30a95e21dbc" />

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)