### PR TITLE
chore: renovate readiness log output

### DIFF
--- a/scripts/renovate/compareImagesAndCharts.spec.ts
+++ b/scripts/renovate/compareImagesAndCharts.spec.ts
@@ -362,7 +362,7 @@ describe("compareImagesAndCharts", () => {
 
     expect(result.labels).toEqual(["waiting on ironbank"]);
     expect(result.changes).toContain(
-      "Waiting on Ironbank image update: registry1.dso.mil/ironbank/nginx:1.21.6",
+      "Waiting on Ironbank to update registry1.dso.mil/ironbank/nginx to version 1.25.3",
     );
   });
 
@@ -421,7 +421,7 @@ describe("compareImagesAndCharts", () => {
 
     expect(result.labels).toEqual(["waiting on rapidfort"]);
     expect(result.changes).toContain(
-      "Waiting on Rapidfort image update: quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+      "Waiting on Rapidfort to update quay.io/rfcurated/nginx to version 1.25.3",
     );
   });
 
@@ -491,10 +491,10 @@ describe("compareImagesAndCharts", () => {
 
     expect(result.labels).toEqual(["waiting on ironbank", "waiting on rapidfort"]);
     expect(result.changes).toContain(
-      "Waiting on Ironbank image update: registry1.dso.mil/ironbank/nginx:1.21.6",
+      "Waiting on Ironbank to update registry1.dso.mil/ironbank/nginx to version 1.25.3",
     );
     expect(result.changes).toContain(
-      "Waiting on Rapidfort image update: quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+      "Waiting on Rapidfort to update quay.io/rfcurated/nginx to version 1.25.3",
     );
   });
 
@@ -890,6 +890,6 @@ it("should detect wait for loki (regression test)", async () => {
 
   expect(result.labels).toEqual(["waiting on rapidfort"]);
   expect(result.changes).toContain(
-    "Waiting on Rapidfort image update: quay.io/rfcurated/grafana/loki:3.4.3-jammy-fips-rfcurated-rfhardened",
+    "Waiting on Rapidfort to update quay.io/rfcurated/grafana/loki to version 3.5.0",
   );
 });

--- a/scripts/renovate/compareImagesAndCharts.ts
+++ b/scripts/renovate/compareImagesAndCharts.ts
@@ -252,12 +252,16 @@ function compareImages(
           if (missingImg.includes("registry1.dso.mil")) {
             if (!result.labels.includes("waiting on ironbank")) {
               result.labels.push("waiting on ironbank");
-              result.changes.push(`Waiting on Ironbank image update: ${missingImg}`);
+              result.changes.push(
+                `Waiting on Ironbank to update ${imgName} to version ${newVersion}`,
+              );
             }
           } else if (missingImg.startsWith("quay.io/rfcurated")) {
             if (!result.labels.includes("waiting on rapidfort")) {
               result.labels.push("waiting on rapidfort");
-              result.changes.push(`Waiting on Rapidfort image update: ${missingImg}`);
+              result.changes.push(
+                `Waiting on Rapidfort to update ${imgName} to version ${newVersion}`,
+              );
             }
           }
         }

--- a/scripts/renovate/getImagesAndCharts.spec.ts
+++ b/scripts/renovate/getImagesAndCharts.spec.ts
@@ -83,7 +83,7 @@ components:
         valuesFiles:
           - values/upstream-values.yaml
     images:
-      - docker.io/grafana/grafana:11.6.0
+      - docker.io/grafana/grafana:v11.6.0
       - docker.io/curlimages/curl:8.12.1
       - docker.io/library/busybox:1.37.0
       - ghcr.io/kiwigrid/k8s-sidecar:1.30.3
@@ -188,7 +188,7 @@ components:
     // Verify images content - note that we expect normalized versions
     expect(images).toEqual({
       "11.6.0": [
-        "docker.io/grafana/grafana:11.6.0",
+        "docker.io/grafana/grafana:v11.6.0",
         "registry1.dso.mil/ironbank/opensource/grafana/grafana:11.6.0",
       ],
       "8.12.1": [


### PR DESCRIPTION
## Description

Small changes to renovate readiness:
- Adjust the "changes" log messages to print the image name + expected new version (previously just printed the old image string)
- Add a `v` prefix to one of the image tests to cover `v` prefix trimming/grouping

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

CI will validate, can confirm you like the new log format.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed