### PR TITLE
fix: renovate readiness changes list

### DIFF
--- a/scripts/renovate/compareImagesAndCharts.spec.ts
+++ b/scripts/renovate/compareImagesAndCharts.spec.ts
@@ -366,6 +366,87 @@ describe("compareImagesAndCharts", () => {
     );
   });
 
+  it("should detect multiple waiting on messages for multiple missing images", async () => {
+    // Mock fs.readFileSync to return different content based on the file path
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "old/charts.yaml") {
+        return "charts-old";
+      }
+      if (filePath === "new/charts.yaml") {
+        return "charts-new";
+      }
+      if (filePath === "old/images.yaml") {
+        return "images-old";
+      }
+      if (filePath === "new/images.yaml") {
+        return "images-new";
+      }
+      return "";
+    });
+
+    // Mock fs.existsSync to return true for all files
+    (fs.existsSync as Mock).mockReturnValue(true);
+
+    // Mock yaml.parse to return different content based on the input
+    (yaml.parse as Mock).mockImplementation(content => {
+      if (content === "charts-old") {
+        return {
+          chart1: "1.0.0",
+        };
+      }
+      if (content === "charts-new") {
+        return {
+          chart1: "1.0.0",
+        };
+      }
+      if (content === "images-old") {
+        return {
+          "1.21.6": [
+            "docker.io/library/nginx:1.25.3",
+            "docker.io/library/curl:1.25.3",
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/curl:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+            "quay.io/rfcurated/curl:1.21.6-jammy-scratch-fips-rfcurated",
+          ],
+        };
+      }
+      if (content === "images-new") {
+        return {
+          "1.25.3": ["docker.io/library/nginx:1.25.3", "docker.io/library/curl:1.25.3"],
+          "1.21.6": [
+            "registry1.dso.mil/ironbank/nginx:1.21.6",
+            "registry1.dso.mil/ironbank/curl:1.21.6",
+            "quay.io/rfcurated/nginx:1.21.6-slim-jammy-fips-rfcurated-rfhardened",
+            "quay.io/rfcurated/curl:1.21.6-jammy-scratch-fips-rfcurated",
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await compareImagesAndCharts("old", "new");
+
+    expect(result.labels).toContain("waiting on ironbank");
+    expect(result.labels).toContain("waiting on rapidfort");
+
+    // Check for multiple Ironbank messages
+    expect(result.changes).toContain(
+      "Waiting on Ironbank to update registry1.dso.mil/ironbank/nginx to version 1.25.3",
+    );
+    expect(result.changes).toContain(
+      "Waiting on Ironbank to update registry1.dso.mil/ironbank/curl to version 1.25.3",
+    );
+
+    // Check for multiple Rapidfort messages
+    expect(result.changes).toContain(
+      "Waiting on Rapidfort to update quay.io/rfcurated/nginx to version 1.25.3",
+    );
+    expect(result.changes).toContain(
+      "Waiting on Rapidfort to update quay.io/rfcurated/curl to version 1.25.3",
+    );
+  });
+
   it("should detect waiting on rapidfort", async () => {
     // Mock fs.readFileSync to return different content based on the file path
     (fs.readFileSync as Mock).mockImplementation(filePath => {

--- a/scripts/renovate/compareImagesAndCharts.ts
+++ b/scripts/renovate/compareImagesAndCharts.ts
@@ -250,19 +250,21 @@ function compareImages(
           }
 
           if (missingImg.includes("registry1.dso.mil")) {
+            // Only add the label once, but add a message for each missing image
             if (!result.labels.includes("waiting on ironbank")) {
               result.labels.push("waiting on ironbank");
-              result.changes.push(
-                `Waiting on Ironbank to update ${imgName} to version ${newVersion}`,
-              );
             }
+            result.changes.push(
+              `Waiting on Ironbank to update ${imgName} to version ${newVersion}`,
+            );
           } else if (missingImg.startsWith("quay.io/rfcurated")) {
+            // Only add the label once, but add a message for each missing image
             if (!result.labels.includes("waiting on rapidfort")) {
               result.labels.push("waiting on rapidfort");
-              result.changes.push(
-                `Waiting on Rapidfort to update ${imgName} to version ${newVersion}`,
-              );
             }
+            result.changes.push(
+              `Waiting on Rapidfort to update ${imgName} to version ${newVersion}`,
+            );
           }
         }
 


### PR DESCRIPTION
## Description

Fixes a small bug in the `results.changes` list where only the first missing image was added for a given flavor + adds test coverage to make sure multiple missing images are logged.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

CI will test this.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed