### PR TITLE
fix: sync watch config with upstream default

### DIFF
--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -24,7 +24,7 @@ export const watchCfg: WatchCfg = {
     : 300,
   relistIntervalSec: process.env.PEPR_RELIST_INTERVAL_SECONDS
     ? parseInt(process.env.PEPR_RELIST_INTERVAL_SECONDS, 10)
-    : 1800,
+    : 600,
 };
 
 /**


### PR DESCRIPTION
## Description

With the introduction of the cluster config we removed our override for the relist interval. As a result, our default watch config used 1800 which is not aligned with the [upstream default](https://github.com/defenseunicorns/pepr/blob/c187d342d2789ce1423b8f9be8dab61697b3ddde/src/lib/processors/watch-processor.ts#L72) of 600.

This PR aligns with the upstream defaults. While the higher interval may not cause any issues, it's best to keep aligned with the upstream here.

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)