### PR TITLE
chore: update istio / pepr policy behavior

### DIFF
--- a/adrs/0003-exclude-istio-from-policy-engine.md
+++ b/adrs/0003-exclude-istio-from-policy-engine.md
@@ -4,7 +4,7 @@ Date: 2025-08-12
 
 ## Status
 
-Accepted
+Superseded by [ADR-0004](./0004-implement-per-namespace-webhook-failure-policy.md)
 
 ## Context
 

--- a/adrs/0004-implement-per-namespace-webhook-failure-policy.md
+++ b/adrs/0004-implement-per-namespace-webhook-failure-policy.md
@@ -33,7 +33,7 @@ The following changes will be made to `package.json`:
 
 ### Positive
 
-- Improved Security: Maintains strict policy enforcement for all namespaces, and ensures "best-effort" policy enforcement on `istio-system` (when webhooks are available).
+- Improved Security: Maintains strict policy enforcement for all namespaces, and ensures policy enforcement on `istio-system` when webhooks are available.
 - Continued Reliability: Does not have any poor impact on availability of service mesh (`istio-system`) components, or cause any new deadlock behaviors.
 
 ### Negative
@@ -43,6 +43,6 @@ The following changes will be made to `package.json`:
 
 ## Alternatives Considered
 
-Maintain the current implementation: Rejected as it leaves a wider gap in policy enforcement for the `istio-system` nameespace.
+Maintain the current implementation: Rejected as it leaves a wider gap in policy enforcement for the `istio-system` namespace.
 
 For additional alternatives considered on the original issue see [ADR-0003](./0003-exclude-istio-from-policy-engine.md).

--- a/adrs/0004-implement-per-namespace-webhook-failure-policy.md
+++ b/adrs/0004-implement-per-namespace-webhook-failure-policy.md
@@ -1,0 +1,48 @@
+# 4. Implement Per-Namespace Webhook Failure Policy for Istio
+
+Date: 2025-08-25
+
+## Status
+
+Accepted
+
+## Context
+
+In [ADR-0003](./0003-exclude-istio-from-policy-engine.md), there was a need to exclude the `istio-system` namespace from policy enforcement to prevent deadlocks during cluster operations. The original implementation used a blanket namespace exclusion in the Pepr webhook configuration.
+
+Since then, upstream Pepr has implemented support for [per-namespace webhook failure policies](https://github.com/defenseunicorns/pepr/issues/2546). This allows more granular control over webhook failures, particularly for critical system namespaces like `istio-system`.
+
+For additional context on the original issue see [ADR-0003](./0003-exclude-istio-from-policy-engine.md).
+
+## Decision
+
+The Pepr configuration will be updated to use the new `additionalWebhooks` feature with an `Ignore` failure policy for the `istio-system` namespace, while maintaining strict policy enforcement for other namespaces.
+
+The following changes will be made to `package.json`:
+
+1. Remove `istio-system` from `admission.alwaysIgnore.namespaces`
+2. Add a new `additionalWebhooks` configuration:
+   ```json
+   "additionalWebhooks": [{
+     "failurePolicy": "Ignore",
+     "namespace": "istio-system"
+   }]
+   ```
+
+## Consequences
+
+### Positive
+
+- Improved Security: Maintains strict policy enforcement for all namespaces, and ensures "best-effort" policy enforcement on `istio-system` (when webhooks are available).
+- Continued Reliability: Does not have any poor impact on availability of service mesh (`istio-system`) components, or cause any new deadlock behaviors.
+
+### Negative
+
+- In different environments, `istio-system` may run with slightly different `securityContext` behavior depending on whether mutations are performed or not (leading to a chance of configuration drift). In general, however, Istio has predefined `securityContext`s for its pods, meaning that mutations are minimal.
+- As noted in [ADR-0003](./0003-exclude-istio-from-policy-engine.md), there is still potential for a malicious user with access to `istio-system` to run a privileged workload, when the webhooks are down. However this is a slight improvement over the previous implementation as this is only possible during webhook downtime.
+
+## Alternatives Considered
+
+Maintain the current implementation: Rejected as it leaves a wider gap in policy enforcement for the `istio-system` nameespace.
+
+For additional alternatives considered on the original issue see [ADR-0003](./0003-exclude-istio-from-policy-engine.md).

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "admission": {
       "alwaysIgnore": {
         "namespaces": [
-          "zarf",
-          "istio-system"
+          "zarf"
         ]
       }
     },
@@ -34,7 +33,11 @@
           "zarf"
         ]
       }
-    }
+    },
+    "additionalWebhooks": [{
+      "failurePolicy": "Ignore",
+      "namespace": "istio-system"
+    }]
   },
   "scripts": {
     "k3d-setup": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0'"

--- a/packages/checkpoint-dev/zarf.yaml
+++ b/packages/checkpoint-dev/zarf.yaml
@@ -111,17 +111,11 @@ components:
           - description: "Scale up ztunnel, pepr, and keycloak after checkpoint restore"
             cmd: |
               set -e
-              ./zarf tools kubectl patch mutatingwebhookconfiguration pepr-uds-core --type='json' -p='[{"op":"replace","path":"/webhooks/0/failurePolicy","value":"Ignore"}]'
-              ./zarf tools kubectl patch validatingwebhookconfiguration pepr-uds-core --type='json' -p='[{"op":"replace","path":"/webhooks/0/failurePolicy","value":"Ignore"}]'
-
               ./zarf tools kubectl -n istio-system patch daemonset ztunnel --type=json -p='[{"op":"remove","path":"/spec/template/spec/nodeSelector/no-such-label"}]'
               ./zarf tools kubectl -n istio-system rollout status daemonset ztunnel --timeout=60s
 
               ./zarf tools kubectl -n pepr-system scale deploy pepr-uds-core --replicas=2
               ./zarf tools kubectl rollout status -n pepr-system deploy pepr-uds-core --timeout=60s
-
-              ./zarf tools kubectl patch mutatingwebhookconfiguration pepr-uds-core --type='json' -p='[{"op":"replace","path":"/webhooks/0/failurePolicy","value":"Fail"}]'
-              ./zarf tools kubectl patch validatingwebhookconfiguration pepr-uds-core --type='json' -p='[{"op":"replace","path":"/webhooks/0/failurePolicy","value":"Fail"}]'
 
               ./zarf tools kubectl -n pepr-system scale deploy pepr-uds-core-watcher --replicas=1
               ./zarf tools kubectl -n pepr-system rollout status deploy pepr-uds-core-watcher --timeout=60s

--- a/src/istio/common/chart/templates/exemptions.yaml
+++ b/src/istio/common/chart/templates/exemptions.yaml
@@ -1,9 +1,6 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2025 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-# Note: These exemptions are not currently used/processed since `istio-system` is excluded from UDS Policies via webhook configuration. This Exemption does however provide:
-# 1. Backwards compatible support for upgrade/downgrade cases that may be unexpected and still require Exemptions.
-# 2. A helpful reference for the privileges Istio is expected to have, and why.
 apiVersion: uds.dev/v1alpha1
 kind: Exemption
 metadata:


### PR DESCRIPTION
## Description

Adopts the new Pepr feature to set `istio-system` as a secondary webhook with a policy of Ignore for failures.

Also adds a [new ADR](https://github.com/defenseunicorns/uds-core/blob/istio-pepr-ignore/adrs/0004-implement-per-namespace-webhook-failure-policy.md) to document this change.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

CI should validate the normal behavior. You can also validate the worst-case with Istio/Pepr both being down by:
```console
# "scale" down daemonsets
kubectl -n istio-system patch ds istio-cni-node -p '{"spec":{"template":{"spec":{"nodeSelector":{"foo":"bar"}}}}}'
kubectl -n istio-system patch ds ztunnel -p '{"spec":{"template":{"spec":{"nodeSelector":{"foo":"bar"}}}}}'
# scale down deployments
kubectl -n istio-system scale deploy/istiod --replicas=0
kubectl -n pepr-system  scale deploy/pepr-uds-core --replicas=0
```

Then to test recovery, spin everything back up at the same time:
```console
kubectl -n istio-system patch ds istio-cni-node --type='json' -p='[{"op":"remove","path":"/spec/template/spec/nodeSelector/foo"}]'
kubectl -n istio-system patch ds ztunnel --type='json' -p='[{"op":"remove","path":"/spec/template/spec/nodeSelector/foo"}]'
kubectl -n istio-system scale deploy/istiod --replicas=1
kubectl -n pepr-system scale deploy/pepr-uds-core --replicas=2
```

If all works as expected, all pods should come up (it may take a minute or so).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed