### PR TITLE
chore: switch to bitnamilegacy, cleanup keycloak sources

### DIFF
--- a/src/keycloak/chart/Chart.yaml
+++ b/src/keycloak/chart/Chart.yaml
@@ -17,6 +17,4 @@ home: https://www.keycloak.org/
 icon: https://www.keycloak.org/resources/images/keycloak_icon_512px.svg
 sources:
   - https://github.com/codecentric/helm-charts
-  - https://github.com/jboss-dockerfiles/keycloak
-  - https://github.com/bitnami/charts/tree/master/bitnami/postgresql
   - https://repo1.dso.mil/big-bang/product/packages/keycloak

--- a/src/velero/values/upstream-values.yaml
+++ b/src/velero/values/upstream-values.yaml
@@ -7,7 +7,7 @@ image:
 
 kubectl:
   image:
-    repository: docker.io/bitnami/kubectl
+    repository: docker.io/bitnamilegacy/kubectl
     tag: 1.33.4
 
 initContainers:

--- a/src/velero/zarf.yaml
+++ b/src/velero/zarf.yaml
@@ -21,7 +21,7 @@ components:
     images:
       - velero/velero:v1.16.2
       - velero/velero-plugin-for-aws:v1.12.2
-      - docker.io/bitnami/kubectl:1.33.4
+      - docker.io/bitnamilegacy/kubectl:1.33.4
       - velero/velero-plugin-for-microsoft-azure:v1.12.2
 
   - name: velero


### PR DESCRIPTION
## Description

Bitnami images are going to experience brownouts over the next month, and then no longer be available at the current repo ([ref](https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon)). For now this switches to the legacy repo where they will be available for longer.

Additional context:
- [Upstream chart issue](https://www.github.com/vmware-tanzu/helm-charts/issues/698): no current path forward besides some `latest` images that might work, or the `bitnamilegacy` image
- [Upstream PR](https://www.github.com/vmware-tanzu/velero/pull/9132): This should remove the requirement of a kubectl image entirely, but has been put on hold until after 1.17.0.

I also cleaned up the sources in the Keycloak chart as neither are relevant to our current chart anymore.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

CI should validate, but ensure that the velero CRD jobs pass.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed