### PR TITLE
fix: use fixed Keycloak hostname

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -120,11 +120,12 @@ spec:
             - "--spi-authentication-sessions--map--auth-sessions-limit={{ .Values.realmConfig.maxInFlightLoginsPerUser | default 300 }}"
             - "--proxy-headers=xforwarded"
             - "--http-enabled=true"
-            - "--hostname-strict=false"
             - "--hostname-backchannel-dynamic=true"
             {{- if .Values.useFixedHostname }}
             - "--hostname=https://sso.{{ .Values.domain }}"
             - "--hostname-admin=https://keycloak.{{ tpl .Values.adminDomain . }}"
+            {{- else }}
+            - "--hostname-strict=false"
             {{- end }}
             {{- if .Values.jsonLogFormat }}
             - "--log-console-output=json"

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -121,6 +121,11 @@ spec:
             - "--proxy-headers=xforwarded"
             - "--http-enabled=true"
             - "--hostname-strict=false"
+            - "--hostname-backchannel-dynamic=true"
+            {{- if .Values.useFixedHostname }}
+            - "--hostname=https://sso.{{ .Values.domain }}"
+            - "--hostname-admin=https://keycloak.{{ tpl .Values.adminDomain . }}"
+            {{- end }}
             {{- if .Values.jsonLogFormat }}
             - "--log-console-output=json"
             {{- end }}

--- a/src/keycloak/chart/tests/kc_use_fixed_hostname_test.yaml
+++ b/src/keycloak/chart/tests/kc_use_fixed_hostname_test.yaml
@@ -1,0 +1,37 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - useFixedHostname propagation
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: should render hostname args when useFixedHostname is true
+    set:
+      useFixedHostname: true
+      domain: example.com
+      adminDomain: admin.example.com
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hostname=https://sso.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--hostname-admin=https://keycloak.admin.example.com"
+
+  - it: should not render hostname args when useFixedHostname is false
+    set:
+      useFixedHostname: false
+      domain: example.com
+      adminDomain: admin.example.com
+    template: statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hostname=https://sso.example.com"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--hostname-admin=https://keycloak.admin.example.com"

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -209,6 +209,9 @@
     "adminDomain": {
       "type": "string"
     },
+    "useFixedHostname": {
+      "type": "boolean"
+    },
     "enableServiceLinks": {
       "type": "boolean"
     },

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -17,6 +17,9 @@ domain: "###ZARF_VAR_DOMAIN###"
 # The admin domain for hosts to trust clients on
 adminDomain: '{{ "###ZARF_VAR_ADMIN_DOMAIN###" | default "admin.###ZARF_VAR_DOMAIN###" }}'
 
+# When true, Keycloak will use fixed hostnames for tenant and admin endpoints
+useFixedHostname: true
+
 # Additional Istio Gateways that expose Keycloak, to allow for client cert usage
 # A prefix of `istio-` is required for namespaces to prevent accidental misconfiguration
 additionalGatewayNamespaces: []


### PR DESCRIPTION
## Description

This Pull Request introduces a fixed Keycloak hostname. When calling the Well Known OIDC endpoint from the inside of the cluster, the following content is produced:

```json
{
    "issuer": "https://sso.uds.dev/realms/uds",
    "authorization_endpoint": "https://sso.uds.dev/realms/uds/protocol/openid-connect/auth",
    "token_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/token",
    "introspection_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/token/introspect",
    "userinfo_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/userinfo",
    "end_session_endpoint": "https://sso.uds.dev/realms/uds/protocol/openid-connect/logout",
    "frontchannel_logout_session_supported": true,
    "frontchannel_logout_supported": true,
    "jwks_uri": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/certs",
    "check_session_iframe": "https://sso.uds.dev/realms/uds/protocol/openid-connect/login-status-iframe.html",
    "grant_types_supported": [
        "authorization_code",
        "client_credentials",
        "implicit",
        "password",
        "refresh_token",
        "urn:ietf:params:oauth:grant-type:device_code",
        "urn:ietf:params:oauth:grant-type:token-exchange",
        "urn:ietf:params:oauth:grant-type:uma-ticket",
        "urn:openid:params:grant-type:ciba"
    ],
    "acr_values_supported": [
        "0",
        "1"
    ],
    "response_types_supported": [
        "code",
        "none",
        "id_token",
        "token",
        "id_token token",
        "code id_token",
        "code token",
        "code id_token token"
    ],
    "subject_types_supported": [
        "public",
        "pairwise"
    ],
    "prompt_values_supported": [
        "none",
        "login",
        "consent",
        "create"
    ],
    "id_token_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "HS256",
        "HS512",
        "ES256",
        "RS256",
        "HS384",
        "ES512",
        "PS256",
        "PS512",
        "RS512"
    ],
    "id_token_encryption_alg_values_supported": [
        "ECDH-ES+A256KW",
        "ECDH-ES+A192KW",
        "ECDH-ES+A128KW",
        "RSA-OAEP",
        "RSA-OAEP-256",
        "RSA1_5",
        "ECDH-ES"
    ],
    "id_token_encryption_enc_values_supported": [
        "A256GCM",
        "A192GCM",
        "A128GCM",
        "A128CBC-HS256",
        "A192CBC-HS384",
        "A256CBC-HS512"
    ],
    "userinfo_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "HS256",
        "HS512",
        "ES256",
        "RS256",
        "HS384",
        "ES512",
        "PS256",
        "PS512",
        "RS512",
        "none"
    ],
    "userinfo_encryption_alg_values_supported": [
        "ECDH-ES+A256KW",
        "ECDH-ES+A192KW",
        "ECDH-ES+A128KW",
        "RSA-OAEP",
        "RSA-OAEP-256",
        "RSA1_5",
        "ECDH-ES"
    ],
    "userinfo_encryption_enc_values_supported": [
        "A256GCM",
        "A192GCM",
        "A128GCM",
        "A128CBC-HS256",
        "A192CBC-HS384",
        "A256CBC-HS512"
    ],
    "request_object_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "HS256",
        "HS512",
        "ES256",
        "RS256",
        "HS384",
        "ES512",
        "PS256",
        "PS512",
        "RS512",
        "none"
    ],
    "request_object_encryption_alg_values_supported": [
        "ECDH-ES+A256KW",
        "ECDH-ES+A192KW",
        "ECDH-ES+A128KW",
        "RSA-OAEP",
        "RSA-OAEP-256",
        "RSA1_5",
        "ECDH-ES"
    ],
    "request_object_encryption_enc_values_supported": [
        "A256GCM",
        "A192GCM",
        "A128GCM",
        "A128CBC-HS256",
        "A192CBC-HS384",
        "A256CBC-HS512"
    ],
    "response_modes_supported": [
        "query",
        "fragment",
        "form_post",
        "query.jwt",
        "fragment.jwt",
        "form_post.jwt",
        "jwt"
    ],
    "registration_endpoint": "http://keycloak-http.keycloak/realms/uds/clients-registrations/openid-connect",
    "token_endpoint_auth_methods_supported": [
        "private_key_jwt",
        "client_secret_basic",
        "client_secret_post",
        "client_secret_basic",
        "client_secret_post",
        "tls_client_auth",
        "client_secret_jwt"
    ],
    "token_endpoint_auth_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "HS256",
        "HS512",
        "ES256",
        "RS256",
        "HS384",
        "ES512",
        "PS256",
        "PS512",
        "RS512"
    ],
    "introspection_endpoint_auth_methods_supported": [
        "private_key_jwt",
        "client_secret_basic",
        "client_secret_post",
        "client_secret_basic",
        "client_secret_post",
        "tls_client_auth",
        "client_secret_jwt"
    ],
    "introspection_endpoint_auth_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "HS256",
        "HS512",
        "ES256",
        "RS256",
        "HS384",
        "ES512",
        "PS256",
        "PS512",
        "RS512"
    ],
    "authorization_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "HS256",
        "HS512",
        "ES256",
        "RS256",
        "HS384",
        "ES512",
        "PS256",
        "PS512",
        "RS512"
    ],
    "authorization_encryption_alg_values_supported": [
        "ECDH-ES+A256KW",
        "ECDH-ES+A192KW",
        "ECDH-ES+A128KW",
        "RSA-OAEP",
        "RSA-OAEP-256",
        "RSA1_5",
        "ECDH-ES"
    ],
    "authorization_encryption_enc_values_supported": [
        "A256GCM",
        "A192GCM",
        "A128GCM",
        "A128CBC-HS256",
        "A192CBC-HS384",
        "A256CBC-HS512"
    ],
    "claims_supported": [
        "aud",
        "sub",
        "iss",
        "auth_time",
        "name",
        "given_name",
        "family_name",
        "preferred_username",
        "email",
        "acr"
    ],
    "claim_types_supported": [
        "normal"
    ],
    "claims_parameter_supported": true,
    "scopes_supported": [
        "email",
        "profile",
        "roles",
        "mapper-oidc-username-username",
        "bare-groups",
        "offline_access",
        "acr",
        "phone",
        "microprofile-jwt",
        "mapper-oidc-mattermostid-id",
        "openid",
        "mapper-oidc-email-email",
        "web-origins",
        "address"
    ],
    "request_parameter_supported": true,
    "request_uri_parameter_supported": true,
    "require_request_uri_registration": true,
    "code_challenge_methods_supported": [
        "plain",
        "S256"
    ],
    "tls_client_certificate_bound_access_tokens": true,
    "dpop_signing_alg_values_supported": [
        "PS384",
        "ES384",
        "RS384",
        "ES256",
        "RS256",
        "ES512",
        "PS256",
        "PS512",
        "RS512"
    ],
    "revocation_endpoint": "https://sso.uds.dev/realms/uds/protocol/openid-connect/revoke",
    "revocation_endpoint_auth_methods_supported": [
        "private_key_jwt",
        "client_secret_basic",
        "client_secret_post",
        "client_secret_basic",
        "client_secret_post",
        "tls_client_auth",
        "client_secret_jwt"
    ],
    "revocation_endpoint_auth_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "HS256",
        "HS512",
        "ES256",
        "RS256",
        "HS384",
        "ES512",
        "PS256",
        "PS512",
        "RS512"
    ],
    "backchannel_logout_supported": true,
    "backchannel_logout_session_supported": true,
    "device_authorization_endpoint": "https://sso.uds.dev/realms/uds/protocol/openid-connect/auth/device",
    "backchannel_token_delivery_modes_supported": [
        "poll",
        "ping"
    ],
    "backchannel_authentication_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/ext/ciba/auth",
    "backchannel_authentication_request_signing_alg_values_supported": [
        "PS384",
        "RS384",
        "EdDSA",
        "ES384",
        "ES256",
        "RS256",
        "ES512",
        "PS256",
        "PS512",
        "RS512"
    ],
    "require_pushed_authorization_requests": false,
    "pushed_authorization_request_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/ext/par/request",
    "mtls_endpoint_aliases": {
        "token_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/token",
        "revocation_endpoint": "https://sso.uds.dev/realms/uds/protocol/openid-connect/revoke",
        "introspection_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/token/introspect",
        "device_authorization_endpoint": "https://sso.uds.dev/realms/uds/protocol/openid-connect/auth/device",
        "registration_endpoint": "http://keycloak-http.keycloak/realms/uds/clients-registrations/openid-connect",
        "userinfo_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/userinfo",
        "pushed_authorization_request_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/ext/par/request",
        "backchannel_authentication_endpoint": "http://keycloak-http.keycloak/realms/uds/protocol/openid-connect/ext/ciba/auth"
    },
    "authorization_response_iss_parameter_supported": true
}
```

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/1861

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

- Deploy UDS Core as usual and use `kubectl exec` to get into Grafana Pod
- Delete all network policies
- Call `curl keycloak-http.keycloak:8080/realms/uds/.well-known/openid-configuration`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed