### PR TITLE
feat: add helm values for extra volumes and truststorepaths to keycloak

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -109,6 +109,9 @@ spec:
             {{- else }}
             - "--features=preview"
             {{- end }}
+            {{- if .Values.truststorePaths }}
+            - "--truststore-paths={{ join "," .Values.truststorePaths }}"
+            {{- end }}
             - "--spi-authentication-sessions--map--auth-sessions-limit={{ .Values.realmConfig.maxInFlightLoginsPerUser | default 300 }}"
             - "--proxy-headers=xforwarded"
             - "--http-enabled=true"

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -292,6 +292,9 @@ spec:
               readOnly: true
             - name: client-secrets
               mountPath: /var/run/secrets/uds/client-secrets
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- with .Values.nodeSelector }}
@@ -372,4 +375,7 @@ spec:
                       path: tc.txt
               {{- end }}
               {{- end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/src/keycloak/chart/tests/kc_extra_volumes_test.yaml
+++ b/src/keycloak/chart/tests/kc_extra_volumes_test.yaml
@@ -1,0 +1,46 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - extraVolumes and extraVolumeMounts
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: should not render extra volumes or mounts when not configured
+    template: statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certs
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-certs
+
+  - it: should render extraVolumes and extraVolumeMounts when configured
+    set:
+      extraVolumes:
+        - name: ca-certs
+          configMap:
+            name: private-ca
+      extraVolumeMounts:
+        - name: ca-certs
+          mountPath: /opt/keycloak/conf/truststores/private-ca
+          readOnly: true
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certs
+            configMap:
+              name: private-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-certs
+            mountPath: /opt/keycloak/conf/truststores/private-ca
+            readOnly: true

--- a/src/keycloak/chart/tests/kc_truststore_paths_test.yaml
+++ b/src/keycloak/chart/tests/kc_truststore_paths_test.yaml
@@ -1,0 +1,27 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - truststorePaths
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: should not render truststore-paths argument when not configured
+    template: statefulset.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args
+          pattern: "--truststore-paths"
+
+  - it: should render truststore-paths argument when configured
+    set:
+      truststorePaths:
+        - "/tmp/ca-certs"
+        - "/opt/custom-certs"
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--truststore-paths=/tmp/ca-certs,/opt/custom-certs"

--- a/src/keycloak/chart/tests/kc_truststore_paths_test.yaml
+++ b/src/keycloak/chart/tests/kc_truststore_paths_test.yaml
@@ -8,13 +8,6 @@ templates:
   - statefulset.yaml
 
 tests:
-  - it: should not render truststore-paths argument when not configured
-    template: statefulset.yaml
-    asserts:
-      - notMatchRegex:
-          path: spec.template.spec.containers[0].args
-          pattern: "--truststore-paths"
-
   - it: should render truststore-paths argument when configured
     set:
       truststorePaths:

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -480,6 +480,18 @@
         "required": ["name", "value"]
       }
     },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
     "themeCustomizations": {
       "type": "object",
       "properties": {

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -459,6 +459,12 @@
       "type": "array",
       "items": {}
     },
+    "truststorePaths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "topologySpreadConstraints": {
       "type": "null"
     },

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -371,3 +371,9 @@ thirdPartyIntegration:
     # The Client Certificate format used by the L7 Load Balancer.
     # Allowed settings: "PEM" and "AWS"
     tlsCertificateFormat: PEM
+
+# Extra volumes to mount in the StatefulSet
+extraVolumes: []
+
+# Extra volume mounts to mount in the Keycloak container
+extraVolumeMounts: []

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -377,3 +377,7 @@ extraVolumes: []
 
 # Extra volume mounts to mount in the Keycloak container
 extraVolumeMounts: []
+
+# Additional truststore paths for Keycloak to scan for certificates
+# These paths will be added to the --truststore-paths startup argument
+truststorePaths: []


### PR DESCRIPTION
## Description

- Adds the ability to attach extra volumes and volume mounts to the Keycloak statefulset.  
- Adds a value to set the `--truststore-paths` to provide additional truststore directories you would like keycloak to read from (ref: https://www.keycloak.org/server/keycloak-truststore#_configuring_the_system_truststore)

This is useful for injecting additional private CA bundles for Keycloak to trust.

## Related Issue

Relates to #593 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- create private CA cert bundle and put it in a configmap called `private-ca` in the keycloak namespace
- deploy slim-dev bundle with these overrides:
```yaml
values:
  - path: extraVolumeMounts
    value:
      - name: ca-certs
        mountPath: /tmp/ca-certs
        readOnly: true
  - path: extraVolumes
    value:
      - name: ca-certs
        configMap:
          name: private-ca
  - path: truststorePaths
    value:
      - "/tmp/ca-certs"
```
- exec into the keycloak pod and run `keytool -list -keystore /opt/keycloak/data/keycloak-truststore.p12  -storetype PKCS12` and verify the CA you added is in this output

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed