### PR TITLE
docs: fix some broken links on authservice

### DIFF
--- a/src/authservice/README.md
+++ b/src/authservice/README.md
@@ -4,4 +4,4 @@ to the Istio mesh. `authservice` is compatible with any standard OIDC Provider a
 including [Authentication Policy](https://istio.io/docs/tasks/security/authn-policy/) and [RBAC](https://istio.io/docs/tasks/security/rbac-groups/).
 Together, they allow developers to protect their APIs and web apps without any application code required.
 
-See [IDAM.md](../../docs/IDAM.md) for guidance on using the [UDS Package](../pepr/operator/README.md) custom resource to generate Authservice chains.
+See the [Authservice Protection documentation](https://uds.defenseunicorns.com/reference/configuration/single-sign-on/auth-service/) for guidance on using the [UDS Package](https://uds.defenseunicorns.com/reference/configuration/uds-operator/package/) custom resource to generate Authservice chains.


### PR DESCRIPTION
## Description

Fixes a broken link and one that should go to the docs site.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/1889