### PR TITLE
chore: bump uds-k3d to 0.17.0

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -13,7 +13,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.16.0-airgap
+    ref: 0.17.0-airgap
     overrides:
       uds-dev-stack:
         minio:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.16.0-airgap
+    ref: 0.17.0-airgap
     overrides:
       uds-dev-stack:
         minio:

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -6,7 +6,7 @@ tasks:
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/uds-k3d versioning=docker
-        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.16.0-airgap --confirm --no-progress"
+        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.17.0-airgap --confirm --no-progress"
 
   - name: k3d-test-cluster
     actions:


### PR DESCRIPTION
## Description

Separating out from https://github.com/defenseunicorns/uds-core/pull/1876 since the uds-cli update will require more work there.

This update includes k3s 1.33.4 as well as some other dependency updates and new features.