### PR TITLE
fix!: improve Keycloak stability

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}
   serviceName: {{ include "keycloak.fullname" . }}-headless
-  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  podManagementPolicy: OrderedReady
   updateStrategy:
     type: {{ .Values.updateStrategy }}
   template:
@@ -271,18 +271,22 @@ spec:
               path: /health/live
               port: metrics
               scheme: HTTP
-            failureThreshold: 15
-            timeoutSeconds: 2
-            periodSeconds: 15
-            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /health/ready
               port: metrics
               scheme: HTTP
-            failureThreshold: 15
-            timeoutSeconds: 2
-            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /health/started
+              port: metrics
+              scheme: HTTP
+            failureThreshold: 600
+            periodSeconds: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -291,9 +291,6 @@
       "type": "object",
       "properties": {}
     },
-    "podManagementPolicy": {
-      "type": "string"
-    },
     "podSecurityContext": {
       "type": "object",
       "properties": {}

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -109,9 +109,6 @@ additionalNetworkAllow: []
 # Indicates whether information about services should be injected into Pod's environment variables, matching the syntax of Docker links
 enableServiceLinks: true
 
-# Pod management policy. One of `Parallel` or `OrderedReady`
-podManagementPolicy: Parallel
-
 # StatefulSet's update strategy
 updateStrategy: RollingUpdate
 

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -27,7 +27,7 @@ components:
               set +e
 
               echo "Checking if Keycloak StatefulSet should be deleted"
-              KEYCLOAK_INSTALLED=$(uds zarf tools kubectl get sts -n keycloak keycloak > /dev/null 2>&1; echo $?)
+              KEYCLOAK_INSTALLED=$(./zarf tools kubectl get sts -n keycloak keycloak > /dev/null 2>&1; echo $?)
               if [ "${KEYCLOAK_INSTALLED}" -eq 0 ]; then
                 echo "Keycloak has been previously installed. Checking the podManagementPolicy..."
                 POD_MGMT_POLICY=$(uds zarf tools kubectl get sts -n keycloak keycloak -o jsonpath='{.spec.podManagementPolicy}' 2>/dev/null || true)

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -34,7 +34,7 @@ components:
                 echo "Detected podManagementPolicy: ${POD_MGMT_POLICY:-<none>}"
                 if [ -n "${POD_MGMT_POLICY}" ] && [ "${POD_MGMT_POLICY}" != "OrderedReady" ]; then
                   echo "podManagementPolicy is '${POD_MGMT_POLICY}', deleting StatefulSet (cascade=orphan) to allow re-create with OrderedReady"
-                  uds zarf tools kubectl delete sts -n keycloak keycloak --cascade=orphan
+                 ./zarf tools kubectl delete sts -n keycloak keycloak --cascade=orphan
                 else
                   echo "podManagementPolicy is correct. Skipping..."
                 fi

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -19,6 +19,28 @@ components:
           - ../chart/values.yaml
     actions:
       onDeploy:
+        before:
+          - description: Re-create Keycloak StatefulSet
+            # This can be switched to true in subsequent UDS Core versions
+            mute: false
+            cmd: |
+              set +e
+
+              echo "Checking if Keycloak StatefulSet should be deleted"
+              KEYCLOAK_INSTALLED=$(uds zarf tools kubectl get sts -n keycloak keycloak > /dev/null 2>&1; echo $?)
+              if [ "${KEYCLOAK_INSTALLED}" -eq 0 ]; then
+                echo "Keycloak has been previously installed. Checking the podManagementPolicy..."
+                POD_MGMT_POLICY=$(uds zarf tools kubectl get sts -n keycloak keycloak -o jsonpath='{.spec.podManagementPolicy}' 2>/dev/null || true)
+                echo "Detected podManagementPolicy: ${POD_MGMT_POLICY:-<none>}"
+                if [ -n "${POD_MGMT_POLICY}" ] && [ "${POD_MGMT_POLICY}" != "OrderedReady" ]; then
+                  echo "podManagementPolicy is '${POD_MGMT_POLICY}', deleting StatefulSet (cascade=orphan) to allow re-create with OrderedReady"
+                  uds zarf tools kubectl delete sts -n keycloak keycloak --cascade=orphan
+                else
+                  echo "podManagementPolicy is correct. Skipping..."
+                fi
+              else
+                echo "Keycloak has not been installed. Skipping..."
+              fi
         after:
           - description: Validate Keycloak Pods
             wait:

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -30,7 +30,7 @@ components:
               KEYCLOAK_INSTALLED=$(./zarf tools kubectl get sts -n keycloak keycloak > /dev/null 2>&1; echo $?)
               if [ "${KEYCLOAK_INSTALLED}" -eq 0 ]; then
                 echo "Keycloak has been previously installed. Checking the podManagementPolicy..."
-                POD_MGMT_POLICY=$(uds zarf tools kubectl get sts -n keycloak keycloak -o jsonpath='{.spec.podManagementPolicy}' 2>/dev/null || true)
+                POD_MGMT_POLICY=$(./zarf tools kubectl get sts -n keycloak keycloak -o jsonpath='{.spec.podManagementPolicy}' 2>/dev/null || true)
                 echo "Detected podManagementPolicy: ${POD_MGMT_POLICY:-<none>}"
                 if [ -n "${POD_MGMT_POLICY}" ] && [ "${POD_MGMT_POLICY}" != "OrderedReady" ]; then
                   echo "podManagementPolicy is '${POD_MGMT_POLICY}', deleting StatefulSet (cascade=orphan) to allow re-create with OrderedReady"


### PR DESCRIPTION
## Description

This Pull Request contains essential stability improvements that were split out from https://github.com/defenseunicorns/uds-core/pull/1898:

* Aligned Kubernetes Probes with the upstream
* Removed `podManagementPolicy` as anything other than `OrderedReady` may lead to issues:
  * Scaling out rapidly will clash on database schema update transactions (only the first one will succeed)
  * Scaling in rapidly may cause data loss in Infinispan cluster (killed both primary and secondary owners of the data segment)

## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/issues/1748

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Tested automatically

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed

BEGIN_COMMIT_OVERRIDE
fix!: improve Keycloak stability (https://github.com/defenseunicorns/uds-core/pull/1917)

BREAKING CHANGE: Keycloak `podManagementPolicy` Helm Chart value has been removed as setting it to anything other than `OrderedReady` can cause clustering outages. During the upgrade procedure, if the previously used value was `Parallel`, Keycloak will temporarily scale in to 1 replica. Once the StatefulSet gets updated, it will scale out to previously set value. 

Release-As: 0.52.1
END_COMMIT_OVERRIDE