### PR TITLE
fix: renovate readiness pepr labels

### DIFF
--- a/.github/actions/renovate-readiness/action.yaml
+++ b/.github/actions/renovate-readiness/action.yaml
@@ -80,6 +80,7 @@ runs:
         # Compare versions
         if [[ "$PEPR_VERSION" != "$IRONBANK_IMAGE_VERSION" ]]; then
           echo "Pepr version mismatch. Waiting on Ironbank image update."
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "needs-review" || true
           gh pr edit ${{ github.event.pull_request.number }} --add-label "waiting on ironbank"
           exit 1
         else


### PR DESCRIPTION
## Description

Small fix to ensure the `needs-review` label is removed if the Pepr PR updates and is no longer ready.