### PR TITLE
fix(ci): ignore metrics on policy test pod

### DIFF
--- a/test/vitest/pepr-policies/istio.spec.ts
+++ b/test/vitest/pepr-policies/istio.spec.ts
@@ -315,6 +315,9 @@ describe("restrict istio sidecar configuration overrides", () => {
               metadata: {
                 name: "istio-sidecar",
                 namespace: "policy-tests",
+                labels: {
+                  "istio-prometheus-ignore": "yes",
+                },
               },
               spec: {
                 containers: [


### PR DESCRIPTION
## Description

During some recent CI the Prometheus e2e test has been failing due to the istio policy test sidecar metrics not being scrapeable. This is a race condition between the pod termination and how fast Prometheus scrapes pods.

Since we don't care about metrics for this test pod, this PR adds the ignore label to it so that Prometheus will not pick it up as a target.