### PR TITLE
chore: revert authservice 1.1.0, add slim-dev-ha task

### DIFF
--- a/bundles/k3d-slim-dev/uds-ha-config.yaml
+++ b/bundles/k3d-slim-dev/uds-ha-config.yaml
@@ -1,0 +1,15 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+variables:
+  core-identity-authorization:
+    keycloak_ha: true
+    keycloak_pg_username: postgres
+    keycloak_pg_password: unicorn123!@#UN
+    keycloak_pg_database: keycloak
+    keycloak_pg_host: host.k3d.internal
+    keycloak_devmode: false
+
+  # Authservice config is managed by the operator in the base layer
+  core-base:
+    AUTHSERVICE_REDIS_URI: redis://authservice:authservice@host.k3d.internal:6379

--- a/src/authservice/values/registry1-values.yaml
+++ b/src/authservice/values/registry1-values.yaml
@@ -3,4 +3,4 @@
 
 image:
   repository: registry1.dso.mil/ironbank/istio-ecosystem/authservice
-  tag: "1.1.0-ubi9"
+  tag: "1.0.4-ubi9"

--- a/src/authservice/values/unicorn-values.yaml
+++ b/src/authservice/values/unicorn-values.yaml
@@ -3,4 +3,4 @@
 
 image:
   repository: quay.io/rfcurated/istio-ecosystem/authservice
-  tag: "1.1.0-jammy-scratch-fips-rfcurated"
+  tag: "1.0.4-jammy-scratch-fips-rfcurated"

--- a/src/authservice/values/upstream-values.yaml
+++ b/src/authservice/values/upstream-values.yaml
@@ -3,4 +3,4 @@
 
 image:
   repository: ghcr.io/istio-ecosystem/authservice/authservice
-  tag: "1.1.0"
+  tag: "1.0.4"

--- a/src/authservice/zarf.yaml
+++ b/src/authservice/zarf.yaml
@@ -19,7 +19,7 @@ components:
         valuesFiles:
           - values/upstream-values.yaml
     images:
-      - ghcr.io/istio-ecosystem/authservice/authservice:1.1.0
+      - ghcr.io/istio-ecosystem/authservice/authservice:1.0.4
 
   - name: authservice
     required: true
@@ -32,7 +32,7 @@ components:
         valuesFiles:
           - values/registry1-values.yaml
     images:
-      - registry1.dso.mil/ironbank/istio-ecosystem/authservice:1.1.0-ubi9
+      - registry1.dso.mil/ironbank/istio-ecosystem/authservice:1.0.4-ubi9
 
   - name: authservice
     required: true
@@ -45,4 +45,4 @@ components:
         valuesFiles:
           - values/unicorn-values.yaml
     images:
-      - quay.io/rfcurated/istio-ecosystem/authservice:1.1.0-jammy-scratch-fips-rfcurated
+      - quay.io/rfcurated/istio-ecosystem/authservice:1.0.4-jammy-scratch-fips-rfcurated

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -69,6 +69,18 @@ tasks:
       - description: "Deploy slim dev bundle"
         task: deploy:k3d-slim-dev-bundle
 
+  - name: slim-dev-ha
+    description: "Build and deploy slim dev bundle with HA configuration"
+    actions:
+      - description: "Setup HA PostgreSQL"
+        task: setup:ha-postgres
+      - description: "Setup HA Redis"
+        task: setup:ha-redis
+      - description: "Build slim dev bundle"
+        task: create:k3d-slim-dev-bundle
+      - description: "Deploy slim dev bundle with HA configuration"
+        task: deploy:k3d-slim-dev-bundle-ha
+
   - name: dev-identity
     description: "Create k3d cluster with istio, Pepr, Keycloak, and Authservice for development"
     actions:

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -35,6 +35,13 @@ tasks:
       - description: "Deploy the UDS Core Slim Dev Only Bundle"
         cmd: uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
 
+  - name: k3d-slim-dev-bundle-ha
+    actions:
+      - description: "Deploy the UDS Core Slim Dev Bundle with HA configuration"
+        cmd: uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+        env:
+          - UDS_CONFIG=bundles/k3d-slim-dev/uds-ha-config.yaml
+
   # This task is a wrapper to support --set LAYER=identity-authorization
   - name: single-layer-callable
     actions:


### PR DESCRIPTION
## Description

Reverts authservice version update due to upstream bug/breaking change (see [issue](https://www.github.com/istio-ecosystem/authservice/issues/304)).

Also adds a slim-dev-ha task for quicker iterations on keycloak/authservice HA.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed