### PR TITLE
chore: update HA bundle configs to use 2 authservice replicas

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -127,6 +127,13 @@ packages:
     ref: 0.52.1
     # x-release-please-end
     overrides:
+      authservice:
+        authservice:
+          variables:
+            - name: AUTHSERVICE_REPLICA_COUNT
+              description: "Number of authservice replicas"
+              default: 1
+              path: replicaCount
       keycloak:
         keycloak:
           variables:

--- a/bundles/k3d-slim-dev/uds-ha-config.yaml
+++ b/bundles/k3d-slim-dev/uds-ha-config.yaml
@@ -9,6 +9,7 @@ variables:
     keycloak_pg_database: keycloak
     keycloak_pg_host: host.k3d.internal
     keycloak_devmode: false
+    AUTHSERVICE_REPLICA_COUNT: 2
 
   # Authservice config is managed by the operator in the base layer
   core-base:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -132,6 +132,13 @@ packages:
             - name: TENANT_SERVICE_PORTS
               description: "The ports that are exposed from the tenant gateway LoadBalancer (useful for non-HTTP(S) traffic)"
               path: "service.ports"
+      authservice:
+        authservice:
+          variables:
+            - name: AUTHSERVICE_REPLICA_COUNT
+              description: "Number of authservice replicas"
+              default: 1
+              path: replicaCount
       keycloak:
         keycloak:
           variables:

--- a/bundles/k3d-standard/uds-ha-config.yaml
+++ b/bundles/k3d-standard/uds-ha-config.yaml
@@ -22,3 +22,4 @@ variables:
 
     # Authservice variables
     AUTHSERVICE_REDIS_URI: redis://authservice:authservice@host.k3d.internal:6379
+    AUTHSERVICE_REPLICA_COUNT: 2


### PR DESCRIPTION
## Description

Our HA bundle configs for testing were not using more than 1 replica for authservice.  This PR update to use 2 replicas for the slim-dev and standard HA bundles.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- `uds run slim-dev-ha` and validate 2 authservice replicas

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed