### PR TITLE
chore: split pepr and operator-deps into own renovate groups

### DIFF
--- a/.github/actions/renovate-readiness/action.yaml
+++ b/.github/actions/renovate-readiness/action.yaml
@@ -55,6 +55,11 @@ runs:
           echo "package=support-deps" >> $GITHUB_OUTPUT
           echo "is_support_deps=true" >> $GITHUB_OUTPUT
           echo "needs_comparison=false" >> $GITHUB_OUTPUT
+        elif [[ "$PACKAGE_NAME" == "operator-deps" ]]; then
+          echo "Detected operator dependencies update"
+          echo "package=operator-deps" >> $GITHUB_OUTPUT
+          echo "is_operator_deps=true" >> $GITHUB_OUTPUT
+          echo "needs_comparison=false" >> $GITHUB_OUTPUT
         else
           echo "Regular package update: $PACKAGE_NAME"
           echo "package=$PACKAGE_NAME" >> $GITHUB_OUTPUT
@@ -100,6 +105,16 @@ runs:
         gh pr edit ${{ github.event.pull_request.number }} --add-label "needs-review"
         # Fail the job to prevent excessive CI runs of IAC clusters
         exit 1
+
+    # Handle operator dependencies
+    - name: Handle operator dependencies
+      if: steps.process-branch.outputs.is_operator_deps == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "Operator dependencies update detected. Needs manual review."
+        gh pr edit ${{ github.event.pull_request.number }} --add-label "needs-review"
 
     # Checkout PR branch (sparse checkout of src/<pkg>)
     - name: Checkout PR branch

--- a/renovate.json
+++ b/renovate.json
@@ -69,7 +69,14 @@
       "commitMessageTopic": "support dependencies"
     },
     {
+      "matchFileNames": ["package.json", "package-lock.json"],
+      "groupName": "operator-deps",
+      "excludeDepNames": ["pepr"],
+      "commitMessageTopic": "operator-deps"
+    },
+    {
       "matchFileNames": ["package.json", "package-lock.json", "tasks/create.yaml"],
+      "matchDepNames": ["pepr", "registry1.dso.mil/ironbank/opensource/defenseunicorns/pepr/controller", "defenseunicorns/pepr"],
       "groupName": "pepr",
       "commitMessageTopic": "pepr"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,12 @@
     },
     {
       "matchFileNames": ["package.json", "package-lock.json"],
+      "groupName": "support-deps",
+      "matchDepTypes": ["devDependencies"],
+      "commitMessageTopic": "support dependencies"
+    },
+    {
+      "matchFileNames": ["package.json", "package-lock.json"],
       "groupName": "operator-deps",
       "excludeDepNames": ["pepr"],
       "commitMessageTopic": "operator-deps"

--- a/renovate.json
+++ b/renovate.json
@@ -70,15 +70,15 @@
     },
     {
       "matchFileNames": ["package.json", "package-lock.json"],
-      "groupName": "support-deps",
-      "matchDepTypes": ["devDependencies"],
-      "commitMessageTopic": "support dependencies"
-    },
-    {
-      "matchFileNames": ["package.json", "package-lock.json"],
       "groupName": "operator-deps",
       "excludeDepNames": ["pepr"],
       "commitMessageTopic": "operator-deps"
+    },
+    {
+      "matchFileNames": ["package.json", "package-lock.json"],
+      "groupName": "support-deps",
+      "matchDepTypes": ["devDependencies"],
+      "commitMessageTopic": "support dependencies"
     },
     {
       "matchFileNames": ["package.json", "package-lock.json", "tasks/create.yaml"],


### PR DESCRIPTION
## Description

All npm deps are being grouped into the pepr renovate group.  See: https://github.com/defenseunicorns/uds-core/pull/1954 as an example PR where this causes issues.

- Updates the renovate config to bump pepr as a completely separate group
- npm dev deps will get grouped to support-deps
- npm actual deps with get grouped to operator-deps

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed