### PR TITLE
chore: update renovate config to ignore a bad tag in registry1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,6 +95,12 @@
       "matchPackageNames": ["defenseunicorns/uds-common", "mcr.microsoft.com/playwright", "defenseunicorns/kubernetes-fluent-client"],
       "groupName": "support-deps",
       "commitMessageTopic": "support-deps"
+    },
+    {
+      "matchPackageNames": [
+          "registry1.dso.mil/ironbank/opensource/falcosecurity/falcosidekick"
+      ],
+      "allowedVersions": "!/99.99.99/"
     }
   ]
 }


### PR DESCRIPTION
## Description

Update renovate config to ignore bad tag for `registry1.dso.mil/ironbank/opensource/falcosecurity/falcosidekick`.
<img width="853" height="129" alt="image" src="https://github.com/user-attachments/assets/1e591b88-5cc5-4219-a857-681825b58fcb" />

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed