### PR TITLE
chore: add keycloak default sso_session_idle_timeout value/add compliance mapping

### DIFF
--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -47,6 +47,10 @@ realmInitEnv:
   # Maximum number of concurrent active sessions per user. Set to 0 to disable the limit (unlimited).
   SSO_SESSION_MAX_PER_USER: "0"
   # @lulaEnd ef276ec4-7921-4287-a18c-80dec5f8e742
+  # @lulaStart 251f6498-05a3-416c-b6eb-b9fadd776704
+  # Specifies how long a session remains active without user activity
+  SSO_SESSION_IDLE_TIMEOUT: "600"
+  # @lulaEnd 251f6498-05a3-416c-b6eb-b9fadd776704
 
 # Realm-level configuration
 realmConfig:


### PR DESCRIPTION
## Description

Adds the default value for Keycloak `SSO_SESSION_IDLE_TIMEOUT` and adds a Lula compliance mapping.  Default value taken from identity config: https://github.com/defenseunicorns/uds-identity-config/blob/v0.17.0/src/realm.json#L12

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed