### PR TITLE
fix(ci): upgrade bug on release PR

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -13,7 +13,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.17.0-airgap
+    ref: 0.16.0-airgap
     overrides:
       uds-dev-stack:
         minio:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.17.0-airgap
+    ref: 0.16.0-airgap
     overrides:
       uds-dev-stack:
         minio:

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -73,15 +73,17 @@ tasks:
         cmd: uds zarf tools registry ls ${TARGET_REPO}/core | grep ${FLAVOR} | sort -V | tail -1
         setVariables:
           - name: LATEST_VERSION
+      - description: "Extract unflavored version for git tag"
+        cmd: echo ${LATEST_VERSION} | cut -d'-' -f1 # Extract version before any hyphen (e.g., "0.52.0" from "0.52.0-upstream")
+        setVariables:
+          - name: LATEST_CORE_TAG
       - description: "Create the latest version with bundle overrides"
         cmd: |
           # Create temp directory
           mkdir -p tmp/core-shim
 
-          LATEST_CORE_VERSION=$(echo ${LATEST_VERSION} | cut -d'-' -f1) # Extract version before any hyphen (e.g., "0.52.0" from "0.52.0-upstream")
-
           # Download latest release bundle
-          curl -sSL https://raw.githubusercontent.com/defenseunicorns/uds-core/v${LATEST_CORE_VERSION}/bundles/k3d-standard/uds-bundle.yaml -o tmp/core-shim/uds-bundle.yaml
+          curl -sSL https://raw.githubusercontent.com/defenseunicorns/uds-core/v${LATEST_CORE_TAG}/bundles/k3d-standard/uds-bundle.yaml -o tmp/core-shim/uds-bundle.yaml
 
           # Update the bundle with the latest version using yq
           uds zarf tools yq e -i "
@@ -96,7 +98,7 @@ tasks:
         cmd: |
           # Set UDS_CONFIG for bundle deployment
           export UDS_CONFIG="${{ .inputs.configFile }}"
-          uds deploy tmp/core-shim/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+          uds deploy tmp/core-shim/uds-bundle-k3d-core-demo-${UDS_ARCH}-${LATEST_CORE_TAG}.tar.zst --confirm --no-progress
       - description: "Clean up temporary files"
         cmd: rm -rf tmp/core-shim
 

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -6,7 +6,7 @@ tasks:
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/uds-k3d versioning=docker
-        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.17.0-airgap --confirm --no-progress"
+        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.16.0-airgap --confirm --no-progress"
 
   - name: k3d-test-cluster
     actions:


### PR DESCRIPTION
## Description

Issue seen on https://github.com/defenseunicorns/uds-core/pull/1924 ([CI Run](https://github.com/defenseunicorns/uds-core/actions/runs/18128196906/job/51589441448))

This ensures that the proper version is used in bundle deploy commands during the release PRs (where `VERSION` will be the "next" version about to be tagged).

Also reverts uds-k3d due to https://github.com/defenseunicorns/uds-core/issues/1939