### PR TITLE
chore: enable sandbox incubating falco rules for iac tests

### DIFF
--- a/.github/bundles/aks/uds-bundle.yaml
+++ b/.github/bundles/aks/uds-bundle.yaml
@@ -165,8 +165,8 @@ packages:
             - name: FALCO_SANDBOX_RULES_ENABLED
               description: Enable sandbox rules
               path: sandboxRulesEnabled
-              default: "false" # TODO: enable this when we fix flakey test
+              default: "true"
             - name: FALCO_INCUBATING_RULES_ENABLED
               description: Enable incubating rules
               path: incubatingRulesEnabled
-              default: "false" # TODO: enable this when we fix flakey test
+              default: "true"

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -116,8 +116,8 @@ packages:
             - name: FALCO_SANDBOX_RULES_ENABLED
               description: Enable sandbox rules
               path: sandboxRulesEnabled
-              default: "false" # TODO: enable this when we fix flakey test
+              default: "true"
             - name: FALCO_INCUBATING_RULES_ENABLED
               description: Enable incubating rules
               path: incubatingRulesEnabled
-              default: "false" # TODO: enable this when we fix flakey test
+              default: "true"

--- a/.github/bundles/rke2/uds-bundle.yaml
+++ b/.github/bundles/rke2/uds-bundle.yaml
@@ -147,8 +147,8 @@ packages:
             - name: FALCO_SANDBOX_RULES_ENABLED
               description: Enable sandbox rules
               path: sandboxRulesEnabled
-              default: "false" # TODO: enable this when we fix flakey test
+              default: "true"
             - name: FALCO_INCUBATING_RULES_ENABLED
               description: Enable incubating rules
               path: incubatingRulesEnabled
-              default: "false" # TODO: enable this when we fix flakey test
+              default: "true"

--- a/test/vitest/falco-integration.spec.ts
+++ b/test/vitest/falco-integration.spec.ts
@@ -6,7 +6,7 @@
 import * as net from "net";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { closeForward, getForward } from "./helpers/forward";
-import { execAndWait, withTempPod } from "./helpers/k8s";
+import { execAndWait, getAllLogsByLabelSelector, withTempPod } from "./helpers/k8s";
 import { queryLoki } from "./helpers/loki";
 import { pollUntilSuccess } from "./helpers/polling";
 
@@ -68,90 +68,90 @@ describe("Falco Integration e2e Tests", () => {
     );
   }, 70000); // Set test timeout to 70 seconds
 
-  // test("Falco detects 'Write below root' event and sends to Falco Sidekick", async () => {
-  //   // Generate a random string to identify this test run
-  //   const randomString = Math.random().toString(36).substring(2, 10);
+  test("Falco detects 'Write below root' event and sends to Falco Sidekick", async () => {
+    // Generate a random string to identify this test run
+    const randomString = Math.random().toString(36).substring(2, 10);
 
-  //   // Use a temporary pod in kube-system to trigger the Falco event
-  //   await withTempPod(
-  //     {
-  //       name: `falco-write-test-${randomString}`,
-  //       namespace: "kube-system", // Use kube-system to get around zarf mutations
-  //       image: "alpine:latest",
-  //       command: ["sleep", "3600"],
-  //     },
-  //     async podName => {
-  //       // Try to write to a system directory (should trigger the rule)
-  //       await execAndWait(
-  //         "kube-system",
-  //         podName,
-  //         ["sh", "-c", `echo "test" >> /etc/passwd`],
-  //         "main",
-  //       );
+    // Use a temporary pod in kube-system to trigger the Falco event
+    await withTempPod(
+      {
+        name: `falco-write-test-${randomString}`,
+        namespace: "kube-system", // Use kube-system to get around zarf mutations
+        image: "alpine:latest",
+        command: ["sleep", "3600"],
+      },
+      async podName => {
+        // Try to write to a system directory (should trigger the rule)
+        await execAndWait(
+          "kube-system",
+          podName,
+          ["sh", "-c", `echo "test" >> /etc/passwd`],
+          "main",
+        );
 
-  //       // Poll for the Falco event in falcosidekick logs until success or timeout
-  //       const falcoSidekickEvent = await pollUntilSuccess(
-  //         async () => {
-  //           const falcoSidekickLogs = await getAllLogsByLabelSelector(
-  //             "falco",
-  //             "app.kubernetes.io/name=falcosidekick",
-  //           );
-  //           return falcoSidekickLogs.find(
-  //             log =>
-  //               log.includes('"rule":"Write below etc"') &&
-  //               log.includes("File below /etc opened for writing") &&
-  //               log.includes("file=/etc/passwd"),
-  //           );
-  //         },
-  //         result => result !== undefined,
-  //         "Falco event for write to /etc/passwd in falcosidekick logs",
-  //         60000, // 1 minute timeout
-  //         15000, // 15 seconds interval
-  //       );
+        // Poll for the Falco event in falcosidekick logs until success or timeout
+        const falcoSidekickEvent = await pollUntilSuccess(
+          async () => {
+            const falcoSidekickLogs = await getAllLogsByLabelSelector(
+              "falco",
+              "app.kubernetes.io/name=falcosidekick",
+            );
+            return falcoSidekickLogs.find(
+              log =>
+                log.includes('"rule":"Write below etc"') &&
+                log.includes("File below /etc opened for writing") &&
+                log.includes("file=/etc/passwd"),
+            );
+          },
+          result => result !== undefined,
+          "Falco event for write to /etc/passwd in falcosidekick logs",
+          60000, // 1 minute timeout
+          15000, // 15 seconds interval
+        );
 
-  //       expect(falcoSidekickEvent).toBeDefined();
-  //     },
-  //   );
-  // }, 70000); // Set test timeout to 70 seconds
+        expect(falcoSidekickEvent).toBeDefined();
+      },
+    );
+  }, 70000); // Set test timeout to 70 seconds
 
-  // test("Falco detects 'Read environment variables from /proc files' event and sends to Falco Sidekick", async () => {
-  //   // Generate a random string to identify this test run
-  //   const randomString = Math.random().toString(36).substring(2, 10);
+  test("Falco detects 'Read environment variables from /proc files' event and sends to Falco Sidekick", async () => {
+    // Generate a random string to identify this test run
+    const randomString = Math.random().toString(36).substring(2, 10);
 
-  //   // Use a temporary pod in kube-system to trigger the Falco event
-  //   await withTempPod(
-  //     {
-  //       name: `falco-proc-env-test-${randomString}`,
-  //       namespace: "kube-system", // Use kube-system to get around zarf mutations
-  //       image: "alpine:latest",
-  //       command: ["sleep", "3600"],
-  //     },
-  //     async podName => {
-  //       // Try to read environment variables from /proc/1/environ
-  //       await execAndWait("kube-system", podName, ["sh", "-c", "cat /proc/1/environ"], "main");
+    // Use a temporary pod in kube-system to trigger the Falco event
+    await withTempPod(
+      {
+        name: `falco-proc-env-test-${randomString}`,
+        namespace: "kube-system", // Use kube-system to get around zarf mutations
+        image: "alpine:latest",
+        command: ["sleep", "3600"],
+      },
+      async podName => {
+        // Try to read environment variables from /proc/1/environ
+        await execAndWait("kube-system", podName, ["sh", "-c", "cat /proc/1/environ"], "main");
 
-  //       // Poll for the Falco event in falcosidekick logs until success or timeout
-  //       const falcoSidekickEvent = await pollUntilSuccess(
-  //         async () => {
-  //           const falcoSidekickLogs = await getAllLogsByLabelSelector(
-  //             "falco",
-  //             "app.kubernetes.io/name=falcosidekick",
-  //           );
-  //           return falcoSidekickLogs.find(
-  //             log =>
-  //               log.includes('"rule":"Read environment variable from /proc files"') &&
-  //               log.includes("Environment variables") &&
-  //               log.includes("file=/proc/1/environ"),
-  //           );
-  //         },
-  //         result => result !== undefined,
-  //         "Falco event for reading /proc/1/environ in falcosidekick logs",
-  //         60000, // 1 minute timeout
-  //         15000, // 15 seconds interval
-  //       );
+        // Poll for the Falco event in falcosidekick logs until success or timeout
+        const falcoSidekickEvent = await pollUntilSuccess(
+          async () => {
+            const falcoSidekickLogs = await getAllLogsByLabelSelector(
+              "falco",
+              "app.kubernetes.io/name=falcosidekick",
+            );
+            return falcoSidekickLogs.find(
+              log =>
+                log.includes('"rule":"Read environment variable from /proc files"') &&
+                log.includes("Environment variables") &&
+                log.includes("file=/proc/1/environ"),
+            );
+          },
+          result => result !== undefined,
+          "Falco event for reading /proc/1/environ in falcosidekick logs",
+          60000, // 1 minute timeout
+          15000, // 15 seconds interval
+        );
 
-  //       expect(falcoSidekickEvent).toBeDefined();
-  //     },
-  //   );
-  // }, 70000); // Set test timeout to 70 seconds
+        expect(falcoSidekickEvent).toBeDefined();
+      },
+    );
+  }, 70000); // Set test timeout to 70 seconds
 });


### PR DESCRIPTION
## Description

Enable sandbox/incubating rules for Falco in IAC bundles.  Also reenable tests for the sandbox/incubating rules.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- IAC tests in CI

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed