### PR TITLE
fix: add wait for pepr pods to have ambient annotation

### DIFF
--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -108,6 +108,34 @@ components:
               else
                 echo "No sidecars detected. Pepr pods are already Ambient-compatible. Skipping restart."
               fi
+          - description: "Wait for Pepr pods to have ambient redirection annotation"
+            cmd: |
+              echo "Waiting for Pepr pods to have ambient redirection annotation..."
+              ATTEMPTS=0
+              MAX_ATTEMPTS=30
+              while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
+                # Check if any Pepr pods exist
+                PEPR_PODS=$(./zarf tools kubectl get pods -n pepr-system -o name 2>/dev/null)
+                if [ -z "$PEPR_PODS" ]; then
+                  echo "No Pepr pods found. Waiting..."
+                  ATTEMPTS=$((ATTEMPTS+1))
+                  sleep 5
+                  continue
+                fi
+                # Check if all pods have the ambient redirection annotation set to enabled
+                PODS_WITHOUT_AMBIENT=$(./zarf tools kubectl get pods -n pepr-system -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.ambient\.istio\.io/redirection}{"\n"}{end}' | grep -v "enabled" | wc -l)
+                if [ "$PODS_WITHOUT_AMBIENT" -gt 0 ]; then
+                  echo "Some Pepr pods don't have ambient redirection annotation yet. Waiting..."
+                  ATTEMPTS=$((ATTEMPTS+1))
+                  sleep 5
+                  continue
+                fi
+                break
+              done
+              if [ $ATTEMPTS -eq $MAX_ATTEMPTS ]; then
+                echo "Timed out waiting for Pepr pods to have ambient redirection annotation"
+                exit 1
+              fi
 
   - name: gateway-api-crds
     required: true


### PR DESCRIPTION
## Description
We've had a lot of flaky testing recently in CI because of pepr webhooks nothing be ready for gateways. Attempting to add a check for the ambient annotation before continuing to gateway creation.

## Related Issue
Relates to #2021

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- run ci a bunch of times?

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed