### PR TITLE
fix: velero crd helm ownership

### DIFF
--- a/src/velero/common/zarf.yaml
+++ b/src/velero/common/zarf.yaml
@@ -71,9 +71,15 @@ components:
                 serverstatusrequests.velero.io \
                 volumesnapshotlocations.velero.io; do
 
-                kubectl label crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
-                kubectl annotate crd "$crd" meta.helm.sh/release-name="$RELEASE_NAME" --overwrite 2>/dev/null || true
-                kubectl annotate crd "$crd" meta.helm.sh/release-namespace="$RELEASE_NAMESPACE" --overwrite 2>/dev/null || true
+                # Only apply the labels/annotations if the CRD exists and is not already managed by Helm
+                if ./zarf tools kubectl get crd "$crd" >/dev/null 2>&1; then
+                  MANAGED_BY=$(./zarf tools kubectl get crd "$crd" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>/dev/null)
+                  if [ "$MANAGED_BY" != "Helm" ]; then
+                    ./zarf tools kubectl label crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite
+                    ./zarf tools kubectl annotate crd "$crd" meta.helm.sh/release-name="$RELEASE_NAME" --overwrite
+                    ./zarf tools kubectl annotate crd "$crd" meta.helm.sh/release-namespace="$RELEASE_NAMESPACE" --overwrite
+                  fi
+                fi
               done
 
   - name: velero

--- a/src/velero/common/zarf.yaml
+++ b/src/velero/common/zarf.yaml
@@ -71,14 +71,11 @@ components:
                 serverstatusrequests.velero.io \
                 volumesnapshotlocations.velero.io; do
 
-                # Only apply the labels/annotations if the CRD exists and is not already managed by Helm
+                # Only apply the labels/annotations if the CRD exists
                 if ./zarf tools kubectl get crd "$crd" >/dev/null 2>&1; then
-                  MANAGED_BY=$(./zarf tools kubectl get crd "$crd" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>/dev/null)
-                  if [ "$MANAGED_BY" != "Helm" ]; then
-                    ./zarf tools kubectl label crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite
-                    ./zarf tools kubectl annotate crd "$crd" meta.helm.sh/release-name="$RELEASE_NAME" --overwrite
-                    ./zarf tools kubectl annotate crd "$crd" meta.helm.sh/release-namespace="$RELEASE_NAMESPACE" --overwrite
-                  fi
+                  ./zarf tools kubectl label crd "$crd" app.kubernetes.io/managed-by=Helm --overwrite
+                  ./zarf tools kubectl annotate crd "$crd" meta.helm.sh/release-name="$RELEASE_NAME" --overwrite
+                  ./zarf tools kubectl annotate crd "$crd" meta.helm.sh/release-namespace="$RELEASE_NAMESPACE" --overwrite
                 fi
               done
 


### PR DESCRIPTION
## Description

Fixes the Velero CRD Helm ownership zarf action.  This was failing if you didn't have `kubectl` on your path.

This PR changes the logic so that:
1. `./zarf tools kubectl` is used
2. Fail if the label and annotate commands fail

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Deploy UDS core 0.53.1 `uds deploy k3d-core-demo:0.53.1 --confirm`
- Deploy the standard bundle (core package only) on top of this
- Ensure CRDs are owned properly by the helm chart 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed