### PR TITLE
fix: keycloak statefulset spi provider syntax

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -166,13 +166,13 @@ spec:
               value: "true"
 
             ## Activate the nginx provider
-            - name: KC_SPI_X509CERT_LOOKUP_PROVIDER
+            - name: KC_SPI__X509CERT_LOOKUP__PROVIDER
               value: {{ .Values.x509LookupProvider }}
             # Set nginx provider header name
-            - name: KC_SPI_X509CERT_LOOKUP_{{ .Values.x509LookupProvider | upper }}_SSL_CLIENT_CERT
+            - name: KC_SPI__X509CERT_LOOKUP__{{ .Values.x509LookupProvider | upper }}__SSL_CLIENT_CERT
               value: istio-mtls-client-certificate
             # Dumb value (not used in the nginx provider, but required by the SPI)
-            - name: KC_SPI_X509CERT_LOOKUP_{{ .Values.x509LookupProvider | upper }}_SSL_CLIENT_CERT_CHAIN_PREFIX
+            - name: KC_SPI__X509CERT_LOOKUP__{{ .Values.x509LookupProvider | upper }}__SSL_CLIENT_CERT_CHAIN_PREFIX
               value: UNUSED
           {{- if or .Values.devMode .Values.debugMode }}
             # Enable debug logs


### PR DESCRIPTION
## Description
In a previous keycloak update they updated their spi statefulset reference syntax, it now needs to be double underscores. At the moment this is just a warning error that happens when not using the correct syntax.

`WARNING: The following SPI options are using the legacy format and are not being treated as build time options. Please use the new format with the appropriate -- separators to resolve this ambiguity: kc.spi-x509cert-lookup-provider`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run test-single-layer --set LAYER=identity-authorization` from main and monitoring the logs of keycloak pod as it comes up to see the warning
- run the same command from my branch and see that the warning is no longer present.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed