### PR TITLE
fix: remove setting --blocking-factor=64 when extracting the checkpoint image

### DIFF
--- a/packages/checkpoint-dev/zarf.yaml
+++ b/packages/checkpoint-dev/zarf.yaml
@@ -88,7 +88,7 @@ components:
               DATA_DIR="${TMPDIR}/uds-checkpoint-data"
               mkdir -p "$DATA_DIR"
 
-              sudo tar --blocking-factor=64 -xpf uds-checkpoint.tar -C "$DATA_DIR"
+              sudo tar -xpf uds-checkpoint.tar -C "$DATA_DIR"
               K8S_TOKEN="$(sudo cat ${DATA_DIR}/k3s_data/server/token)"
               echo $K8S_TOKEN
               sudo docker load -i "${DATA_DIR}/uds-k3d-checkpoint-latest.tar"


### PR DESCRIPTION
## Description

On a STIGed Ubuntu 22.04 w/ FIPS enabled (kernel version `5.15.0-1093-aws-fips`) EC2 instance acting as a GitLab CI fleeting runner, running `sudo tar --blocking-factor=64 -xpf  uds-checkpoint.tar` will cause the machine to lock up due to `auditd` attempting to log all the `mknod` commands being run as a result of `tar`.

It is not immediately clear whether removing `--blocking-factor` will decrease performance when extracting as [sources for this flag usually refer to magnetic tapes](https://docs.oracle.com/cd/E19253-01/816-5165/6mbb0m9td/index.html#:~:text=When%20a%20tape%20archive%20is%20being%20read%2C%20its%20actual%20blocking%20factor%20will%20be%20automatically%20detected).

Things that were tried, but had either no success or no consistent success:

1. Changing the instance type of the EC2 instance from `m7i.2xlarge` to an `m7i.4xlarge`
2. Using `zarf package deploy` instead of `uds zarf package deploy`
3. Trying various different `--blocking-factor` values besides `64`
4. Adding a sleep before the `tar` command
6. Modifying the `auditd` configs and/or rules
7. Disabling FIPS
8. Downgrading the versions of UDS CLI, Zarf, and/or the checkpoint image
9. Extracting the checkpoint image, re-packaging it, and then attempting to unarchive it again on the same system

Things that did have consistent success include:

1. Disabling `auditd` (not advisable/possible as the runners should be STIGed)
2. Piping the contents of the file via `cat` into the `sudo tar` command

## Related Issue

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Things should still work normally.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed