### PR TITLE
fix: keycloak spi envs syntax

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -154,11 +154,11 @@ spec:
               value: "true"
             # @lulaStart e4ea044c-75fc-4acc-a552-8bba2aab1b12
             {{- if .Values.detailedObservability.logging.enabled }}
-            - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL
+            - name: KC_SPI_EVENTS_LISTENER__JBOSS_LOGGING__SUCCESS_LEVEL
               value: "info"
-            - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SANITIZE
+            - name: KC_SPI_EVENTS_LISTENER__JBOSS_LOGGING__SANITIZE
               value: "true"
-            - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_INCLUDE_REPRESENTATION
+            - name: KC_SPI_EVENTS_LISTENER__JBOSS_LOGGING__INCLUDE_REPRESENTATION
               value: "true"
             {{- end }}
             # @lulaEnd e4ea044c-75fc-4acc-a552-8bba2aab1b12
@@ -167,17 +167,17 @@ spec:
               value: request
 
             # Escape Slashes in Group Names
-            - name: KC_SPI_GROUP_JPA_ESCAPE_SLASHES_IN_GROUP_PATH
+            - name: KC_SPI_GROUP__JPA__ESCAPE_SLASHES_IN_GROUP_PATH
               value: "true"
 
             ## Activate the nginx provider
-            - name: KC_SPI_X509CERT_LOOKUP_PROVIDER
+            - name: KC_SPI_X509CERT_LOOKUP__PROVIDER
               value: {{ .Values.x509LookupProvider }}
             # Set nginx provider header name
-            - name: KC_SPI_X509CERT_LOOKUP_{{ .Values.x509LookupProvider | upper }}_SSL_CLIENT_CERT
+            - name: KC_SPI_X509CERT_LOOKUP__{{ .Values.x509LookupProvider | upper }}__SSL_CLIENT_CERT
               value: istio-mtls-client-certificate
             # Dumb value (not used in the nginx provider, but required by the SPI)
-            - name: KC_SPI_X509CERT_LOOKUP_{{ .Values.x509LookupProvider | upper }}_SSL_CLIENT_CERT_CHAIN_PREFIX
+            - name: KC_SPI_X509CERT_LOOKUP__{{ .Values.x509LookupProvider | upper }}__SSL_CLIENT_CERT_CHAIN_PREFIX
               value: UNUSED
           {{- if or .Values.devMode .Values.debugMode }}
             # Enable debug logs
@@ -212,12 +212,12 @@ spec:
             - name: KC_CACHE
               value: ispn
             # Hints Infinispan to distribute data across machines in a Multi AZ environment
-            - name: KC_SPI_CACHE_EMBEDDED_DEFAULT_MACHINE_NAME
+            - name: KC_SPI_CACHE_EMBEDDED__DEFAULT__MACHINE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
                   apiVersion: v1
-            - name: KC_SPI_STICKY_SESSION_ENCODER_INFINISPAN_SHOULD_ATTACH_ROUTE
+            - name: KC_SPI_STICKY_SESSION_ENCODER__INFINISPAN__SHOULD_ATTACH_ROUTE
               value: "false"
             # Rely on Istio mTLS encryption
             # See https://www.keycloak.org/server/caching#_running_inside_a_service_mesh


### PR DESCRIPTION
## Description
Updating the Keycloak spi envs to use the newer syntax. I was able to search the official docs and find various places these envs are referenced, unfortunately there isn't somewhere that references all of them in one place.

[Both the code](https://github.com/keycloak/keycloak/blob/3724409c5ee57bbebf36ed745c82855a731942cd/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java#L100) and the docs are very ambiguous with this change.

docs:
[provider spi envs](https://www.keycloak.org/server/all-provider-config)
[x509 lookup spi envs](https://www.keycloak.org/server/reverseproxy#_enabling_client_certificate_lookup)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Verified this by running locally both:
  - `uds run test-single-layer --set LAYER=identity-authorization --set FLAVOR=unicorn`
  - `uds run -f tasks/test.yaml uds-core-e2e --set FLAVOR=unicorn`
- Additionally verified in identity-config that i was able to run both:
  - `uds run uds-core-integration-tests --set FLAVOR=unicorn`
  - `uds run uds-core-smoke-test --set FLAVOR=unicorn`

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed