### PR TITLE
fix: renovate readiness check unicorn pepr image version

### DIFF
--- a/.github/actions/renovate-readiness/README.md
+++ b/.github/actions/renovate-readiness/README.md
@@ -15,7 +15,12 @@ The action performs the following steps:
 2. **Branch Name Processing**: The action extracts the package name from the branch name by removing the `renovate/` prefix.
 
 3. **Special Case Handling**:
-   - **Pepr Updates**: For Pepr updates, the action compares the version in `package.json` with the image versions in `tasks/create.yaml`. If they don't match, it adds the `waiting on ironbank` label.
+   - **Pepr Updates**: For Pepr updates, the action validates that all three Pepr versions are in sync:
+     - `package.json` dependency version
+     - `REGISTRY1_PEPR_IMAGE` (Ironbank) in `tasks/create.yaml`
+     - `UNICORN_PEPR_IMAGE` (Unicorn private) in `tasks/create.yaml`
+
+     If any versions are out of sync, it adds the `waiting on ironbank` label and fails the check.
    - **Support Dependencies**: For support dependency updates, the action adds the `needs-review` label and sets `should_process` to `false` to prevent excessive IAC runs.
 
 4. **Regular Package Updates**:

--- a/.github/actions/renovate-readiness/README.md
+++ b/.github/actions/renovate-readiness/README.md
@@ -17,10 +17,14 @@ The action performs the following steps:
 3. **Special Case Handling**:
    - **Pepr Updates**: For Pepr updates, the action validates that all three Pepr versions are in sync:
      - `package.json` dependency version
-     - `REGISTRY1_PEPR_IMAGE` (Ironbank) in `tasks/create.yaml`
-     - `UNICORN_PEPR_IMAGE` (Unicorn private) in `tasks/create.yaml`
+     - `REGISTRY1_PEPR_IMAGE` in `tasks/create.yaml`
+     - `UNICORN_PEPR_IMAGE` in `tasks/create.yaml`
 
-     If any versions are out of sync, it adds the `waiting on ironbank` label and fails the check.
+     The action applies specific labels based on which versions are out of sync:
+     - `waiting on upstream`: If package.json version is behind both/either image versions (indicates a Pepr release issue)
+     - `waiting on ironbank`: If Ironbank image is behind package.json
+     - `waiting on unicorn`: If Unicorn image is behind package.json
+     - Multiple `waiting on` labels can be applied if multiple images are behind
    - **Support Dependencies**: For support dependency updates, the action adds the `needs-review` label and sets `should_process` to `false` to prevent excessive IAC runs.
 
 4. **Regular Package Updates**:

--- a/.github/actions/renovate-readiness/action.yaml
+++ b/.github/actions/renovate-readiness/action.yaml
@@ -87,31 +87,62 @@ runs:
         echo "Unicorn image version: $UNICORN_IMAGE_VERSION"
 
         # Check if all three versions are in sync
-        VERSIONS_MATCH=true
+        IRONBANK_MISMATCH=false
+        UNICORN_MISMATCH=false
+        UPSTREAM_BEHIND=false
+
         if [[ "$PEPR_VERSION" != "$IRONBANK_IMAGE_VERSION" ]]; then
           echo "ERROR: package.json version ($PEPR_VERSION) does not match Ironbank image version ($IRONBANK_IMAGE_VERSION)"
-          VERSIONS_MATCH=false
+          # Check if package.json version is less than image version (upstream is behind)
+          if printf '%s\n' "$PEPR_VERSION" "$IRONBANK_IMAGE_VERSION" | sort -V | head -n1 | grep -q "^$PEPR_VERSION$" && [[ "$PEPR_VERSION" != "$IRONBANK_IMAGE_VERSION" ]]; then
+            UPSTREAM_BEHIND=true
+          else
+            IRONBANK_MISMATCH=true
+          fi
         fi
 
         if [[ "$PEPR_VERSION" != "$UNICORN_IMAGE_VERSION" ]]; then
           echo "ERROR: package.json version ($PEPR_VERSION) does not match Unicorn image version ($UNICORN_IMAGE_VERSION)"
-          VERSIONS_MATCH=false
+          # Check if package.json version is less than image version (upstream is behind)
+          if printf '%s\n' "$PEPR_VERSION" "$UNICORN_IMAGE_VERSION" | sort -V | head -n1 | grep -q "^$PEPR_VERSION$" && [[ "$PEPR_VERSION" != "$UNICORN_IMAGE_VERSION" ]]; then
+            UPSTREAM_BEHIND=true
+          else
+            UNICORN_MISMATCH=true
+          fi
         fi
 
-        if [[ "$IRONBANK_IMAGE_VERSION" != "$UNICORN_IMAGE_VERSION" ]]; then
-          echo "ERROR: Ironbank image version ($IRONBANK_IMAGE_VERSION) does not match Unicorn image version ($UNICORN_IMAGE_VERSION)"
-          VERSIONS_MATCH=false
-        fi
-
-        # Apply labels based on version sync status
-        if [[ "$VERSIONS_MATCH" == "false" ]]; then
-          echo "Versions are not in sync. Waiting on image updates."
+        # Apply labels and exit if any mismatch
+        if [[ "$UPSTREAM_BEHIND" == "true" ]] || [[ "$IRONBANK_MISMATCH" == "true" ]] || [[ "$UNICORN_MISMATCH" == "true" ]]; then
+          echo "Pepr versions are not in sync. Waiting on updates."
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "needs-review" || true
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "waiting on ironbank"
+
+          if [[ "$UPSTREAM_BEHIND" == "true" ]]; then
+            echo "Upstream package.json is behind image versions - possible Pepr release issue"
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "waiting on upstream"
+            gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on ironbank" || true
+            gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on unicorn" || true
+          else
+            gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on upstream" || true
+
+            if [[ "$IRONBANK_MISMATCH" == "true" ]]; then
+              gh pr edit ${{ github.event.pull_request.number }} --add-label "waiting on ironbank"
+            else
+              gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on ironbank" || true
+            fi
+
+            if [[ "$UNICORN_MISMATCH" == "true" ]]; then
+              gh pr edit ${{ github.event.pull_request.number }} --add-label "waiting on unicorn"
+            else
+              gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on unicorn" || true
+            fi
+          fi
+
           exit 1
         else
-          echo "Versions are in sync. Ready for review."
+          echo "All Pepr versions are in sync. Ready for review."
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on upstream" || true
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on ironbank" || true
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on unicorn" || true
           gh pr edit ${{ github.event.pull_request.number }} --add-label "needs-review"
         fi
 
@@ -220,7 +251,7 @@ runs:
           echo "Current labels: $CURRENT_LABELS"
 
           # Define the managed labels we care about
-          MANAGED_LABELS=("waiting on ironbank" "waiting on rapidfort" "needs-review" "helm-chart-only" "major-helm-update" "major-image-update")
+          MANAGED_LABELS=("waiting on upstream" "waiting on ironbank" "waiting on unicorn" "waiting on rapidfort" "needs-review" "helm-chart-only" "major-helm-update" "major-image-update")
 
           # Remove labels that are currently on the PR but not in the new set
           for LABEL in "${MANAGED_LABELS[@]}"; do

--- a/.github/actions/renovate-readiness/action.yaml
+++ b/.github/actions/renovate-readiness/action.yaml
@@ -82,14 +82,35 @@ runs:
         IRONBANK_IMAGE_VERSION=${IRONBANK_IMAGE_VERSION#v}
         echo "Ironbank image version: $IRONBANK_IMAGE_VERSION"
 
-        # Compare versions
+        UNICORN_IMAGE_VERSION=$(yq e '.variables[] | select(.name == "UNICORN_PEPR_IMAGE") | .default | split(":")[1]' tasks/create.yaml)
+        UNICORN_IMAGE_VERSION=${UNICORN_IMAGE_VERSION#v}
+        echo "Unicorn image version: $UNICORN_IMAGE_VERSION"
+
+        # Check if all three versions are in sync
+        VERSIONS_MATCH=true
         if [[ "$PEPR_VERSION" != "$IRONBANK_IMAGE_VERSION" ]]; then
-          echo "Pepr version mismatch. Waiting on Ironbank image update."
+          echo "ERROR: package.json version ($PEPR_VERSION) does not match Ironbank image version ($IRONBANK_IMAGE_VERSION)"
+          VERSIONS_MATCH=false
+        fi
+
+        if [[ "$PEPR_VERSION" != "$UNICORN_IMAGE_VERSION" ]]; then
+          echo "ERROR: package.json version ($PEPR_VERSION) does not match Unicorn image version ($UNICORN_IMAGE_VERSION)"
+          VERSIONS_MATCH=false
+        fi
+
+        if [[ "$IRONBANK_IMAGE_VERSION" != "$UNICORN_IMAGE_VERSION" ]]; then
+          echo "ERROR: Ironbank image version ($IRONBANK_IMAGE_VERSION) does not match Unicorn image version ($UNICORN_IMAGE_VERSION)"
+          VERSIONS_MATCH=false
+        fi
+
+        # Apply labels based on version sync status
+        if [[ "$VERSIONS_MATCH" == "false" ]]; then
+          echo "Versions are not in sync. Waiting on image updates."
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "needs-review" || true
           gh pr edit ${{ github.event.pull_request.number }} --add-label "waiting on ironbank"
           exit 1
         else
-          echo "Pepr versions match. Ready for review."
+          echo "Versions are in sync. Ready for review."
           gh pr edit ${{ github.event.pull_request.number }} --remove-label "waiting on ironbank" || true
           gh pr edit ${{ github.event.pull_request.number }} --add-label "needs-review"
         fi


### PR DESCRIPTION
## Description
The current implementation only checks the REGISTRY1_PEPR_IMAGE version against package.json, only validates that registry1 matches package.json, but doesn't check if unicorn is also in sync.

I've updated the Pepr version checking logic in the renovate readiness action to validate that all three Pepr versions are in sync.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed