### PR TITLE
fix: add retries to all network tests

### DIFF
--- a/test/vitest/network.spec.ts
+++ b/test/vitest/network.spec.ts
@@ -161,7 +161,7 @@ beforeAll(async () => {
   }
 });
 
-describe("Network Policy Validation", () => {
+describe("Network Policy Validation", { retry: 2 }, () => {
   const INTERNAL_CURL_COMMAND_1 = getCurlCommand("curl-pkg-deny-all-2", "curl-ns-deny-all-2");
   const INTERNAL_CURL_COMMAND_2 = getCurlCommand("curl-pkg-allow-all", "curl-ns-allow-all");
   const INTERNAL_CURL_COMMAND_5 = getCurlCommand(
@@ -174,11 +174,7 @@ describe("Network Policy Validation", () => {
     "curl",
     "-s",
     "-m",
-    "20",
-    "--retry",
-    "3",
-    "--retry-delay",
-    "1",
+    "10",
     "-o",
     "/dev/null",
     "-w",


### PR DESCRIPTION
## Description
remove the network tests google curl's retries and bump the curl timeout down to 10 second. Add 2 retry attempts to all tests.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed