### PR TITLE
chore: bumb version references

### DIFF
--- a/docs/reference/configuration/service-mesh/ingress.md
+++ b/docs/reference/configuration/service-mesh/ingress.md
@@ -33,7 +33,7 @@ metadata:
 packages:
   - name: core
     repository: oci://ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.23.0-upstream
+    ref: 0.54.1-upstream
     # You must specify the istio-passthrough-gateway as an optionalComponent or else it will not be deployed
     optionalComponents:
       - istio-passthrough-gateway
@@ -55,7 +55,7 @@ metadata:
 packages:
   - name: core
     repository: oci://ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.23.0-upstream
+    ref: 0.54.1-upstream
     overrides:
       istio-admin-gateway:
         uds-istio-config:
@@ -124,7 +124,7 @@ metadata:
 packages:
   - name: core
     repository: oci://ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.23.0-upstream
+    ref: 0.54.1-upstream
     overrides:
       istio-admin-gateway:
         uds-istio-config:
@@ -150,7 +150,7 @@ If you want your application to be reachable at `https://uds.dev`, enable root (
 ```yaml
   - name: core
     repository: oci://ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.23.0-upstream
+    ref: 0.54.1-upstream
     overrides:
       istio-tenant-gateway:
         uds-istio-config:

--- a/docs/reference/deployment/upgrades.md
+++ b/docs/reference/deployment/upgrades.md
@@ -83,16 +83,16 @@ Typically the actual version update is as easy as updating your version referenc
 packages:
   - name: core
     repository: ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.9.0-upstream
+    ref: 0.53.1-upstream
 ```
 
-Upgrading to 0.10.0 would be as easy as updating this to:
+Upgrading to 0.54.1 would be as easy as updating this to:
 
 ```yaml
 packages:
   - name: core
     repository: ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.10.0-upstream
+    ref: 0.54.1-upstream
 ```
 
 Try to avoid other concurrent package upgrades (e.g., zarf init or other UDS packages) or larger changes, such as switching between flavors, unless you have restrictive maintenance windows. Where possible, it is often better to perform these upgrades independently to simplify troubleshooting if issues occur.

--- a/docs/reference/uds-core/dns.md
+++ b/docs/reference/uds-core/dns.md
@@ -36,7 +36,7 @@ metadata:
 packages:
   - name: core
     repository: oci://ghcr.io/defenseunicorns/packages/uds/core
-    ref: 0.27.0-upstream
+    ref: 0.54.1-upstream
 
 overrides:
  istio-admin-gateway:

--- a/docs/reference/uds-core/functional-layers.md
+++ b/docs/reference/uds-core/functional-layers.md
@@ -26,25 +26,25 @@ metadata:
 packages:
   - name: core-base
     repository: ghcr.io/defenseunicorns/packages/uds/core-base
-    ref: 0.29.0-upstream
+    ref: 0.54.1-upstream
   - name: core-identity-authorization
     repository: ghcr.io/defenseunicorns/packages/uds/core-identity-authorization
-    ref: 0.29.0-upstream
+    ref: 0.54.1-upstream
   - name: core-metrics-server
     repository: ghcr.io/defenseunicorns/packages/uds/core-metrics-server
-    ref: 0.29.0-upstream
+    ref: 0.54.1-upstream
   - name: core-runtime-security
     repository: ghcr.io/defenseunicorns/packages/uds/core-runtime-security
-    ref: 0.29.0-upstream
+    ref: 0.54.1-upstream
   - name: core-logging
     repository: ghcr.io/defenseunicorns/packages/uds/core-logging
-    ref: 0.29.0-upstream
+    ref: 0.54.1-upstream
   - name: core-monitoring
     repository: ghcr.io/defenseunicorns/packages/uds/core-monitoring
-    ref: 0.29.0-upstream
+    ref: 0.54.1-upstream
   - name: core-backup-restore
     repository: ghcr.io/defenseunicorns/packages/uds/core-backup-restore
-    ref: 0.29.0-upstream
+    ref: 0.54.1-upstream
 ```
 
 ## Layer Selection

--- a/docs/reference/uds-core/prerequisites.md
+++ b/docs/reference/uds-core/prerequisites.md
@@ -196,7 +196,7 @@ Metrics server is provided as an optional component in UDS Core and can be enabl
 ```yaml
 - name: uds-core
   repository: ghcr.io/defenseunicorns/packages/private/uds/core
-  ref: 0.25.2-unicorn
+  ref: 0.54.1-unicorn
   optionalComponents:
     - metrics-server
 ```


### PR DESCRIPTION
## Description

I noticed various version references what were very out of date, this just updates those versions.

It'd be nice to be able to use `x-release-please...` but I didn't find an obvious way to include those annotations and keep them excluded from the published documentation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed