### PR TITLE
chore: make private-pki task macos compatible

### DIFF
--- a/.github/workflows/private-pki-test.yaml
+++ b/.github/workflows/private-pki-test.yaml
@@ -14,7 +14,7 @@ on:
     paths:
       - ".github/workflows/private-pki-test.yaml"
       - "bundles/k3d-standard/**"
-      - "test/private-pki/**"
+      - "test/playwright/private-pki/**"
 
 permissions:
   contents: read

--- a/.github/workflows/private-pki-test.yaml
+++ b/.github/workflows/private-pki-test.yaml
@@ -14,6 +14,7 @@ on:
     paths:
       - ".github/workflows/private-pki-test.yaml"
       - "bundles/k3d-standard/**"
+      - "test/private-pki/**"
 
 permissions:
   contents: read

--- a/src/grafana/tasks.yaml
+++ b/src/grafana/tasks.yaml
@@ -16,24 +16,17 @@ tasks:
             condition: Ready
       - description: Validate grafana virtual service
         cmd: |
-          # Note: this check forces to use /usr/bin/curl if it exists
-          # This is to force using the system curl on macos which is needed for our private-pki tests
-          CURL_CMD="/usr/bin/curl"
-          if [ ! -x "$CURL_CMD" ]; then
-            CURL_CMD="curl"
-          fi
-
-          if [ "$($CURL_CMD -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}')" = "302" ]; then
+          if [ "$(curl -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}')" = "302" ]; then
             echo "Grafana is up and running."
           else
-            echo "ERROR: Grafana returned a $($CURL_CMD -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}') code."
+            echo "ERROR: Grafana returned a $(curl -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}') code."
             exit 1
           fi
 
-          if $CURL_CMD -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}' | grep "sso.uds.dev" 2>&1 1>/dev/null; then
+          if curl -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}' | grep "sso.uds.dev" 2>&1 1>/dev/null; then
             echo "Grafana is redirecting to SSO as expected."
           else
-            echo "ERROR: Grafana is redirecting to $($CURL_CMD -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}')."
+            echo "ERROR: Grafana is redirecting to $(curl -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}')."
             exit 1
           fi
 

--- a/src/grafana/tasks.yaml
+++ b/src/grafana/tasks.yaml
@@ -16,17 +16,24 @@ tasks:
             condition: Ready
       - description: Validate grafana virtual service
         cmd: |
-          if [ "$(curl -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}')" = "302" ]; then
+          # Note: this check forces to use /usr/bin/curl if it exists
+          # This is to force using the system curl on macos which is needed for our private-pki tests
+          CURL_CMD="/usr/bin/curl"
+          if [ ! -x "$CURL_CMD" ]; then
+            CURL_CMD="curl"
+          fi
+
+          if [ "$($CURL_CMD -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}')" = "302" ]; then
             echo "Grafana is up and running."
           else
-            echo "ERROR: Grafana returned a $(curl -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}') code."
+            echo "ERROR: Grafana returned a $($CURL_CMD -isS https://grafana.admin.uds.dev --output /dev/null -w '%{http_code}') code."
             exit 1
           fi
 
-          if curl -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}' | grep "sso.uds.dev" 2>&1 1>/dev/null; then
+          if $CURL_CMD -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}' | grep "sso.uds.dev" 2>&1 1>/dev/null; then
             echo "Grafana is redirecting to SSO as expected."
           else
-            echo "ERROR: Grafana is redirecting to $(curl -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}')."
+            echo "ERROR: Grafana is redirecting to $($CURL_CMD -L -isS https://grafana.admin.uds.dev --output /dev/null -w '%{url_effective}')."
             exit 1
           fi
 

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -249,8 +249,3 @@ tasks:
           uds zarf tools kubectl label namespace authservice-ambient-test-app zarf.dev/agent=ignore
           uds zarf tools kubectl apply -f src/test/app-ambient-authservice-tenant.yaml
       - task: private-pki:private-pki-tests
-      - description: "Follow on Instructions"
-        cmd: |
-          echo ""
-          echo "Load the build/private-pki/ca.crt into your browser if you want to use the Grafana, Keycloak, or httpbin UIs."
-          echo ""

--- a/test/playwright/private-pki/private-pki.test.ts
+++ b/test/playwright/private-pki/private-pki.test.ts
@@ -5,7 +5,7 @@
 
 import { expect, test } from "@playwright/test";
 
-test.describe("Grafana SSO with Private PKI", () => {
+test.describe("Private PKI tests", () => {
   test("Grafana SSO authentication flow", async ({ page }) => {
     // Step 1: Navigate to Grafana which should redirect to Keycloak
     await page.goto(`https://grafana.admin.uds.dev`);

--- a/test/playwright/private-pki/tasks.yaml
+++ b/test/playwright/private-pki/tasks.yaml
@@ -76,6 +76,8 @@ tasks:
 
   - name: private-pki-tests
     description: "Run Private PKI Tests"
+    # Note: if you have curl installed with hombebrew on macOS, you may need to explicitly trust the CA Cert generated. You can do so by running the following command before running the tests:
+    # export CURL_CA_BUNDLE=path/to/uds-core/build/private-pki/ca.crt
     actions:
       - description: "Move Cert to Testing directory"
         cmd: cp build/private-pki/ca.crt test/playwright/private-pki

--- a/test/playwright/private-pki/tasks.yaml
+++ b/test/playwright/private-pki/tasks.yaml
@@ -44,16 +44,20 @@ tasks:
               -days 365 -sha256 -extensions v3_req -extfile hack/private-pki/openssl.cnf
 
             # Base64 encode
-            base64 -w 0 build/private-pki/${gateway}-gateway.crt > build/private-pki/${gateway}-gateway.crt.b64
-            base64 -w 0 build/private-pki/${gateway}-gateway.key > build/private-pki/${gateway}-gateway.key.b64
+            base64 < build/private-pki/${gateway}-gateway.crt | tr -d '\n' > build/private-pki/${gateway}-gateway.crt.b64
+            base64 < build/private-pki/${gateway}-gateway.key | tr -d '\n' > build/private-pki/${gateway}-gateway.key.b64
           done
 
           # Base64 encode CA
-          base64 -w 0 build/private-pki/ca.crt > build/private-pki/ca.crt.b64
+          base64 < build/private-pki/ca.crt | tr -d '\n' > build/private-pki/ca.crt.b64
 
           # Add CA to system trust store
-          sudo cp build/private-pki/ca.crt /usr/local/share/ca-certificates/uds-test-ca.crt
-          sudo update-ca-certificates
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain build/private-pki/ca.crt
+          else
+            sudo cp build/private-pki/ca.crt /usr/local/share/ca-certificates/uds-test-ca.crt
+            sudo update-ca-certificates
+          fi
 
           # Configure UDS with certificates
           cp bundles/k3d-standard/uds-private-pki-config.yaml build/private-pki/uds-private-pki-config.yaml

--- a/test/playwright/private-pki/tasks.yaml
+++ b/test/playwright/private-pki/tasks.yaml
@@ -16,9 +16,16 @@ tasks:
           mkdir -p build/private-pki
 
           # remove existing local private pki certs
-          if [ -f /usr/local/share/ca-certificates/uds-test-ca.crt ]; then
-            sudo rm /usr/local/share/ca-certificates/uds-test-ca.crt
-            sudo update-ca-certificates --fresh
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            # Remove from macOS keychain
+            for HASH in $(sudo security find-certificate -c "UDS Test CA" -a -Z /Library/Keychains/System.keychain 2>/dev/null | awk '/SHA-1/{print $3}'); do
+              sudo security delete-certificate -Z "$HASH" /Library/Keychains/System.keychain
+            done
+          else
+            if [ -f /usr/local/share/ca-certificates/uds-test-ca.crt ]; then
+              sudo rm /usr/local/share/ca-certificates/uds-test-ca.crt
+              sudo update-ca-certificates --fresh
+            fi
           fi
 
           # Generate CA key and certificate
@@ -51,7 +58,7 @@ tasks:
           # Base64 encode CA
           base64 < build/private-pki/ca.crt | tr -d '\n' > build/private-pki/ca.crt.b64
 
-          # Add CA to system trust store
+          # Add CA to trust store
           if [[ "$OSTYPE" == "darwin"* ]]; then
             sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain build/private-pki/ca.crt
           else


### PR DESCRIPTION
## Description

This updates the private-pki task macos compatible.  Two things to call out:
* base64 on mac has different flags/syntax (no `-w` flag and requires `-i`) for input
* macos has a different way to trust CAs (keychain)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- run `uds run -f tasks/test.yaml uds-core-private-pki` on macos

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed