### PR TITLE
fix: install test apps preupgrade and validate

### DIFF
--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -37,11 +37,11 @@ tasks:
     actions:
       - description: "Run Network Tests"
         cmd: |
-          npm ci && EGRESS_TESTS=${{ .inputs.validate_egress }} npx vitest run "network.spec.ts"
+          EGRESS_TESTS=${{ .inputs.validate_egress }} npx vitest run "network.spec.ts"
         dir: test/vitest
       - description: "Run Test Resources Tests"
         cmd: |
-          npm ci && npx vitest run "test-resources.spec.ts"
+          npx vitest run "test-resources.spec.ts"
         dir: test/vitest
       - description: "Run Ambient Playwright Test"
         cmd: |
@@ -54,7 +54,7 @@ tasks:
         dir: test/playwright
       - description: "Run Secret Reload Tests"
         cmd: |
-          npm ci && npx vitest run "pod-reload.spec.ts"
+          npx vitest run "pod-reload.spec.ts"
         dir: test/vitest
 
   - name: create-deploy

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -35,17 +35,13 @@ tasks:
         default: "true"
 
     actions:
-      - description: "Install test dependencies"
-        cmd: |
-          npm ci
-        dir: test/vitest
       - description: "Run Network Tests"
         cmd: |
-          EGRESS_TESTS=${{ .inputs.validate_egress }} npx vitest run "network.spec.ts"
+          npm ci && EGRESS_TESTS=${{ .inputs.validate_egress }} npx vitest run "network.spec.ts"
         dir: test/vitest
       - description: "Run Test Resources Tests"
         cmd: |
-          npx vitest run "test-resources.spec.ts"
+          npm ci && npx vitest run "test-resources.spec.ts"
         dir: test/vitest
       - description: "Run Ambient Playwright Test"
         cmd: |
@@ -58,7 +54,7 @@ tasks:
         dir: test/playwright
       - description: "Run Secret Reload Tests"
         cmd: |
-          npx vitest run "pod-reload.spec.ts"
+          npm ci && npx vitest run "pod-reload.spec.ts"
         dir: test/vitest
 
   - name: create-deploy

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -22,19 +22,6 @@ tasks:
         task: create-deploy
         with:
           validate_egress: ${{ .inputs.validate_egress }}
-      - task: tests
-        with:
-          validate_egress: ${{ .inputs.validate_egress }}
-      - description: "Remove Test Apps resources"
-        task: remove
-
-  - name: tests
-    inputs:
-      validate_egress:
-        description: Whether to validate egress controls with the egress gateway
-        default: "true"
-
-    actions:
       - description: "Run Network Tests"
         cmd: |
           EGRESS_TESTS=${{ .inputs.validate_egress }} npx vitest run "network.spec.ts"
@@ -43,6 +30,10 @@ tasks:
         cmd: |
           npx vitest run "test-resources.spec.ts"
         dir: test/vitest
+      - description: "Setup the Doug User for testing"
+        task: uds-common:keycloak-user
+        with:
+          group: "/UDS Core/Admin"
       - description: "Run Ambient Playwright Test"
         cmd: |
           # renovate: datasource=docker depName=mcr.microsoft.com/playwright versioning=docker
@@ -56,6 +47,8 @@ tasks:
         cmd: |
           npx vitest run "pod-reload.spec.ts"
         dir: test/vitest
+      - description: "Remove Test Apps resources"
+        task: remove
 
   - name: create-deploy
     description: Test app used for UDS Core validation
@@ -81,11 +74,6 @@ tasks:
       - description: Deploy the test resources
         if: ${{ eq .inputs.validate_egress "false" }}
         cmd: "uds zarf package deploy build/zarf-package-uds-core-test-apps-*.zst --confirm --no-progress"
-
-      - description: "Setup the Doug User for testing"
-        task: uds-common:keycloak-user
-        with:
-          group: "/UDS Core/Admin"
 
       - description: Verify the admin app is accessible
         wait:

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -23,6 +23,8 @@ tasks:
         with:
           validate_egress: ${{ .inputs.validate_egress }}
       - task: tests
+        with:
+          validate_egress: ${{ .inputs.validate_egress }}
       - description: "Remove Test Apps resources"
         task: remove
 

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -35,6 +35,10 @@ tasks:
         default: "true"
 
     actions:
+      - description: "Install test dependencies"
+        cmd: |
+          npm ci
+        dir: test/vitest
       - description: "Run Network Tests"
         cmd: |
           EGRESS_TESTS=${{ .inputs.validate_egress }} npx vitest run "network.spec.ts"

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -22,6 +22,17 @@ tasks:
         task: create-deploy
         with:
           validate_egress: ${{ .inputs.validate_egress }}
+      - task: tests
+      - description: "Remove Test Apps resources"
+        task: remove
+
+  - name: tests
+    inputs:
+      validate_egress:
+        description: Whether to validate egress controls with the egress gateway
+        default: "true"
+
+    actions:
       - description: "Run Network Tests"
         cmd: |
           EGRESS_TESTS=${{ .inputs.validate_egress }} npx vitest run "network.spec.ts"
@@ -30,10 +41,6 @@ tasks:
         cmd: |
           npx vitest run "test-resources.spec.ts"
         dir: test/vitest
-      - description: "Setup the Doug User for testing"
-        task: uds-common:keycloak-user
-        with:
-          group: "/UDS Core/Admin"
       - description: "Run Ambient Playwright Test"
         cmd: |
           # renovate: datasource=docker depName=mcr.microsoft.com/playwright versioning=docker
@@ -47,8 +54,6 @@ tasks:
         cmd: |
           npx vitest run "pod-reload.spec.ts"
         dir: test/vitest
-      - description: "Remove Test Apps resources"
-        task: remove
 
   - name: create-deploy
     description: Test app used for UDS Core validation
@@ -74,6 +79,11 @@ tasks:
       - description: Deploy the test resources
         if: ${{ eq .inputs.validate_egress "false" }}
         cmd: "uds zarf package deploy build/zarf-package-uds-core-test-apps-*.zst --confirm --no-progress"
+
+      - description: "Setup the Doug User for testing"
+        task: uds-common:keycloak-user
+        with:
+          group: "/UDS Core/Admin"
 
       - description: Verify the admin app is accessible
         wait:

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -119,18 +119,29 @@ tasks:
       - description: "Clean up temporary files"
         cmd: rm -rf tmp/core-shim
 
-  - name: main-branch-test-resources
+  - name: latest-release-test-resources
     actions:
-      - description: "Get uds-core main branch for test resources"
+      - task: utils:determine-repo
+      - description: "Get latest tag version from OCI for aligning test resources"
+        cmd: uds zarf tools registry ls ${TARGET_REPO}/core | grep ${FLAVOR} | sort -V | tail -1
+        setVariables:
+          - name: LATEST_VERSION
+      - description: "Extract unflavored version for git tag"
+        cmd: echo ${LATEST_VERSION} | cut -d'-' -f1 # Extract version before any hyphen (e.g., "0.52.0" from "0.52.0-upstream")
+        setVariables:
+          - name: LATEST_CORE_TAG
+      - description: "Fetch src/test from tagged release"
         cmd: |
           # Create temp directory
           mkdir -p tmp/test-shim
 
-          #Download Main branch
-          curl -sSL https://codeload.github.com/defenseunicorns/uds-core/tar.gz/refs/heads/main | tar -xz -C tmp/test-shim
-      - description: "Deploy Main Branch Test Resources"
+          # Clone only the src/test directory
+          git clone --depth 1 --filter=blob:none --sparse --branch v${LATEST_CORE_TAG} https://github.com/defenseunicorns/uds-core.git tmp/test-shim/uds-core
+          cd tmp/test-shim/uds-core
+          git sparse-checkout set src/test tasks
+      - description: "Deploy Latest Release Test Resources"
         cmd: uds run -f src/test/tasks.yaml create-deploy
-        dir: tmp/test-shim/uds-core-main/
+        dir: tmp/test-shim/uds-core/
       - description: "Clean up temporary files"
         cmd: rm -rf tmp/test-shim
 

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -119,6 +119,21 @@ tasks:
       - description: "Clean up temporary files"
         cmd: rm -rf tmp/core-shim
 
+  - name: main-branch-test-resources
+    actions:
+      - description: "Get uds-core main branch for test resources"
+        cmd: |
+          # Create temp directory
+          mkdir -p tmp/test-shim
+
+          #Download Main branch
+          curl -sSL https://codeload.github.com/defenseunicorns/uds-core/tar.gz/refs/heads/main | tar -xz -C tmp/test-shim
+      - description: "Deploy Main Branch Test Resources"
+        cmd: uds run -f src/test/tasks.yaml create-deploy
+        dir: tmp/test-shim/uds-core-main/
+      - description: "Clean up temporary files"
+        cmd: rm -rf tmp/test-shim
+
   - name: latest-slim-bundle-release
     actions:
       - description: "Deploy the latest UDS Core package release"

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -98,6 +98,10 @@ tasks:
         default: ${UDS_ARCH}
     # Run each e2e test type from the e2e folder
     actions:
+      - description: "Setup the Doug User for testing"
+        task: common-setup:keycloak-user
+        with:
+          group: "/UDS Core/Admin"
       - description: "Create and Deploy Test App Package"
         task: test-resources:create-deploy
         with:
@@ -180,24 +184,12 @@ tasks:
     inputs:
       configFile:
         description: "UDS_CONFIG file to use for the deployments"
-      architecture:
-        description: "System architecture that the test-apps package should be built for."
-        required: true
-        default: ${UDS_ARCH}
     description: "Test an upgrade from the latest released UDS Core package to current branch"
     actions:
       - task: deploy:latest-bundle-release
         with:
           configFile: ${{ .inputs.configFile }}
-      - task: test-resources:create-deploy
-        with:
-          validate_egress: "true"
-          architecture: ${{ .inputs.architecture }}
-      - description: "Install Node deps for tests (pre-upgrade)"
-        cmd: npm ci
-      - task: test-resources:tests
-        with:
-          validate_egress: "true"
+      - task: deploy:main-branch-test-resources
       - task: create:standard-package
         with:
           create_options: "--skip-sbom"
@@ -208,12 +200,7 @@ tasks:
           export UDS_CONFIG="${{ .inputs.configFile }}"
           uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set FALCO_SANDBOX_RULES_ENABLED=true --set FALCO_INCUBATING_RULES_ENABLED=true --packages core --confirm --no-progress
       - task: validate-packages
-      - description: "Install Node deps for tests (post-upgrade)"
-        cmd: npm ci
-      - task: test-resources:tests
-        with:
-          validate_egress: "true"
-      - task: test-resources:remove
+      - task: e2e-tests
 
   - name: compliance-validate
     description: "validate against the required compliance"
@@ -263,8 +250,3 @@ tasks:
           uds zarf tools kubectl label namespace authservice-ambient-test-app zarf.dev/agent=ignore
           uds zarf tools kubectl apply -f src/test/app-ambient-authservice-tenant.yaml
       - task: private-pki:private-pki-tests
-      - description: "Follow on Instructions"
-        cmd: |
-          echo ""
-          echo "Load the build/private-pki/ca.crt into your browser if you want to use the Grafana, Keycloak, or httpbin UIs."
-          echo ""

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -193,6 +193,8 @@ tasks:
         with:
           validate_egress: "true"
           architecture: ${{ .inputs.architecture }}
+      - description: "Install Node deps for tests (pre-upgrade)"
+        cmd: npm ci
       - task: test-resources:tests
         with:
           validate_egress: "true"
@@ -206,6 +208,8 @@ tasks:
           export UDS_CONFIG="${{ .inputs.configFile }}"
           uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set FALCO_SANDBOX_RULES_ENABLED=true --set FALCO_INCUBATING_RULES_ENABLED=true --packages core --confirm --no-progress
       - task: validate-packages
+      - description: "Install Node deps for tests (post-upgrade)"
+        cmd: npm ci
       - task: test-resources:tests
         with:
           validate_egress: "true"

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -180,6 +180,10 @@ tasks:
     inputs:
       configFile:
         description: "UDS_CONFIG file to use for the deployments"
+      architecture:
+        description: "System architecture that the test-apps package should be built for."
+        required: true
+        default: ${UDS_ARCH}
     description: "Test an upgrade from the latest released UDS Core package to current branch"
     actions:
       - task: deploy:latest-bundle-release
@@ -188,7 +192,10 @@ tasks:
       - task: test-resources:create-deploy
         with:
           validate_egress: "true"
+          architecture: ${{ .inputs.architecture }}
       - task: test-resources:tests
+        with:
+          validate_egress: "true"
       - task: create:standard-package
         with:
           create_options: "--skip-sbom"

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -98,10 +98,6 @@ tasks:
         default: ${UDS_ARCH}
     # Run each e2e test type from the e2e folder
     actions:
-      - description: "Setup the Doug User for testing"
-        task: common-setup:keycloak-user
-        with:
-          group: "/UDS Core/Admin"
       - description: "Create and Deploy Test App Package"
         task: test-resources:create-deploy
         with:
@@ -189,6 +185,10 @@ tasks:
       - task: deploy:latest-bundle-release
         with:
           configFile: ${{ .inputs.configFile }}
+      - task: test-resources:create-deploy
+        with:
+          validate_egress: "true"
+      - task: test-resources:tests
       - task: create:standard-package
         with:
           create_options: "--skip-sbom"
@@ -199,7 +199,10 @@ tasks:
           export UDS_CONFIG="${{ .inputs.configFile }}"
           uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set FALCO_SANDBOX_RULES_ENABLED=true --set FALCO_INCUBATING_RULES_ENABLED=true --packages core --confirm --no-progress
       - task: validate-packages
-      - task: e2e-tests
+      - task: test-resources:tests
+        with:
+          validate_egress: "true"
+      - task: test-resources:remove
 
   - name: compliance-validate
     description: "validate against the required compliance"

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -189,7 +189,7 @@ tasks:
       - task: deploy:latest-bundle-release
         with:
           configFile: ${{ .inputs.configFile }}
-      - task: deploy:main-branch-test-resources
+      - task: deploy:latest-release-test-resources
       - task: create:standard-package
         with:
           create_options: "--skip-sbom"


### PR DESCRIPTION
## Description

Previously we had a gap in our upgrade testing that meant we never actually tested a mission application being upgraded from one version of uds-core to the next in CI. This PR reworks the upgrade testing to make sure this is done.

### New Flow of the upgrade tests

1. install latest release uds-core
2. install latest release test-resources
3. build and deploy (upgrade) current branch
4. validate everything
5. e2e-tests (which is technically an upgrade of the test-resources and all the existing tests)

## Related Issue

Fixes #1995 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed