### PR TITLE
chore(ci): remove iptables from save-logs

### DIFF
--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -29,18 +29,6 @@ runs:
         fi
       shell: bash
 
-    - name: Pull iptables rules (network policies)
-      if: ${{ inputs.distro == 'k3d' }}
-      run: |
-        CONTAINER_NAME="k3d-uds-server-0"
-        if docker ps | grep -q "$CONTAINER_NAME"; then
-          echo "Container $CONTAINER_NAME is running. Proceeding with iptables-save..."
-          docker exec -i ${CONTAINER_NAME} iptables-save > /tmp/uds-iptables.log
-        else
-          echo "Container $CONTAINER_NAME is not running. Skipping iptables-save."
-        fi
-      shell: bash
-
     - name: Dump Node Logs
       if: ${{ inputs.distro == 'k3d' }}
       run: |


### PR DESCRIPTION
## Description

This step has been flaky and of little/no value recently. It was primarily added for debugging a specific netpol issue ~4 months ago (see [here](https://github.com/defenseunicorns/uds-core/commit/e28aca52ba49a2bd6bbf8909e02feaee0fad59da)).