### PR TITLE
chore(docs): add doc warning around remoteHost egress

### DIFF
--- a/docs/reference/configuration/service-mesh/egress.md
+++ b/docs/reference/configuration/service-mesh/egress.md
@@ -87,6 +87,14 @@ Currently, only HTTP and TLS protocols are supported. The configuration will def
 Wildcards in host names are NOT currently supported.
 :::
 
+:::caution
+Adding any `remoteHost` egress creates/uses a shared L7 waypoint in ambient. This can change egress for other namespaces and break L4-only allowances (e.g., `remoteGenerated: Anywhere`), sometimes causing TLS failures. This behavior is by design in Istio ambient today.
+
+Recommendations:
+- Prefer explicit `remoteHost` entries for required external hosts (even with broad L4 egress).
+- Re‑verify critical egress after adding `remoteHost` in any namespace.
+:::
+
 ### Ambient Mode
 
 The following sample Package CR shows configuring egress to a specific host, "httpbin.org", on port 443.


### PR DESCRIPTION
## Description

noting that adding any remoteHost egress in ambient uses a shared L7 waypoint, which can change egress for other namespaces and break L4-only allowances (e.g., remoteGenerated: Anywhere). This is expected Istio behavior.

## Related Issue

Fixes #2072

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed