### PR TITLE
chore: fix test task to check authservice protection

### DIFF
--- a/.github/workflows/private-pki-test.yaml
+++ b/.github/workflows/private-pki-test.yaml
@@ -16,6 +16,7 @@ on:
       - "bundles/k3d-standard/**"
       - "test/playwright/private-pki/**"
 
+
 permissions:
   contents: read
   id-token: write

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -153,12 +153,23 @@ tasks:
             address: ${{ .inputs.address }}
             code: 200
 
-      - description: Verify the service at ${{ .inputs.address }} is protected by checking redirect
+      - description: Get tenant gateway IP
         maxRetries: 3
         task: utils:tenant-gw-ip
+
+      - description: Verify the service at ${{ .inputs.address }} is protected by checking redirect
+        maxRetries: 3
         cmd: |
           set -e
-          SSO_REDIRECT=$(uds zarf tools kubectl run curl-test --image=cgr.dev/chainguard/curl:latest -q --restart=Never --rm -i -- --resolve '${{ .inputs.address }}:$TENANT_GW_IP:443' -Ls -o /dev/null -w %{url_effective} "https://${{ .inputs.address }}")
+          # If running locally with k3d, access via the hostname directly
+          if curl --connect-timeout 2 -s "https://${{ .inputs.address }}" >/dev/null 2>&1; then
+            echo "Running in local environment, accessing via hostname"
+            SSO_REDIRECT=$(curl -Ls -o /dev/null -w %{url_effective} "https://${{ .inputs.address }}")
+          # If running in CI or another environment, resolve via tenant gateway IP
+          else
+            echo "Running in CI/remote environment, resolving via tenant gateway IP"
+            SSO_REDIRECT=$(curl --resolve '${{ .inputs.address }}:443:$TENANT_GW_IP' -Ls -o /dev/null -w %{url_effective} "https://${{ .inputs.address }}")
+          fi
 
           case "${SSO_REDIRECT}" in
           "https://sso.uds.dev"*)

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -153,23 +153,11 @@ tasks:
             address: ${{ .inputs.address }}
             code: 200
 
-      - description: Get tenant gateway IP
-        maxRetries: 3
-        task: utils:tenant-gw-ip
-
       - description: Verify the service at ${{ .inputs.address }} is protected by checking redirect
         maxRetries: 3
         cmd: |
           set -e
-          # If running locally with k3d, access via the hostname directly
-          if curl --connect-timeout 2 -s "https://${{ .inputs.address }}" >/dev/null 2>&1; then
-            echo "Running in local environment, accessing via hostname"
-            SSO_REDIRECT=$(curl -Ls -o /dev/null -w %{url_effective} "https://${{ .inputs.address }}")
-          # If running in CI or another environment, resolve via tenant gateway IP
-          else
-            echo "Running in CI/remote environment, resolving via tenant gateway IP"
-            SSO_REDIRECT=$(curl --resolve '${{ .inputs.address }}:443:$TENANT_GW_IP' -Ls -o /dev/null -w %{url_effective} "https://${{ .inputs.address }}")
-          fi
+          SSO_REDIRECT=$(curl -Ls -o /dev/null -w %{url_effective} "https://${{ .inputs.address }}")
 
           case "${SSO_REDIRECT}" in
           "https://sso.uds.dev"*)


### PR DESCRIPTION
## Description

The check authservice protection task in our test zarf package wasn't running because of bad maru schema.  This fixes it.  Updates the task to use curl locally instead of launching pod on cluster. 

## Related Issue

Fixes #2086 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- `uds run`
- `uds run -f tasks/test.yaml uds-core-private-pki`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed