### PR TITLE
fix: prevent network policies from selecting non-authservice SSO clients

### DIFF
--- a/src/pepr/operator/controllers/istio/ambient-waypoint.spec.ts
+++ b/src/pepr/operator/controllers/istio/ambient-waypoint.spec.ts
@@ -126,16 +126,20 @@ vi.mock("./waypoint-utils", async () => {
 });
 
 // Mock the utils module
-vi.mock("../utils", () => ({
-  getOwnerRef: vi.fn().mockReturnValue([
-    {
-      kind: "Package",
-      name: "test-pkg",
-      uid: "test-uid",
-      apiVersion: "uds.dev/v1alpha1",
-    },
-  ]),
-}));
+vi.mock("../utils", async () => {
+  const actual = await vi.importActual("../utils");
+  return {
+    ...actual,
+    getOwnerRef: vi.fn().mockReturnValue([
+      {
+        kind: "Package",
+        name: "test-pkg",
+        uid: "test-uid",
+        apiVersion: "uds.dev/v1alpha1",
+      },
+    ]),
+  };
+});
 
 // Create a mock for the log functions
 const mockLog = vi.hoisted(() => ({

--- a/src/pepr/operator/controllers/keycloak/authservice/authservice.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/authservice.ts
@@ -10,7 +10,7 @@ import { K8sGateway, UDSPackage } from "../../../crd";
 import { AuthserviceClient, Mode } from "../../../crd/generated/package-v1alpha1";
 import { cleanupWaypointLabels, setupAmbientWaypoint } from "../../istio/ambient-waypoint";
 import { getWaypointName } from "../../istio/waypoint-utils";
-import { purgeOrphans } from "../../utils";
+import { getAuthserviceClients, purgeOrphans } from "../../utils";
 import { Client } from "../types";
 import { UDSConfig, updatePolicy } from "./authorization-policy";
 import {
@@ -43,11 +43,8 @@ export async function authservice(
   const previousMeshMode = pkg.status?.meshMode || Mode.Sidecar;
   const isAmbient = istioMode === Mode.Ambient;
 
-  // Get the list of clients from the package
-  const authServiceClients = R.filter(
-    sso => R.isNotNil(sso.enableAuthserviceSelector),
-    pkg.spec?.sso || [],
-  );
+  // Get the list of authservice-enabled clients from the package
+  const authServiceClients = getAuthserviceClients(pkg);
 
   // Build the new client status objects
   const newAuthserviceClients = authServiceClients.map(sso => ({

--- a/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
@@ -1170,7 +1170,7 @@ describe("findMatchingSsoClient", () => {
     expect(findMatchingSsoClient(pkg, { app: "x" })).toMatchObject({ clientId: "c1" });
   });
 
-  test("non-empty SSO selector uses any-label matching semantics", () => {
+  test("non-empty SSO selector uses all-label matching semantics", () => {
     const pkg: UDSPackage = {
       metadata: { name: "app", namespace: "ns" },
       spec: {
@@ -1179,10 +1179,12 @@ describe("findMatchingSsoClient", () => {
       },
     };
 
-    // Matches because 'tier' label matches (any-label semantics)
-    expect(findMatchingSsoClient(pkg, { tier: "prod" })).toMatchObject({ clientId: "c1" });
-    // Does not match when none of the labels match
-    expect(findMatchingSsoClient(pkg, { env: "prod" })).toBeUndefined();
+    // Matches only when all labels match
+    expect(findMatchingSsoClient(pkg, { app: "a", tier: "prod" })).toMatchObject({
+      clientId: "c1",
+    });
+    // Does not match when only a subset matches
+    expect(findMatchingSsoClient(pkg, { tier: "prod" })).toBeUndefined();
   });
 
   test("two enabled clients both match; first match wins", () => {
@@ -1197,9 +1199,11 @@ describe("findMatchingSsoClient", () => {
       },
     };
 
-    // Any-label semantics: both clients match { app: "x" }.
+    // All-label semantics: with selector { app: "x", tier: "prod" }, both clients match.
     // Order matters: ensure the first matching client is returned.
-    expect(findMatchingSsoClient(pkg, { app: "x" })).toMatchObject({ clientId: "first" });
+    expect(findMatchingSsoClient(pkg, { app: "x", tier: "prod" })).toMatchObject({
+      clientId: "first",
+    });
   });
 
   test("ordering: {} selector client wins over specific-label client", () => {

--- a/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
@@ -6,9 +6,11 @@
 import { describe, expect, test, vi } from "vitest";
 import { Direction, Gateway, RemoteGenerated, UDSPackage } from "../../crd";
 import { Action, AuthorizationPolicy } from "../../crd/generated/istio/authorizationpolicy-v1beta1";
+import { Mode } from "../../crd/generated/package-v1alpha1";
 import { IstioState } from "../istio/namespace";
 import {
   createDenyAllExceptWaypointPolicy,
+  findMatchingSsoClient,
   generateAuthorizationPolicies,
 } from "./authorizationPolicies";
 
@@ -1110,5 +1112,127 @@ describe("createDenyAllExceptWaypointPolicy", () => {
     expect(policy.spec?.rules?.[0].from?.[0].source?.notPrincipals).toEqual([
       "cluster.local/ns/test-ns/sa/test-waypoint",
     ]);
+  });
+});
+
+describe("findMatchingSsoClient", () => {
+  test("returns undefined when selector is undefined", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [{ clientId: "c1", name: "", enableAuthserviceSelector: { app: "a" } }],
+        network: { serviceMesh: { mode: Mode.Ambient } },
+      },
+    };
+
+    expect(
+      findMatchingSsoClient(pkg, undefined as unknown as Record<string, string>),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when mesh mode is not Ambient", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [{ clientId: "c1", name: "", enableAuthserviceSelector: { app: "a" } }],
+        network: { serviceMesh: { mode: Mode.Sidecar } },
+      },
+    };
+
+    expect(findMatchingSsoClient(pkg, { app: "a" })).toBeUndefined();
+  });
+
+  test("prefilters to enabled clients only (missing/null/undefined selector are ignored)", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [
+          { clientId: "d1", name: "" },
+          { clientId: "d3", name: "", enableAuthserviceSelector: undefined },
+        ],
+        network: { serviceMesh: { mode: Mode.Ambient } },
+      },
+    };
+
+    expect(findMatchingSsoClient(pkg, { app: "anything" })).toBeUndefined();
+  });
+
+  test("empty SSO selector ({}) matches any provided selector (namespace-wide)", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [{ clientId: "c1", name: "", enableAuthserviceSelector: {} }],
+        network: { serviceMesh: { mode: Mode.Ambient } },
+      },
+    };
+
+    expect(findMatchingSsoClient(pkg, {})).toMatchObject({ clientId: "c1" });
+    expect(findMatchingSsoClient(pkg, { app: "x" })).toMatchObject({ clientId: "c1" });
+  });
+
+  test("non-empty SSO selector uses any-label matching semantics", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [{ clientId: "c1", name: "", enableAuthserviceSelector: { app: "a", tier: "prod" } }],
+        network: { serviceMesh: { mode: Mode.Ambient } },
+      },
+    };
+
+    // Matches because 'tier' label matches (any-label semantics)
+    expect(findMatchingSsoClient(pkg, { tier: "prod" })).toMatchObject({ clientId: "c1" });
+    // Does not match when none of the labels match
+    expect(findMatchingSsoClient(pkg, { env: "prod" })).toBeUndefined();
+  });
+
+  test("two enabled clients both match; first match wins", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [
+          { clientId: "first", name: "", enableAuthserviceSelector: { app: "x", tier: "prod" } },
+          { clientId: "second", name: "", enableAuthserviceSelector: { app: "x" } },
+        ],
+        network: { serviceMesh: { mode: Mode.Ambient } },
+      },
+    };
+
+    // Any-label semantics: both clients match { app: "x" }.
+    // Order matters: ensure the first matching client is returned.
+    expect(findMatchingSsoClient(pkg, { app: "x" })).toMatchObject({ clientId: "first" });
+  });
+
+  test("ordering: {} selector client wins over specific-label client", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [
+          { clientId: "wide", name: "", enableAuthserviceSelector: {} },
+          { clientId: "specific", name: "", enableAuthserviceSelector: { app: "x" } },
+        ],
+        network: { serviceMesh: { mode: Mode.Ambient } },
+      },
+    };
+
+    // {} means namespace-wide; it matches any provided selector.
+    // Verify ordering: the {} client appears first and should win.
+    expect(findMatchingSsoClient(pkg, { app: "x" })).toMatchObject({ clientId: "wide" });
+  });
+
+  test("empty-string selector value matches only empty-string label", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        sso: [{ clientId: "empty", name: "", enableAuthserviceSelector: { foo: "" } }],
+        network: { serviceMesh: { mode: Mode.Ambient } },
+      },
+    };
+
+    // Exact-value requirement: empty-string label matches only empty-string selector value.
+    expect(findMatchingSsoClient(pkg, { foo: "" })).toMatchObject({ clientId: "empty" });
+    // Non-empty value should not match empty-string selector value.
+    expect(findMatchingSsoClient(pkg, { foo: "bar" })).toBeUndefined();
+    // Empty provided selector has no keys -> no labels to match -> no match.
+    expect(findMatchingSsoClient(pkg, {})).toBeUndefined();
   });
 });

--- a/src/pepr/operator/controllers/network/authorizationPolicies.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.ts
@@ -433,8 +433,8 @@ export function findMatchingSsoClient(
       return true;
     }
 
-    // For non-empty selectors, check if any label matches
-    return Object.entries(waypointSelector!).some(([key, value]) => selector[key] === value);
+    // For non-empty selectors, require all labels to match
+    return Object.entries(waypointSelector!).every(([key, value]) => selector[key] === value);
   });
 }
 

--- a/src/pepr/operator/controllers/network/authorizationPolicies.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.ts
@@ -15,7 +15,7 @@ import {
 import { Mode } from "../../crd/generated/package-v1alpha1";
 import { IstioState } from "../istio/namespace";
 import { getWaypointName, shouldUseAmbientWaypoint } from "../istio/waypoint-utils";
-import { getOwnerRef, purgeOrphans, sanitizeResourceName } from "../utils";
+import { getAuthserviceClients, getOwnerRef, purgeOrphans, sanitizeResourceName } from "../utils";
 import { META_IP } from "./generators/cloudMetadata";
 import { kubeAPI } from "./generators/kubeAPI";
 import { kubeNodes } from "./generators/kubeNodes";
@@ -424,21 +424,17 @@ export function findMatchingSsoClient(
     return undefined;
   }
 
-  return pkg.spec.sso?.find(sso => {
-    const waypointSelector = sso.enableAuthserviceSelector;
-
-    // Skip if no selector defined
-    if (waypointSelector === undefined || waypointSelector === null) {
-      return false;
-    }
+  const authserviceClients = getAuthserviceClients(pkg);
+  return authserviceClients.find(client => {
+    const waypointSelector = client.enableAuthserviceSelector;
 
     // Empty object means namespace-wide protection
-    if (Object.keys(waypointSelector).length === 0) {
+    if (Object.keys(waypointSelector!).length === 0) {
       return true;
     }
 
     // For non-empty selectors, check if any label matches
-    return Object.entries(waypointSelector).some(([key, value]) => selector[key] === value);
+    return Object.entries(waypointSelector!).some(([key, value]) => selector[key] === value);
   });
 }
 

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -7,6 +7,7 @@ import { V1OwnerReference } from "@kubernetes/client-node";
 import { GenericClass, GenericKind, WatchCfg } from "kubernetes-fluent-client";
 import { K8s, kind } from "pepr";
 import { Logger } from "pino";
+import { UDSPackage } from "../crd";
 
 /**
  * Watch configuration for use in KFC watches
@@ -231,4 +232,13 @@ export async function validateNamespace(
       throw e;
     }
   }
+}
+
+/**
+ * Get SSO clients with authservice enabled.
+ * Filters to entries where enableAuthserviceSelector is present (not null/undefined).
+ */
+export function getAuthserviceClients(pkg: UDSPackage) {
+  const list = pkg.spec?.sso || [];
+  return list.filter(sso => sso?.enableAuthserviceSelector != null);
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where NetPols could be generated for SSO clients that were not "authservice-enabled" because a missing `enableAuthserviceSelector` was effectively treated as namespace-wide.

Pulled an existing authservice enabled sso client filter into a new utility to function that can be used to pre filter for the clients that we need. Implemented a bunch of new tests for the utility and the functions that use that utility to make sure i maintained existing expected behavior. Updated a few different spots that were filtering for authservice clients in different ways.
 
## Related Issue

Fixes #2120 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run test:uds-core-e2e`
- `uds run test:unit-tests`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed