### PR TITLE
feat: adding custom pod annotations to keycloak statefulset

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -33,7 +33,7 @@ runs:
       uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
       with:
         # renovate: datasource=github-tags depName=astral-sh/uv versioning=semver
-        version: v0.9.9
+        version: 0.9.9
 
     - name: Install k3d
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -29,6 +29,12 @@ runs:
       with:
         node-version: 24
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
+      with:
+        # renovate: datasource=github-tags depName=astral-sh/uv versioning=semver
+        version: v0.9.9
+
     - name: Install k3d
       shell: bash
       # renovate: datasource=github-tags depName=k3d-io/k3d versioning=semver

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Before starting, ensure that you have the following installed:
 - **Go** (for pre-commit tooling): [Install Go](https://go.dev/doc/install)
 - **Helm** (for development and testing): [Install Helm](https://helm.sh/docs/intro/install/)
 - **Helm Unittest Plugin** (for development and testing): [Install Helm unittest](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install)
-- **uv** is required for running linting tooling:  [Install uv](https://docs.astral.sh/uv/getting-started/installation/#installing-uv).  The `lint` tasks will install latest if not already installed.
+- **uv** is required for running linting tooling:  [Install uv](https://docs.astral.sh/uv/getting-started/installation/#installing-uv).
 
 #### Setting Up Your Local Repository
 
@@ -83,7 +83,7 @@ The easiest way to install all required dependencies is:
 # Install the helm-unittest plugin
 helm plugin install https://github.com/helm-unittest/helm-unittest.git
 
-# Run the lint-check task (installs uv if not installed)
+# Run the lint-check task
 uds run lint-check
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Before starting, ensure that you have the following installed:
 - **Go** (for pre-commit tooling): [Install Go](https://go.dev/doc/install)
 - **Helm** (for development and testing): [Install Helm](https://helm.sh/docs/intro/install/)
 - **Helm Unittest Plugin** (for development and testing): [Install Helm unittest](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install)
+- **Python 3** is required for installing [pipx](https://pipx.pypa.io/) to install lint tooling.
 
 #### Setting Up Your Local Repository
 
@@ -81,7 +82,7 @@ The easiest way to install all required dependencies is:
 ```console
 # Install the helm-unittest plugin
 helm plugin install https://github.com/helm-unittest/helm-unittest.git
-# Run the lint-check which installs other dependencies
+# Run the lint-check task (installs yamllint and codespell via pipx)
 uds run lint-check
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Before starting, ensure that you have the following installed:
 - **Go** (for pre-commit tooling): [Install Go](https://go.dev/doc/install)
 - **Helm** (for development and testing): [Install Helm](https://helm.sh/docs/intro/install/)
 - **Helm Unittest Plugin** (for development and testing): [Install Helm unittest](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install)
-- **uv** is required for running linting tooling:  [Install uv](https://docs.astral.sh/uv/getting-started/installation/#installing-uv).
+- **uv** is required for running linting tooling:  [Install uv](https://docs.astral.sh/uv/getting-started/installation).
 
 #### Setting Up Your Local Repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Before starting, ensure that you have the following installed:
 - **Go** (for pre-commit tooling): [Install Go](https://go.dev/doc/install)
 - **Helm** (for development and testing): [Install Helm](https://helm.sh/docs/intro/install/)
 - **Helm Unittest Plugin** (for development and testing): [Install Helm unittest](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install)
-- **Python 3** is required for installing [pipx](https://pipx.pypa.io/) to install lint tooling.
+- **uv** is required for running linting tooling:  [Install uv](https://docs.astral.sh/uv/getting-started/installation/#installing-uv).  The `lint` tasks will install latest if not already installed.
 
 #### Setting Up Your Local Repository
 
@@ -82,7 +82,8 @@ The easiest way to install all required dependencies is:
 ```console
 # Install the helm-unittest plugin
 helm plugin install https://github.com/helm-unittest/helm-unittest.git
-# Run the lint-check task (installs yamllint and codespell via pipx)
+
+# Run the lint-check task (installs uv if not installed)
 uds run lint-check
 ```
 

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -28,11 +28,14 @@ spec:
         {{- end }}
         istio.io/use-waypoint: {{ include "keycloak.fullname" . }}-waypoint
         istio.io/ingress-use-waypoint: "true"
-      {{- if not .Values.devMode }}
       annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if not .Values.devMode }}
         postgres-hash: {{ include (print $.Template.BasePath "/secret-postgresql.yaml") . | sha256sum }}
         kc-realm-hash: {{ include (print $.Template.BasePath "/secret-kc-realm.yaml") . | sha256sum }}
-      {{- end }}
+        {{- end }}
     spec:
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/src/keycloak/chart/tests/kc_annotations_test.yaml
+++ b/src/keycloak/chart/tests/kc_annotations_test.yaml
@@ -1,0 +1,89 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Annotations block
+templates:
+  - statefulset.yaml
+  - secret-kc-realm.yaml
+  - secret-postgresql.yaml
+
+tests:
+  - it: should render only hash annotations when podAnnotations is not set and devMode is false
+    set:
+      devMode: false
+      postgresql:
+        username: "test-user-12345"
+        password: "test-password-67890"
+        database: "test-database-name"
+        host: "test-postgres-host.example.com"
+        port: 5432
+    template: statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations.postgres-hash
+          pattern: "^[a-f0-9]{64}$"
+      - matchRegex:
+          path: spec.template.metadata.annotations.kc-realm-hash
+          pattern: "^[a-f0-9]{64}$"
+      - notExists:
+          path: spec.template.metadata.annotations.foo
+
+  - it: should render empty annotations block when podAnnotations is not set and devMode is true
+    set:
+      devMode: true
+    template: statefulset.yaml
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations
+      - notExists:
+          path: spec.template.metadata.annotations.postgres-hash
+      - notExists:
+          path: spec.template.metadata.annotations.kc-realm-hash
+
+  - it: should render both hash and custom annotations when podAnnotations is set and devMode is false
+    set:
+      devMode: false
+      postgresql:
+        username: "test-user-12345"
+        password: "test-password-67890"
+        database: "test-database-name"
+        host: "test-postgres-host.example.com"
+        port: 5432
+      podAnnotations:
+        foo: bar
+        custom: "baz"
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: bar
+      - equal:
+          path: spec.template.metadata.annotations.custom
+          value: baz
+      - matchRegex:
+          path: spec.template.metadata.annotations.postgres-hash
+          pattern: "^[a-f0-9]{64}$"
+      - matchRegex:
+          path: spec.template.metadata.annotations.kc-realm-hash
+          pattern: "^[a-f0-9]{64}$"
+
+  - it: should render only custom annotations when podAnnotations is set and devMode is true
+    set:
+      devMode: true
+      podAnnotations:
+        foo: bar
+        custom: "baz"
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: bar
+      - equal:
+          path: spec.template.metadata.annotations.custom
+          value: baz
+      - notExists:
+          path: spec.template.metadata.annotations.postgres-hash
+      - notExists:
+          path: spec.template.metadata.annotations.kc-realm-hash

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -639,6 +639,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Custom annotations to add to the pod template"
     }
   }
 }

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -187,6 +187,9 @@ tolerations: []
 # Additional Pod labels
 podLabels: {}
 
+# Additional Pod annotations
+podAnnotations: {}
+
 # Pod resource requests and limits
 resources:
   requests:

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -11,8 +11,9 @@ tasks:
       - description: Check if uv is installed
         cmd: |
           if ! command -v uv; then
-            echo "⚠️  uv is not installed. Installing now..."
-            curl -LsSf https://astral.sh/uv/install.sh | sh
+            echo "⚠️  uv is not installed."
+            echo "💡 Refer to installation steps: https://docs.astral.sh/uv/getting-started/installation/"
+            exit 1
           fi
 
   - name: fix

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -5,11 +5,40 @@ includes:
   - remote: https://raw.githubusercontent.com/defenseunicorns/uds-common/v1.21.3/tasks/lint.yaml
 
 tasks:
+  - name: ensure-python-tools
+    description: Install linting tool dependencies
+    actions:
+      - description: Check if pipx is installed
+        cmd: |
+          if ! command -v pipx; then
+            echo "⚠️  pipx is not installed."
+
+            # Detect the OS and suggest the appropriate install method
+            if [ "$(uname)" = "Darwin" ]; then
+              echo "💡 Install pipx with: brew install pipx"
+            elif [ -f /etc/debian_version ]; then
+              echo "💡 Install pipx with: sudo apt update && sudo apt install pipx"
+            else
+              echo "💡 Please refer to your package manager to install pipx."
+            fi
+            exit 1
+          fi
+      - description: Ensure yamllint is installed
+        cmd: |
+          if ! pipx list | grep -q yamllint; then
+            pipx install yamllint
+          fi
+      - description: Ensure codespell is installed
+        cmd: |
+          if ! pipx list | grep -q codespell; then
+            pipx install codespell
+          fi
+
   - name: fix
     description: "Fix formatting issues in the repo"
     actions:
-      - description: install codespell deps
-        cmd: CMD=pip && which $CMD || CMD=pip3 && $CMD install codespell
+      - description: Ensure python tools are installed
+        task: ensure-python-tools
       - description: "Pepr Format"
         cmd: npx pepr format
       - description: Fix codespell lint issues
@@ -20,12 +49,12 @@ tasks:
   - name: check
     description: "Run linting checks"
     actions:
+      - description: Ensure python tools are installed
+        task: ensure-python-tools
       - description: install pepr deps
         cmd: npm ci
       - description: "Pepr Format check"
         cmd: npx pepr format --validate-only
-      - description: install yamllint and codespell deps
-        cmd: CMD=pip && which $CMD || CMD=pip3 && $CMD install yamllint codespell
       - description: yaml lint
         cmd: yamllint . -c .yamllint --no-warnings
       - description: codespell lint

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -5,60 +5,41 @@ includes:
   - remote: https://raw.githubusercontent.com/defenseunicorns/uds-common/v1.21.3/tasks/lint.yaml
 
 tasks:
-  - name: ensure-python-tools
+  - name: ensure-uv
     description: Install linting tool dependencies
     actions:
-      - description: Check if pipx is installed
+      - description: Check if uv is installed
         cmd: |
-          if ! command -v pipx; then
-            echo "⚠️  pipx is not installed."
-
-            # Detect the OS and suggest the appropriate install method
-            if [ "$(uname)" = "Darwin" ]; then
-              echo "💡 Install pipx with: brew install pipx"
-            elif [ -f /etc/debian_version ]; then
-              echo "💡 Install pipx with: sudo apt update && sudo apt install pipx"
-            else
-              echo "💡 Please refer to your package manager to install pipx."
-            fi
-            exit 1
-          fi
-      - description: Ensure yamllint is installed
-        cmd: |
-          if ! pipx list | grep -q yamllint; then
-            pipx install yamllint
-          fi
-      - description: Ensure codespell is installed
-        cmd: |
-          if ! pipx list | grep -q codespell; then
-            pipx install codespell
+          if ! command -v uv; then
+            echo "⚠️  uv is not installed. Installing now..."
+            curl -LsSf https://astral.sh/uv/install.sh | sh
           fi
 
   - name: fix
     description: "Fix formatting issues in the repo"
     actions:
-      - description: Ensure python tools are installed
-        task: ensure-python-tools
+      - description: Ensure uv is installed
+        task: ensure-uv
       - description: "Pepr Format"
         cmd: npx pepr format
       - description: Fix codespell lint issues
         cmd: |
-          codespell || true
-          codespell -w
+          uvx codespell || true
+          uvx codespell -w
 
   - name: check
     description: "Run linting checks"
     actions:
-      - description: Ensure python tools are installed
-        task: ensure-python-tools
+      - description: Ensure uv is installed
+        task: ensure-uv
       - description: install pepr deps
         cmd: npm ci
       - description: "Pepr Format check"
         cmd: npx pepr format --validate-only
       - description: yaml lint
-        cmd: yamllint . -c .yamllint --no-warnings
+        cmd: uvx yamllint . -c .yamllint --no-warnings
       - description: codespell lint
-        cmd: codespell
+        cmd: uvx codespell
       - description: Install addlicense dep
         # renovate: datasource=github-tags depName=google/addlicense versioning=semver
         cmd: GOPATH="$HOME/go" go install github.com/google/addlicense@v1.1.1


### PR DESCRIPTION
## Description
- Adding new value `podAnnotations` to allow defining custom annotations
  - Added unittests for annotation scenarios
- Modified `lint-check` task to use `uv` and `uvx` from `pip3`, avoiding `externally-managed-environment` error with some pip installations
- Add setup-uv action to setup to accommodate switch to `uv`
- Updated CONTRIBUTING.md to reflect uv requirement

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Can test with with unit tests.  Additionally can render chart via `helm template test src/keycloak/chart`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed