### PR TITLE
fix: add conflict resolution for EKS VPC CNI

### DIFF
--- a/.github/test-infra/aws/eks/cluster.tf
+++ b/.github/test-infra/aws/eks/cluster.tf
@@ -130,6 +130,9 @@ module "eks" {
       configuration_values = jsonencode({
         enableNetworkPolicy = "true"
       })
+      # Needed because of https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3582
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
     }
     aws-ebs-csi-driver = {
       most_recent = true


### PR DESCRIPTION
## Description

Adds `resolve_conflicts` settings to the VPC CNI plugin based on an upstream issue.

## Related Issue

Resolves [issue](https://www.github.com/terraform-aws-modules/terraform-aws-eks/issues/3582) identified upstream.