### PR TITLE
fix: install/use proper deps for check-ca-certs task

### DIFF
--- a/.github/workflows/check-ca-certs.yaml
+++ b/.github/workflows/check-ca-certs.yaml
@@ -36,6 +36,10 @@ jobs:
           rapidfortUsername: ${{ secrets.RAPIDFORT_USERNAME }}
           rapidfortPassword: ${{ secrets.RAPIDFORT_PASSWORD }}
 
+      - name: Install script dependencies
+        run: npm ci
+        working-directory: scripts/root-ca-retriever
+
       - name: Check CA Certs for Updates
         run:
           uds run check-ca-certs

--- a/.github/workflows/check-ca-certs.yaml
+++ b/.github/workflows/check-ca-certs.yaml
@@ -7,6 +7,8 @@ on:
   schedule:
     # Runs every morning at 2:00 AM UTC
     - cron: "0 2 * * *"
+  # TODO: Remove this after testing
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/check-ca-certs.yaml
+++ b/.github/workflows/check-ca-certs.yaml
@@ -7,8 +7,6 @@ on:
   schedule:
     # Runs every morning at 2:00 AM UTC
     - cron: "0 2 * * *"
-  # TODO: Remove this after testing
-  pull_request:
 
 permissions:
   contents: read

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -192,9 +192,9 @@ tasks:
   - name: check-ca-certs
     description: "Checks CA certificates for updates"
     actions:
-      - cmd: npx ts-node scripts/root-ca-retriever/index.ts --check
+      - cmd: npx ts-node --project scripts/root-ca-retriever/tsconfig.json scripts/root-ca-retriever/index.ts --check
 
   - name: update-ca-certs
     description: "Updates CA certificates"
     actions:
-      - cmd: npx ts-node scripts/root-ca-retriever/index.ts
+      - cmd: npx ts-node --project scripts/root-ca-retriever/tsconfig.json scripts/root-ca-retriever/index.ts


### PR DESCRIPTION
## Description

Fixes failed runs for check-ca-certs nightly workflow. See [example](https://github.com/defenseunicorns/uds-core/actions/runs/19809497884/job/56749064699#step:4:16).  The issue is that the deps aren't install in the github action workflow and that the task was using the top level package.json instead of the local script directory.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Tested here: https://github.com/defenseunicorns/uds-core/actions/runs/19828308383/job/56807418336?pr=2173

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed