### PR TITLE
chore: add zarf connect for prometheus and alertmanager

### DIFF
--- a/docs/reference/configuration/observability/alert-management.md
+++ b/docs/reference/configuration/observability/alert-management.md
@@ -79,6 +79,11 @@ You can find more information on configuring Alertmanager in the [official docum
 
 :::note[Alertmanager UI]
 In UDS Core we do not expose the Alertmanager UI directly because it does not have built-in authentication.  Instead, we ingest Alertmanager as a data source in Grafana which should be the central landing UI for all things observability.
+
+If you do have a need to connect to the Alertmanager UI it can be done via a port-forward connection:
+```console
+uds zarf connect alertmanager
+```
 :::
 
 By default, UDS Core configures Alertmanager as a data source in Grafana. This means you can view and manage Alertmanager alerts by navigating to the `Alerting` section in the Grafana UI.

--- a/docs/reference/configuration/observability/monitoring-metrics.md
+++ b/docs/reference/configuration/observability/monitoring-metrics.md
@@ -48,7 +48,7 @@ spec:
         type: "Bearer"
 ```
 
-::::tip[Checking Prometheus targets and alerts]
+:::tip[Checking Prometheus targets and alerts]
 When debugging metrics scraping or verifying a new `ServiceMonitor` / `PodMonitor`, you can connect directly to Prometheus from your workstation:
 
 ```console
@@ -56,4 +56,5 @@ uds zarf connect prometheus
 ```
 
 This opens a local port-forward to the Prometheus server. In the Prometheus UI you can check `Status -> Target health` to confirm your application’s metrics endpoint is being scraped and is up.
+
 :::

--- a/docs/reference/configuration/observability/monitoring-metrics.md
+++ b/docs/reference/configuration/observability/monitoring-metrics.md
@@ -48,7 +48,7 @@ spec:
         type: "Bearer"
 ```
 
-:::tip[Checking Prometheus targets and alerts]
+:::tip[Checking Prometheus Targets]
 When debugging metrics scraping or verifying a new `ServiceMonitor` / `PodMonitor`, you can connect directly to Prometheus from your workstation:
 
 ```console

--- a/docs/reference/configuration/observability/monitoring-metrics.md
+++ b/docs/reference/configuration/observability/monitoring-metrics.md
@@ -48,3 +48,12 @@ spec:
         type: "Bearer"
 ```
 
+::::tip[Checking Prometheus targets and alerts]
+When debugging metrics scraping or verifying a new `ServiceMonitor` / `PodMonitor`, you can connect directly to Prometheus from your workstation:
+
+```console
+uds zarf connect prometheus
+```
+
+This opens a local port-forward to the Prometheus server. In the Prometheus UI you can check `Status -> Target health` to confirm your application’s metrics endpoint is being scraped and is up.
+:::

--- a/src/prometheus-stack/values/values.yaml
+++ b/src/prometheus-stack/values/values.yaml
@@ -23,6 +23,12 @@ nodeExporter:
 prometheus:
   serviceMonitor:
     selfMonitor: true
+  # Enables "zarf connect prometheus"
+  service:
+    labels:
+      zarf.dev/connect-name: prometheus
+    annotations:
+      zarf.dev/connect-description: "Directly connect to the Prometheus HTTP service"
   prometheusSpec:
     podMetadata:
       labels:
@@ -88,6 +94,12 @@ prometheusOperator:
 alertmanager:
   alertmanagerSpec:
     scheme: "http"
+  # Enables "zarf connect alertmanager"
+  service:
+    labels:
+      zarf.dev/connect-name: alertmanager
+    annotations:
+      zarf.dev/connect-description: "Directly connect to the Alertmanager HTTP service"
 ## Create default rules for monitoring the cluster
 ##
 defaultRules:


### PR DESCRIPTION
## Description

Adds support for `zarf connect prometheus` and `zarf connect alertmanager` for easier port-forwarding to these services.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

```console
uds run test-single-layer --set LAYER=monitoring
uds zarf connect prometheus # then go to the output IP/port
uds zarf connect alertmanager # then go to the output IP/port
```

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed