### PR TITLE
fix: renovate matching for falco rules

### DIFF
--- a/src/falco/tasks.yaml
+++ b/src/falco/tasks.yaml
@@ -37,22 +37,29 @@ tasks:
           RULES_DIR="chart/rules"
 
           echo "Downloading latest Falco rules..."
+
+          # renovate: datasource=github-tags depName=falcosecurity/rules extractVersion=^falco-rules-(?<version>\d+\.\d+\.\d+)$
+          STABLE_RULES_TAG="4.0.0"
           if ! curl -sSfL --connect-timeout 30 --max-time 60 \
-               https://raw.githubusercontent.com/falcosecurity/rules/falco-rules-4.0.0/rules/falco_rules.yaml \
+               https://raw.githubusercontent.com/falcosecurity/rules/falco-rules-${STABLE_RULES_TAG}/rules/falco_rules.yaml \
                -o "${RULES_DIR}/stable-rules.yaml"; then
             echo "Error: Failed to download stable rules"
             exit 1
           fi
 
+          # renovate: datasource=github-tags depName=falcosecurity/rules extractVersion=^falco-sandbox-rules-(?<version>\d+\.\d+\.\d+)$
+          SANDBOX_RULES_TAG="5.0.1"
           if ! curl -sSfL --connect-timeout 30 --max-time 60 \
-               https://raw.githubusercontent.com/falcosecurity/rules/falco-sandbox-rules-5.0.1/rules/falco-sandbox_rules.yaml \
+               https://raw.githubusercontent.com/falcosecurity/rules/falco-sandbox-rules-${SANDBOX_RULES_TAG}/rules/falco-sandbox_rules.yaml \
                -o "${RULES_DIR}/sandbox-rules.yaml"; then
             echo "Error: Failed to download sandbox rules"
             exit 1
           fi
 
+          # renovate: datasource=github-tags depName=falcosecurity/rules extractVersion=^falco-incubating-rules-(?<version>\d+\.\d+\.\d+)$
+          INCUBATING_RULES_TAG="5.0.1"
           if ! curl -sSfL --connect-timeout 30 --max-time 60 \
-               https://raw.githubusercontent.com/falcosecurity/rules/falco-incubating-rules-5.0.1/rules/falco-incubating_rules.yaml \
+               https://raw.githubusercontent.com/falcosecurity/rules/falco-incubating-rules-${INCUBATING_RULES_TAG}/rules/falco-incubating_rules.yaml \
                -o "${RULES_DIR}/incubating-rules.yaml"; then
             echo "Error: Failed to download incubating rules"
             exit 1


### PR DESCRIPTION
## Description

Updates the tasks for falco rules to properly match the tags for the upstream rules. Currently renovate is using a semver-coerced versioning for these github raw strings that doesn't appear to support/properly match the new upstream tags.

This change pulls the semver portion out to an env, then uses a renovate `extractVersion` to match the proper upstream tags. This approach was tested on my personal repo: https://github.com/mjnagel/test/pull/122/files

Note that I did not update the tags in this PR, so we should have a follow-on Renovate PR that actually bumps these tags and the rules.

## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/issues/2185

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)