### PR TITLE
fix(ci): switch to example curl for egress test

### DIFF
--- a/src/test/app-egress-ambient-package.yaml
+++ b/src/test/app-egress-ambient-package.yaml
@@ -23,9 +23,9 @@ spec:
           app: curl
         ports:
           - 443
-        remoteHost: api.github.com
+        remoteHost: www.example.com
         remoteProtocol: TLS
-        description: "Github API Curl"
+        description: "Example Curl"
 ---
 apiVersion: v1
 kind: Namespace

--- a/test/vitest/network.spec.ts
+++ b/test/vitest/network.spec.ts
@@ -355,13 +355,13 @@ describe("Network Policy Validation", { retry: 2 }, () => {
     const egress_ambient_http_curl = [
       "sh",
       "-c",
-      `curl -s -w " HTTP_CODE:%{http_code}" http://api.github.com`,
+      `curl -s -w " HTTP_CODE:%{http_code}" http://www.example.com`,
     ];
 
     const egress_ambient_tls_curl = [
       "sh",
       "-c",
-      `curl -s -w " HTTP_CODE:%{http_code}" https://api.github.com`,
+      `curl -s -w " HTTP_CODE:%{http_code}" https://www.example.com`,
     ];
 
     // Validate successful tls request when using Egress for egress-ambient-1


### PR DESCRIPTION
## Description

CI has been intermittently failing on one specific egress TLS curl. Through a recent run with debug output ([here](https://github.com/defenseunicorns/uds-core/actions/runs/19943589893/job/57187540503?pr=2166)) we identified this was due to rate limiting on the github api endpoint we were using for testing. This PR switches to example.com for the test host, which has worked well for our [other egress (sidecar) testing](https://github.com/defenseunicorns/uds-core/blob/main/test/vitest/network.spec.ts#L424-L436).

## Related Issue

Related to https://github.com/defenseunicorns/uds-core/issues/2175

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)