### PR TITLE
fix(ci): add podinfo host for iac

### DIFF
--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -105,7 +105,7 @@ tasks:
       - description: Adds Cluster LoadBalancer IP Addresses to match appropriate hosts names in /etc/hosts
         mute: true
         cmd: |
-          echo "$ADMIN_GW_IP keycloak.admin.uds.dev grafana.admin.uds.dev demo.admin.uds.dev\n$TENANT_GW_IP sso.uds.dev demo-8080.uds.dev demo-8081.uds.dev protected.uds.dev ambient-protected.uds.dev ambient2-protected.uds.dev" | sudo tee -a /etc/hosts
+          echo "$ADMIN_GW_IP keycloak.admin.uds.dev grafana.admin.uds.dev demo.admin.uds.dev\n$TENANT_GW_IP sso.uds.dev demo-8080.uds.dev demo-8081.uds.dev protected.uds.dev ambient-protected.uds.dev ambient2-protected.uds.dev podinfo.uds.dev" | sudo tee -a /etc/hosts
 
   - name: rename-flavored-packages
     description: "Rename flavored package files by removing the flavor suffix"


### PR DESCRIPTION
## Description

On a separate PR (https://github.com/defenseunicorns/uds-core/actions/runs/19975548672/job/57290706330?pr=2198) realized that the new testing of authservice/metrics is broken on IAC since we did not setup the host for it.