### PR TITLE
chore: adjust polling for loki integration tests/add debug output for cm/secrets

### DIFF
--- a/.github/actions/debug-output/action.yaml
+++ b/.github/actions/debug-output/action.yaml
@@ -24,6 +24,9 @@ runs:
         echo "::group::kubectl get events"
         uds zarf tools kubectl get events -A --sort-by='.lastTimestamp' | tee /tmp/debug-k-get-events.log || true
         echo "::endgroup::"
+        echo "::group::kubectl get configmaps,secrets"
+        uds zarf tools kubectl get configmaps,secrets -A | tee /tmp/debug-k-get-configmaps-secrets.log || true
+        echo "::endgroup::"
         echo "::group::kubectl describe nodes"
         uds zarf tools kubectl describe nodes | tee /tmp/debug-k-describe-node.log || true
         echo "::endgroup::"

--- a/test/vitest/integration-loki-ruler.spec.ts
+++ b/test/vitest/integration-loki-ruler.spec.ts
@@ -34,16 +34,16 @@ describe("integration - Loki Ruler Tests", () => {
       () => queryPrometheusMetric(prometheusProxy.url, "loki:test_constant"),
       value => value === 1,
       "Checking for loki:test_constant metric with value 1",
-      10000,
+      15000,
     );
-  }, 11000);
+  }, 16000);
 
   test("Loki ruler should send alerts to Alertmanager", async () => {
     await pollUntilSuccess(
       () => checkAlertInAlertmanager(alertmanagerProxy.url, "LokiAlwaysFiring"),
       isAlertFiring => isAlertFiring === true,
       "Checking for LokiAlwaysFiring alert in Alertmanager",
-      10000,
+      15000,
     );
-  }, 11000);
+  }, 16000);
 });

--- a/test/vitest/integration-loki-ruler.spec.ts
+++ b/test/vitest/integration-loki-ruler.spec.ts
@@ -34,16 +34,18 @@ describe("integration - Loki Ruler Tests", () => {
       () => queryPrometheusMetric(prometheusProxy.url, "loki:test_constant"),
       value => value === 1,
       "Checking for loki:test_constant metric with value 1",
-      15000,
+      10000, // 10 seconds timeout for poll
+      1000, // 1 second interval between polls
     );
-  }, 16000);
+  }, 12000); // 12 second total test timeout
 
   test("Loki ruler should send alerts to Alertmanager", async () => {
     await pollUntilSuccess(
       () => checkAlertInAlertmanager(alertmanagerProxy.url, "LokiAlwaysFiring"),
       isAlertFiring => isAlertFiring === true,
       "Checking for LokiAlwaysFiring alert in Alertmanager",
-      15000,
+      10000, // 10 seconds timeout for poll
+      1000, // 1 second interval between polls
     );
-  }, 16000);
+  }, 12000); // 12 second total test timeout
 });


### PR DESCRIPTION
## Description

EKS tests are flakey/failing on loki integration tests. It appears they were only polling once as the default poll period for our helper function is 10 seconds, but we specified a 10 second timeout.  Setting the polling period to 1 second so that we get multiple polls for this test.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed