### PR TITLE
fix: ambient authservice validation use curl and retries

### DIFF
--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -151,18 +151,21 @@ tasks:
         cmd: |
           set -e
           URL="https://${{ .inputs.address }}"
+          echo "=== Begin authservice check: $URL ==="
           set +e
           OUT_ALL="$(curl -sS -L -o /dev/null --max-time 15 -v \
                     -w "HTTP_CODE=%{http_code}\nURL_EFFECTIVE=%{url_effective}\n" \
                     "$URL" 2>&1)"
-          RC=$?
           set -e
           if printf '%s\n' "$OUT_ALL" | grep -qx 'HTTP_CODE=200' && \
              printf '%s\n' "$OUT_ALL" | grep -qi '^URL_EFFECTIVE=https://sso\.uds\.dev'; then
+            echo "=== Authservice check passed: $URL ==="
+            echo
             true
           else
-            echo
             printf '%s\n' "$OUT_ALL"
+            echo "=== Authservice check FAILED: $URL ==="
+            echo
             exit 1
           fi
 

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -147,28 +147,33 @@ tasks:
         required: true
     actions:
       - description: Verify the service at https://${{ .inputs.address }} is accessible
-        wait:
-          network:
-            protocol: https
-            address: ${{ .inputs.address }}
-            code: 200
-
-      - description: Verify the service at ${{ .inputs.address }} is protected by checking redirect
-        maxRetries: 3
+        maxRetries: 5
         cmd: |
           set -e
-          SSO_REDIRECT=$(curl -Ls -o /dev/null -w %{url_effective} "https://${{ .inputs.address }}")
+          URL="https://${{ .inputs.address }}"
+          OUT="$(curl -vkI --no-progress-meter --max-time 10 --url "$URL" 2>&1 || true)"
+          CODE="$(printf '%s\n' "$OUT" | awk '/^< HTTP/{print $3; exit}')"
+          if [ "$CODE" = "200" ] || [ "$CODE" = "302" ]; then
+            :
+          else
+            echo
+            printf '%s\n' "$OUT" | egrep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
+            exit 1
+          fi
 
-          case "${SSO_REDIRECT}" in
-          "https://sso.uds.dev"*)
-              echo "Protected by authservice"
-              ;;
-          *)
-              echo "App is not protected by authservice"
-              echo $SSO_REDIRECT
-              exit 1
-              ;;
-          esac
+      - description: Verify the service at ${{ .inputs.address }} is protected by checking redirect
+        maxRetries: 5
+        cmd: |
+          set -e
+          URL="https://${{ .inputs.address }}"
+          OUT="$(curl -vkI --no-progress-meter --max-time 10 --url "$URL" 2>&1 || true)"
+          if printf '%s\n' "$OUT" | grep -qi '^location:\s*https://sso\.uds\.dev'; then
+            :
+          else
+            echo
+            printf '%s\n' "$OUT" | egrep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
+            exit 1
+          fi
 
   - name: remove
     actions:

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -154,10 +154,10 @@ tasks:
           OUT="$(curl -vkI --no-progress-meter --max-time 10 --url "$URL" 2>&1 || true)"
           CODE="$(printf '%s\n' "$OUT" | awk '/^< HTTP/{print $3; exit}')"
           if [ "$CODE" = "200" ] || [ "$CODE" = "302" ]; then
-            :
+            true
           else
             echo
-            printf '%s\n' "$OUT" | egrep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
+            printf '%s\n' "$OUT" | grep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
             exit 1
           fi
 
@@ -168,10 +168,10 @@ tasks:
           URL="https://${{ .inputs.address }}"
           OUT="$(curl -vkI --no-progress-meter --max-time 10 --url "$URL" 2>&1 || true)"
           if printf '%s\n' "$OUT" | grep -qi '^location:\s*https://sso\.uds\.dev'; then
-            :
+            true
           else
             echo
-            printf '%s\n' "$OUT" | egrep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
+            printf '%s\n' "$OUT" | grep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
             exit 1
           fi
 

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -146,32 +146,23 @@ tasks:
         description: The address to check for authservice protection
         required: true
     actions:
-      - description: Verify the service at https://${{ .inputs.address }} is accessible
+      - description: Verify https://${{ .inputs.address }} redirects to SSO and returns HTTP 200
         maxRetries: 5
         cmd: |
           set -e
           URL="https://${{ .inputs.address }}"
-          OUT="$(curl -vkI --no-progress-meter --max-time 10 --url "$URL" 2>&1 || true)"
-          CODE="$(printf '%s\n' "$OUT" | awk '/^< HTTP/{print $3; exit}')"
-          if [ "$CODE" = "200" ] || [ "$CODE" = "302" ]; then
-            true
-          else
-            echo
-            printf '%s\n' "$OUT" | grep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
-            exit 1
-          fi
-
-      - description: Verify the service at ${{ .inputs.address }} is protected by checking redirect
-        maxRetries: 5
-        cmd: |
+          set +e
+          OUT_ALL="$(curl -sS -k -L -o /dev/null --max-time 15 -v \
+                    -w "HTTP_CODE=%{http_code}\nURL_EFFECTIVE=%{url_effective}\n" \
+                    "$URL" 2>&1)"
+          RC=$?
           set -e
-          URL="https://${{ .inputs.address }}"
-          OUT="$(curl -vkI --no-progress-meter --max-time 10 --url "$URL" 2>&1 || true)"
-          if printf '%s\n' "$OUT" | grep -qi '^location:\s*https://sso\.uds\.dev'; then
+          if printf '%s\n' "$OUT_ALL" | grep -qx 'HTTP_CODE=200' && \
+             printf '%s\n' "$OUT_ALL" | grep -qi '^URL_EFFECTIVE=https://sso\.uds\.dev'; then
             true
           else
             echo
-            printf '%s\n' "$OUT" | grep -E '^(\* |< |> )' || printf '%s\n' "$OUT"
+            printf '%s\n' "$OUT_ALL"
             exit 1
           fi
 

--- a/src/test/tasks.yaml
+++ b/src/test/tasks.yaml
@@ -152,7 +152,7 @@ tasks:
           set -e
           URL="https://${{ .inputs.address }}"
           set +e
-          OUT_ALL="$(curl -sS -k -L -o /dev/null --max-time 15 -v \
+          OUT_ALL="$(curl -sS -L -o /dev/null --max-time 15 -v \
                     -w "HTTP_CODE=%{http_code}\nURL_EFFECTIVE=%{url_effective}\n" \
                     "$URL" 2>&1)"
           RC=$?


### PR DESCRIPTION
## Description
Switch Ambient Authservice validations to use curl instead of network wait. Conditionally displays error output if the curls fail, otherwise leave the terminal clean.

## Related Issue

Relates to #2175

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run test:uds-core-e2e`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed