### PR TITLE
fix: enable iptables reconcile on startup for istio-cni

### DIFF
--- a/packages/checkpoint-dev/zarf.yaml
+++ b/packages/checkpoint-dev/zarf.yaml
@@ -54,21 +54,6 @@ components:
     actions:
       onCreate:
         before:
-          - description: "Scale down ztunnel, pepr, and keycloak before snapshot"
-            cmd: |
-              set -e
-              ./zarf tools kubectl -n keycloak scale statefulset keycloak --replicas=0
-              ./zarf tools kubectl rollout status -n keycloak statefulset keycloak --timeout=60s
-
-              ./zarf tools kubectl -n pepr-system scale deploy pepr-uds-core-watcher --replicas=0
-              ./zarf tools kubectl rollout status -n pepr-system deploy pepr-uds-core-watcher --timeout=60s
-
-              ./zarf tools kubectl -n pepr-system scale deploy pepr-uds-core --replicas=0
-              ./zarf tools kubectl rollout status -n pepr-system deploy pepr-uds-core --timeout=60s
-
-              ./zarf tools kubectl -n istio-system patch daemonset ztunnel --type='strategic' -p '{"spec":{"template":{"spec":{"nodeSelector":{"no-such-label":"true"}}}}}'
-              ./zarf tools kubectl -n istio-system wait --for=delete pod -l app=ztunnel --timeout=60s
-
           - cmd: ./checkpoint.sh
         onSuccess:
           - cmd: |
@@ -107,21 +92,5 @@ components:
                 --image ghcr.io/defenseunicorns/uds-core/checkpoint:latest ${ZARF_VAR_K3D_EXTRA_ARGS} \
                 ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"
-
-          - description: "Scale up ztunnel, pepr, and keycloak after checkpoint restore"
-            cmd: |
-              set -e
-              ./zarf tools kubectl -n istio-system patch daemonset ztunnel --type=json -p='[{"op":"remove","path":"/spec/template/spec/nodeSelector/no-such-label"}]'
-              ./zarf tools kubectl -n istio-system rollout status daemonset ztunnel --timeout=60s
-
-              ./zarf tools kubectl -n pepr-system scale deploy pepr-uds-core --replicas=2
-              ./zarf tools kubectl rollout status -n pepr-system deploy pepr-uds-core --timeout=60s
-
-              ./zarf tools kubectl -n pepr-system scale deploy pepr-uds-core-watcher --replicas=1
-              ./zarf tools kubectl -n pepr-system rollout status deploy pepr-uds-core-watcher --timeout=60s
-
-              ./zarf tools kubectl -n keycloak scale statefulset keycloak --replicas=1
-              ./zarf tools kubectl -n keycloak rollout status statefulset keycloak --timeout=180s
-
         onSuccess:
           - cmd: rm -f uds-checkpoint.tar

--- a/src/istio/values/base-cni.yaml
+++ b/src/istio/values/base-cni.yaml
@@ -10,6 +10,10 @@ excludeNamespaces:
   - kube-system
   - zarf
 
+# Force reconcile iptables on startup to help on node reboot
+ambient:
+  reconcileIptablesOnStartup: true
+
 # SELinux enforcing environments require the spc_t SELinux type
 seLinuxOptions:
   type: spc_t


### PR DESCRIPTION
## Description

Some end users have reported seeing intermittent behavior where Pepr or other pods do not appear to be communicating properly through the mesh, resulting in poor behaviors such as SSO clients not being created. This PR enables the `reconcileIptablesOnStartup` which ensures that any existing ambient pods have their iptables fixed if there is a diff on startup ([ref](https://istio.io/latest/news/releases/1.25.x/announcing-1.25/upgrade-notes/#ambient-mode-pod-upgrade-reconciliation)):
> When a new istio-cni DaemonSet pod starts up, it will inspect pods that were previously enrolled in the ambient mesh, and upgrade their in-pod iptables rules to the current state if there is a diff or delta. This is off by default as of 1.25.0, but will eventually be enabled by default. This feature can be enabled by helm install cni --set ambient.reconcileIptablesOnStartup=true (Helm) or istioctl install --set values.cni.ambient.reconcileIptablesOnStartup=true (istioctl).

These changes also allow us to remove some scale up/down actions from our checkpoint package.

## Related Issue

Relates to https://github.com/defenseunicorns/uds-image-builder/issues/153

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)