### PR TITLE
chore(ci): add more debug on IAC, update AKS deprecations

### DIFF
--- a/.github/actions/debug-output/action.yaml
+++ b/.github/actions/debug-output/action.yaml
@@ -30,4 +30,8 @@ runs:
         echo "::group::kubectl describe nodes"
         uds zarf tools kubectl describe nodes | tee /tmp/debug-k-describe-node.log || true
         echo "::endgroup::"
+        echo "::group::kubectl top"
+        uds zarf tools kubectl top nodes | tee /tmp/debug-k-top-node.log || true
+        uds zarf tools kubectl top pods -A | tee /tmp/debug-k-top-pods.log || true
+        echo "::endgroup::"
       shell: bash

--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -60,8 +60,8 @@ runs:
           | xargs -P 8 -n 2 bash -c '
             ns="$1"; pod="$2"
             base="/tmp/pod-logs/${ns}-${pod}"
-            uds zarf tools kubectl logs -n "$ns" "$pod" --tail=-1 > "${base}.log" 2>&1 || true
-            uds zarf tools kubectl logs -n "$ns" "$pod" --previous --tail=-1 > "${base}-previous.log" 2>&1 || true
+            uds zarf tools kubectl logs --all-containers=true -n "$ns" "$pod" --tail=-1 > "${base}.log" 2>&1 || true
+            uds zarf tools kubectl logs --all-containers=true -n "$ns" "$pod" --previous --tail=-1 > "${base}-previous.log" 2>&1 || true
           ' _
         echo "::endgroup::"
       shell: bash

--- a/.github/actions/save-logs/action.yaml
+++ b/.github/actions/save-logs/action.yaml
@@ -44,37 +44,25 @@ runs:
       shell: bash
 
     - name: Move Playwright Artifacts
-      if: ${{ inputs.distro == 'k3d' }} # Currently only run on k3d
       run: |
         sudo mkdir -p /tmp/playwright
         sudo mv test/playwright/.playwright/* /tmp/playwright || true
       shell: bash
 
-    # Additional/specific debug for non-k3d clusters
-    - name: Pepr Debug
+    # Loop over all pods and use kubectl logs since we don't have the same direct node access as k3d
+    - name: Cluster Pod Logs
       if: ${{ inputs.distro != 'k3d' }}
       run: |
-        echo "::group::Pepr Pod Status and Metrics"
-        uds zarf tools kubectl top pods -n pepr-system
-        uds zarf tools kubectl get pods -n pepr-system
-        echo "::endgroup::"
-        echo "::group::Fetch pepr logs"
-        uds zarf tools kubectl logs -n pepr-system -l app=pepr-uds-core --tail -1 > /tmp/pepr-logs.log
-        uds zarf tools kubectl logs -n pepr-system -l app=pepr-uds-core --tail -1 --previous > /tmp/pepr-previous-logs.log || true
-        uds zarf tools kubectl logs -n pepr-system -l app=pepr-uds-core-watcher --tail -1 > /tmp/pepr-watcher-logs.log
-        uds zarf tools kubectl logs -n pepr-system -l app=pepr-uds-core-watcher --tail -1 --previous > /tmp/pepr-watcher-previous-logs.log || true
-        echo "::endgroup::"
-        echo "::group::Describe Failed Packages"
-        FAILED_PACKAGES=($(uds zarf tools kubectl get package -A -o jsonpath="{range .items[?(@.status.phase!='Ready')]}{.metadata.name}{','}{.metadata.namespace}{'\n'}{end}")); for PACKAGE in "${FAILED_PACKAGES[@]}"; do PACKAGE_NAME=$(echo "$PACKAGE" | awk -F "," '{print $1}'); PACKAGE_NAMESPACE=$(echo "$PACKAGE" | awk -F "," '{print $2}'); uds zarf tools kubectl describe package "$PACKAGE_NAME" -n "$PACKAGE_NAMESPACE"; echo; done
-        echo "::endgroup::"
-      shell: bash
-
-    - name: Keycloak Debug
-      if: ${{ inputs.distro != 'k3d' }}
-      run: |
-        echo "::group::Fetch Keycloak logs"
-        uds zarf tools kubectl logs sts/keycloak -n keycloak --tail -1 > /tmp/keycloak-logs.log
-        uds zarf tools kubectl logs sts/keycloak -n keycloak --tail -1 --previous > /tmp/keycloak-previous-logs.log || true
+        echo "::group::Collecting logs for all pods"
+        mkdir -p /tmp/pod-logs
+        # Loop over all pods and grab current and previous logs (8x parallel processes for efficiency)
+        uds zarf tools kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
+          | xargs -P 8 -n 2 bash -c '
+            ns="$1"; pod="$2"
+            base="/tmp/pod-logs/${ns}-${pod}"
+            uds zarf tools kubectl logs -n "$ns" "$pod" --tail=-1 > "${base}.log" 2>&1 || true
+            uds zarf tools kubectl logs -n "$ns" "$pod" --previous --tail=-1 > "${base}-previous.log" 2>&1 || true
+          ' _
         echo "::endgroup::"
       shell: bash
 
@@ -87,9 +75,8 @@ runs:
           /tmp/uds-*.log
           /tmp/maru-*.log
           /tmp/debug-*.log
+          /tmp/pod-logs
           /tmp/uds-containerd-logs
           /tmp/k3d-uds-*.log
           /tmp/playwright/output
           /tmp/playwright/reports
-          /tmp/pepr-*.log
-          /tmp/keycloak-*.log

--- a/.github/test-infra/azure/aks/storage.tf
+++ b/.github/test-infra/azure/aks/storage.tf
@@ -16,14 +16,14 @@ resource "azurerm_storage_account" "cluster_storage" {
 # Create the container for Velero
 resource "azurerm_storage_container" "velero_container" {
   name                  = "velero"
-  storage_account_name  = azurerm_storage_account.cluster_storage.name
+  storage_account_id    = azurerm_storage_account.cluster_storage.id
   container_access_type = "private"
 }
 
 # Create the container for loki
 resource "azurerm_storage_container" "loki_container" {
   name                  = "loki"
-  storage_account_name  = azurerm_storage_account.cluster_storage.name
+  storage_account_id    = azurerm_storage_account.cluster_storage.id
   container_access_type = "private"
 }
 

--- a/tasks/iac.yaml
+++ b/tasks/iac.yaml
@@ -90,9 +90,13 @@ tasks:
               -backend-config="resource_group_name=$RESOURCE_GROUP_NAME" \
               -backend-config="storage_account_name=$STORAGE_ACCOUNT_NAME" \
               -backend-config="container_name=$CONTAINER_NAME" \
-              -backend-config="key=${STATE_KEY}"
+              -backend-config="key=${STATE_KEY}" \
+              -backend-config="environment=usgovernment" \
+              -backend-config="use_azuread_auth=true"
           else
-            echo "Invalid cloud provider specified."; return 1; fi
+            echo "Invalid cloud provider specified."
+            return 1
+          fi
         dir: .github/test-infra/${CLOUD}/${K8S_DISTRO}
       - cmd: tofu apply -auto-approve
         dir: .github/test-infra/${CLOUD}/${K8S_DISTRO}

--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -49,7 +49,7 @@ tasks:
             name: coredns-custom
             namespace: kube-system
           EOF
-            uds zarf tools kubectl -n kube-system rollout restart deployment coredns
+          uds zarf tools kubectl -n kube-system rollout restart deployment coredns
 
   - name: eks-storageclass-setup
     actions:


### PR DESCRIPTION
## Description

Changes:
- adds `kubectl top` output to debug
- enable playwright artifact collection on IAC runs
- adds collection of all pod logs to IAC save-logs, using parallel `kubectl logs`
- updates AKS terraform to fix deprecated values + add missing init values (only needed during re-init but helpful for local dev)