### PR TITLE
fix: downgrade k8s-sidecar to 1.30.9

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -119,6 +119,14 @@
         "registry1.dso.mil/ironbank/opensource/falcosecurity/falcosidekick"
       ],
       "allowedVersions": "!/99.99.99/"
+    },
+    {
+      "matchPackageNames": [
+        "registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar",
+        "quay.io/rfcurated/k8s-sidecar",
+        "ghcr.io/kiwigrid/k8s-sidecar"
+      ],
+      "allowedVersions": "!/^(1\\.30\\.(1[0-9]|[2-9][0-9])|2\\.[01]\\.[0-4])/"
     }
   ]
 }

--- a/src/grafana/values/registry1-values.yaml
+++ b/src/grafana/values/registry1-values.yaml
@@ -21,4 +21,4 @@ sidecar:
   image:
     registry: registry1.dso.mil
     repository: ironbank/kiwigrid/k8s-sidecar
-    tag: 2.1.4
+    tag: 1.30.9

--- a/src/grafana/values/unicorn-values.yaml
+++ b/src/grafana/values/unicorn-values.yaml
@@ -20,5 +20,5 @@ downloadDashboardsImage:
 sidecar:
   image:
     registry: quay.io
-    repository: rfcurated/kiwigrid/k8s-sidecar
-    tag: 2.1.4-jammy-scratch-fips-rfcurated-rfhardened
+    repository: rfcurated/k8s-sidecar
+    tag: 1.30.9-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/grafana/values/upstream-values.yaml
+++ b/src/grafana/values/upstream-values.yaml
@@ -6,7 +6,7 @@ sidecar:
     # -- The Docker registry
     registry: ghcr.io
     repository: kiwigrid/k8s-sidecar
-    tag: 2.1.4
+    tag: 1.30.9
 
 image:
   registry: docker.io

--- a/src/grafana/zarf.yaml
+++ b/src/grafana/zarf.yaml
@@ -34,7 +34,7 @@ components:
       - docker.io/grafana/grafana:12.3.0
       - docker.io/curlimages/curl:8.17.0
       - docker.io/library/busybox:1.37.0
-      - ghcr.io/kiwigrid/k8s-sidecar:2.1.4
+      - ghcr.io/kiwigrid/k8s-sidecar:1.30.9
 
   - name: grafana
     required: true
@@ -49,7 +49,7 @@ components:
     images:
       - registry1.dso.mil/ironbank/opensource/grafana/grafana:12.3.0
       - registry1.dso.mil/ironbank/redhat/ubi/ubi9-minimal:9.7
-      - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:2.1.4
+      - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.30.9
 
   - name: grafana
     required: true
@@ -65,4 +65,4 @@ components:
       - quay.io/rfcurated/grafana:12.3.0-jammy-scratch-fips-rfcurated
       - quay.io/rfcurated/busybox:1.37.0-musl-rf.1-fips-rfcurated
       - quay.io/rfcurated/curl:8.17.0-jammy-scratch-fips-rfcurated
-      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.1.4-jammy-scratch-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/k8s-sidecar:1.30.9-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/loki/values/registry1-values.yaml
+++ b/src/loki/values/registry1-values.yaml
@@ -31,4 +31,4 @@ memcached:
 sidecar:
   image:
     repository: registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar
-    tag: 1.30.10
+    tag: 1.30.9

--- a/src/loki/values/unicorn-values.yaml
+++ b/src/loki/values/unicorn-values.yaml
@@ -18,4 +18,4 @@ memcached:
 sidecar:
   image:
     repository: quay.io/rfcurated/k8s-sidecar
-    tag: 1.30.10-jammy-scratch-fips-rfcurated-rfhardened
+    tag: 1.30.9-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/loki/values/upstream-values.yaml
+++ b/src/loki/values/upstream-values.yaml
@@ -22,4 +22,4 @@ memcached:
 sidecar:
   image:
     repository: ghcr.io/kiwigrid/k8s-sidecar
-    tag: 1.30.10
+    tag: 1.30.9

--- a/src/loki/zarf.yaml
+++ b/src/loki/zarf.yaml
@@ -28,7 +28,7 @@ components:
       - docker.io/grafana/loki:3.5.8
       - docker.io/nginxinc/nginx-unprivileged:1.29-alpine
       - docker.io/memcached:1.6.39-alpine
-      - ghcr.io/kiwigrid/k8s-sidecar:1.30.10
+      - ghcr.io/kiwigrid/k8s-sidecar:1.30.9
 
   - name: loki
     required: true
@@ -45,7 +45,7 @@ components:
       - registry1.dso.mil/ironbank/opensource/grafana/loki:3.5.8
       - registry1.dso.mil/ironbank/opensource/nginx/nginx-alpine:1.29.3
       - registry1.dso.mil/ironbank/opensource/memcached/memcached:1.6.39
-      - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.30.10
+      - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.30.9
 
   - name: loki
     required: true
@@ -62,4 +62,4 @@ components:
       - quay.io/rfcurated/grafana/loki:3.5.8-jammy-fips-rfcurated-rfhardened
       - quay.io/rfcurated/nginx:1.29.3-slim-jammy-fips-rfcurated-rfhardened
       - quay.io/rfcurated/memcached:1.6.39-jammy-fips-rfcurated-rfhardened
-      - quay.io/rfcurated/k8s-sidecar:1.30.10-jammy-scratch-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/k8s-sidecar:1.30.9-jammy-scratch-fips-rfcurated-rfhardened


### PR DESCRIPTION
## Description

k8s-sidecar had releases for [1.30.10 ](https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.30.10)and [1.30.11 ](https://github.com/kiwigrid/k8s-sidecar/releases/tag/1.30.11)yanked due to instability.

And there are multiple issues that prevent us from upgrade to 2.X.X (2.0.0 - 2.1.4) versions:
- [High memory usage issue](https://github.com/kiwigrid/k8s-sidecar/issues/462)
  - tested 2.1.4 locally and saw memory usage jump from 60MiB to ~270MiB which is not ideal
- [tmp directory mount issue affecting loki chart](https://github.com/kiwigrid/k8s-sidecar/issues/427)
  - This will be fixed in https://github.com/grafana/loki/pull/19759
  - We could use pepr to mutate this until that is merged in, but the high memory usage is a reason to not bump to any of the 2.0.0-2.1.4 versions

Updates the renovate config to skip these bad versions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run` (we hopefully shouldn't see flakiness in the loki ruler integration tests now)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed