### PR TITLE
feat: automount uds trust bundle to keycloak/grafana

### DIFF
--- a/bundles/k3d-standard/uds-private-pki-config.yaml
+++ b/bundles/k3d-standard/uds-private-pki-config.yaml
@@ -15,23 +15,3 @@ variables:
     # Tenant Gateway TLS certificate and key
     TENANT_TLS_CERT: "PLACEHOLDER_TENANT_TLS_CERT"
     TENANT_TLS_KEY: "PLACEHOLDER_TENANT_TLS_KEY"
-
-    # Grafana private PKI configuration
-    GRAFANA_EXTRA_CONFIGMAP_MOUNTS:
-      - name: ca-certs
-        mountPath: /etc/ssl/certs/ca.pem
-        configMap: uds-trust-bundle
-        readOnly: true
-        subPath: ca-bundle.pem
-
-    # Keycloak private PKI configuration
-    KEYCLOAK_EXTRA_VOLUME_MOUNTS:
-      - name: ca-certs
-        mountPath: /tmp/ca-certs
-        readOnly: true
-    KEYCLOAK_EXTRA_VOLUMES:
-      - name: ca-certs
-        configMap:
-          name: uds-trust-bundle
-    KEYCLOAK_TRUSTSTORE_PATHS:
-      - "/tmp/ca-certs"

--- a/docs/reference/configuration/trust-management/private-pki.md
+++ b/docs/reference/configuration/trust-management/private-pki.md
@@ -78,7 +78,7 @@ Many Go-based applications automatically check `/etc/ssl/certs/ca.pem` for addit
 
 Authservice can be configured with an additional trusted CA bundle when UDS Core ingress gateways are deployed with private PKI.
 
-To configure, set `UDS_CA_CERT` as an environment variable with a Base64 encoded PEM formatted CA bundle that can be used to verify the certificates of the tenant gateway.
+To configure, set `UDS_CA_BUNDLE_CERTS` as an environment variable with a Base64 encoded PEM formatted CA bundle that can be used to verify the certificates of the tenant gateway.
 
 See [trusted CA SSO doc](/reference/configuration/single-sign-on/trusted-ca) for complete Authservice configuration details.
 
@@ -86,25 +86,7 @@ See [trusted CA SSO doc](/reference/configuration/single-sign-on/trusted-ca) for
 
 Grafana may need to access external https services.  If these services use certificates signed by a private CA, Grafana needs to be configured to trust these certificates.
 
-Configure Grafana to trust private certificates by mounting the CA bundle via UDS Bundle overrides:
-
-```yaml
-values:
-  - path: extraConfigmapMounts
-    value:
-      - name: ca-certs
-        mountPath: /etc/ssl/certs/ca.pem # Adds CA alongside system CAs (Go applications)
-        # Alternative - System CA replacement (requires bundle with both private and public CAs):
-        # mountPath: /etc/ssl/certs/ca-certificates.crt # For Debian/Ubuntu images (upstream, unicorn flavors)
-        # mountPath: /etc/pki/tls/certs/ca-bundle.crt # For RedHat-based images (registry1 flavor)
-        configMap: private-ca
-        readOnly: true
-        subPath: ca.pem
-```
-
-:::caution
-Mounting to system CA paths (`/etc/ssl/certs/ca-certificates.crt` or `/etc/pki/tls/certs/ca-bundle.crt`) replaces the system CA bundle. Ensure your CA bundle includes both your private CA certificates and any public CAs that Grafana needs to trust.
-:::
+By default, UDS Core will automatically mount private certificates (and DoD Certs if `UDS_CA_BUNDLE_INCLUDE_DOD_CERTS` is `true`) provided by `UDS_CA_BUNDLE_CERTS` so that Grafana will trust them. This uses the default UDS trust bundle created by the UDS Operator and is mounted at `/etc/ssl/certs/ca.pem`.
 
 For additional details on Grafana private CA configuration, see the [upstream Grafana documentation](https://grafana.com/docs/grafana/latest/setup-grafana/installation/helm/#configure-a-private-ca-certificate-authority).
 
@@ -165,28 +147,8 @@ Mounting to system CA paths replaces the system CA bundle for all Loki component
 
 ### Keycloak
 
-Keycloak needs to validate certificates when connecting to external identity providers or LDAP servers. Configure Keycloak to trust private certificates using additional truststore paths:
+Keycloak needs to validate certificates when connecting to external identity providers or LDAP servers.
 
-```yaml
-values:
-  - path: extraVolumeMounts
-    value:
-      - name: ca-certs
-        mountPath: /tmp/ca-certs
-        readOnly: true
-  - path: extraVolumes
-    value:
-      - name: ca-certs
-        configMap:
-          name: private-ca
-  - path: truststorePaths
-    value:
-      - "/tmp/ca-certs"
-```
-
-This configuration:
-- Mounts your private CA ConfigMap to `/tmp/ca-certs`
-- Configures Keycloak to scan this directory using the `--truststore-paths` startup argument
-- Preserves Keycloak's default truststore while adding your private certificates
+By default, UDS Core will automatically mount private certificates (and DoD Certs if `UDS_CA_BUNDLE_INCLUDE_DOD_CERTS` is `true`) provided by `UDS_CA_BUNDLE_CERTS` so that Keycloak will trust them. This uses the default UDS trust bundle created by the UDS Operator and is mounted at `/tmp/ca-certs` with the truststore path configured automatically.
 
 For additional details on Keycloak truststore configuration, see the [upstream Keycloak documentation](https://www.keycloak.org/server/keycloak-truststore#_configuring_the_system_truststore).

--- a/docs/reference/configuration/trust-management/private-pki.md
+++ b/docs/reference/configuration/trust-management/private-pki.md
@@ -156,7 +156,7 @@ Keycloak needs to validate certificates when connecting to external identity pro
 By default, UDS Core will automatically mount private certificates (and DoD Certs if `UDS_CA_BUNDLE_INCLUDE_DOD_CERTS` is `true`) provided by `UDS_CA_BUNDLE_CERTS` so that Keycloak will trust them. This uses the default UDS trust bundle created by the UDS Operator and is mounted at `/tmp/ca-certs` with the truststore path configured automatically.
 
 :::caution
-If override the Keycloak helm values for `extraVolumes`, `extraVolumeMounts`, or `truststorePaths`, these will override the default values and the automatic trust bundle mounting will **not** occur. In this case, you must either merge your custom mounts with the new defaults or rely solely on the automatic mounting. Be sure to review your configuration to ensure Keycloak trusts the intended certificate authorities.
+If you override the Keycloak helm values for `extraVolumes`, `extraVolumeMounts`, or `truststorePaths`, these will override the default values and the automatic trust bundle mounting will **not** occur. In this case, you must either merge your custom mounts with the new defaults or rely solely on the automatic mounting. Be sure to review your configuration to ensure Keycloak trusts the intended certificate authorities.
 :::
 
 For additional details on Keycloak truststore configuration, see the [upstream Keycloak documentation](https://www.keycloak.org/server/keycloak-truststore#_configuring_the_system_truststore).

--- a/docs/reference/configuration/trust-management/private-pki.md
+++ b/docs/reference/configuration/trust-management/private-pki.md
@@ -88,6 +88,10 @@ Grafana may need to access external https services.  If these services use certi
 
 By default, UDS Core will automatically mount private certificates (and DoD Certs if `UDS_CA_BUNDLE_INCLUDE_DOD_CERTS` is `true`) provided by `UDS_CA_BUNDLE_CERTS` so that Grafana will trust them. This uses the default UDS trust bundle created by the UDS Operator and is mounted at `/etc/ssl/certs/ca.pem`.
 
+:::caution
+If you override the Grafana helm values for `extraConfigmapMounts`, these will override the default values and the automatic trust bundle mounting will **not** occur. In this case, you must either merge your custom mounts with the new defaults or rely solely on the automatic mounting. Be sure to review your configuration to ensure Grafana trusts the intended certificate authorities.
+:::
+
 For additional details on Grafana private CA configuration, see the [upstream Grafana documentation](https://grafana.com/docs/grafana/latest/setup-grafana/installation/helm/#configure-a-private-ca-certificate-authority).
 
 ### Velero
@@ -150,5 +154,9 @@ Mounting to system CA paths replaces the system CA bundle for all Loki component
 Keycloak needs to validate certificates when connecting to external identity providers or LDAP servers.
 
 By default, UDS Core will automatically mount private certificates (and DoD Certs if `UDS_CA_BUNDLE_INCLUDE_DOD_CERTS` is `true`) provided by `UDS_CA_BUNDLE_CERTS` so that Keycloak will trust them. This uses the default UDS trust bundle created by the UDS Operator and is mounted at `/tmp/ca-certs` with the truststore path configured automatically.
+
+:::caution
+If override the Keycloak helm values for `extraVolumes`, `extraVolumeMounts`, or `truststorePaths`, these will override the default values and the automatic trust bundle mounting will **not** occur. In this case, you must either merge your custom mounts with the new defaults or rely solely on the automatic mounting. Be sure to review your configuration to ensure Keycloak trusts the intended certificate authorities.
+:::
 
 For additional details on Keycloak truststore configuration, see the [upstream Keycloak documentation](https://www.keycloak.org/server/keycloak-truststore#_configuring_the_system_truststore).

--- a/docs/reference/configuration/trust-management/private-pki.md
+++ b/docs/reference/configuration/trust-management/private-pki.md
@@ -92,6 +92,22 @@ By default, UDS Core will automatically mount private certificates (and DoD Cert
 If you override the Grafana helm values for `extraConfigmapMounts`, these will override the default values and the automatic trust bundle mounting will **not** occur. In this case, you must either merge your custom mounts with the new defaults or rely solely on the automatic mounting. Be sure to review your configuration to ensure Grafana trusts the intended certificate authorities.
 :::
 
+If you wish to not use the automatic mounting, you can manually configure Grafana to trust private certificates by mounting the CA bundle via UDS Bundle overrides:
+
+```yaml
+values:
+  - path: extraConfigmapMounts
+    value:
+      - name: ca-certs
+        mountPath: /etc/ssl/certs/ca.pem # Adds CA alongside system CAs (Go applications)
+        # Alternative - System CA replacement (requires bundle with both private and public CAs):
+        # mountPath: /etc/ssl/certs/ca-certificates.crt # For Debian/Ubuntu images (upstream, unicorn flavors)
+        # mountPath: /etc/pki/tls/certs/ca-bundle.crt # For RedHat-based images (registry1 flavor)
+        configMap: private-ca
+        readOnly: true
+        subPath: ca.pem
+```
+
 For additional details on Grafana private CA configuration, see the [upstream Grafana documentation](https://grafana.com/docs/grafana/latest/setup-grafana/installation/helm/#configure-a-private-ca-certificate-authority).
 
 ### Velero
@@ -158,5 +174,24 @@ By default, UDS Core will automatically mount private certificates (and DoD Cert
 :::caution
 If you override the Keycloak helm values for `extraVolumes`, `extraVolumeMounts`, or `truststorePaths`, these will override the default values and the automatic trust bundle mounting will **not** occur. In this case, you must either merge your custom mounts with the new defaults or rely solely on the automatic mounting. Be sure to review your configuration to ensure Keycloak trusts the intended certificate authorities.
 :::
+
+If you wish to not use the automatic mounting, you can manually configure Keycloak to trust private certificates by mounting the CA bundle via UDS Bundle overrides:
+
+```yaml
+values:
+  - path: extraVolumeMounts
+    value:
+      - name: ca-certs
+        mountPath: /tmp/ca-certs
+        readOnly: true
+  - path: extraVolumes
+    value:
+      - name: ca-certs
+        configMap:
+          name: private-ca
+  - path: truststorePaths
+    value:
+      - "/tmp/ca-certs"
+```
 
 For additional details on Keycloak truststore configuration, see the [upstream Keycloak documentation](https://www.keycloak.org/server/keycloak-truststore#_configuring_the_system_truststore).

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -17,6 +17,14 @@ extraSecretMounts:
     mountPath: /etc/secrets/auth_generic_oauth
     readOnly: true
 
+extraConfigmapMounts:
+  - name: ca-certs
+    mountPath: /etc/ssl/certs/ca.pem
+    configMap: uds-trust-bundle
+    readOnly: true
+    subPath: ca-bundle.pem
+    optional: true
+
 grafana.ini:
   server:
     root_url: https://grafana.{{ "###ZARF_VAR_ADMIN_DOMAIN###" | default "admin.###ZARF_VAR_DOMAIN###" }}

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -416,14 +416,25 @@ thirdPartyIntegration:
     tlsCertificateFormat: PEM
 
 # Extra volumes to mount in the StatefulSet
-extraVolumes: []
+extraVolumes:
+  # Mount the default UDS trust bundle created by the UDS Operator
+  - name: ca-certs
+    configMap:
+      name: uds-trust-bundle
+      optional: true
 
 # Extra volume mounts to mount in the Keycloak container
-extraVolumeMounts: []
+extraVolumeMounts:
+  # Mount the default UDS trust bundle for CA certificate access
+  - name: ca-certs
+    mountPath: /tmp/ca-certs
+    readOnly: true
 
 # Additional truststore paths for Keycloak to scan for certificates
 # These paths will be added to the --truststore-paths startup argument
-truststorePaths: []
+truststorePaths:
+  # Default path for UDS trust bundle certificates
+  - "/tmp/ca-certs"
 
 # Detailed observability settings (Dashboards, Alerts, etc)
 # @lulaStart e4ea044c-75fc-4acc-a552-8bba2aab1b12


### PR DESCRIPTION
## Description

Adds optional ConfigMap mounts to Grafana and Keycloak so that if UDS Trust Bundle Exists it is automatically gets mounted and added to the trusted certs for the application.

Note: Users who were providing UDS Bundle Helm Overrides to mount private certs should now be able to remove these overrides (if they are properly passing in their Private PKI Certs with `CA_BUNDLE_CERTS`).

## Related Issue

Fixes #2203 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run -f tasks/test.yaml uds-core-private-pki`
  - can also confirm that the mounted certs exist in the grafana (`/etc/ssl/certs/ca.pem`) and keycloak (`/tmp/ca-certs`) pods

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed