### PR TITLE
chore: add logging on watch events for admission watches

### DIFF
--- a/src/pepr/operator/controllers/config/config.ts
+++ b/src/pepr/operator/controllers/config/config.ts
@@ -552,7 +552,7 @@ export async function startConfigWatch() {
     }, watchCfg);
     // This will run until the process is terminated or the watch is aborted
     configLog.debug("Starting cluster config watch...");
-    registerWatchEventHandlers(watcher, configLog);
+    registerWatchEventHandlers(watcher, configLog, "ClusterConfig");
     await watcher.start();
   }
 }

--- a/src/pepr/operator/controllers/config/config.ts
+++ b/src/pepr/operator/controllers/config/config.ts
@@ -8,13 +8,13 @@ import { K8s, kind } from "pepr";
 import { Component, setupLogger } from "../../../logger";
 import { ClusterConfig, ConfigCABundle, ConfigPhase as Phase } from "../../crd";
 import { validateCfg } from "../../crd/validators/clusterconfig-validator";
+import { updateAllCaBundleConfigMaps } from "../ca-bundles/ca-bundle";
 import { reconcileAuthservice } from "../keycloak/authservice/authservice";
 import { Action, AuthServiceEvent } from "../keycloak/authservice/types";
 import { initAPIServerCIDR } from "../network/generators/kubeAPI";
 import { initAllNodesTarget } from "../network/generators/kubeNodes";
-import { watchCfg } from "../utils";
+import { registerWatchEventHandlers, watchCfg } from "../utils";
 import { Config } from "./types";
-import { updateAllCaBundleConfigMaps } from "../ca-bundles/ca-bundle";
 
 export const configLog = setupLogger(Component.OPERATOR_CONFIG);
 
@@ -552,6 +552,7 @@ export async function startConfigWatch() {
     }, watchCfg);
     // This will run until the process is terminated or the watch is aborted
     configLog.debug("Starting cluster config watch...");
+    registerWatchEventHandlers(watcher, configLog);
     await watcher.start();
   }
 }

--- a/src/pepr/operator/controllers/istio/ambient-waypoint.ts
+++ b/src/pepr/operator/controllers/istio/ambient-waypoint.ts
@@ -289,9 +289,15 @@ export async function reconcilePod(pod: a.Pod): Promise<void> {
     [ISTIO_WAYPOINT_LABEL]: waypointName,
   };
 
+  const podDisplayName = pod.metadata?.name || pod.metadata?.generateName || "<unknown name>";
+
   log.info(
-    { namespace, waypointName, clientId: matchingSso.clientId },
-    `Added waypoint labels to pod ${pod.metadata?.name}`,
+    {
+      namespace,
+      waypointName,
+      clientId: matchingSso.clientId,
+    },
+    `Added waypoint labels to pod ${podDisplayName}`,
   );
 }
 

--- a/src/pepr/operator/controllers/packages/packages.ts
+++ b/src/pepr/operator/controllers/packages/packages.ts
@@ -35,7 +35,7 @@ export async function startPackageWatch() {
     }, watchCfg);
     // This will run until the process is terminated or the watch is aborted
     log.debug("Starting package watch...");
-    registerWatchEventHandlers(watcher, log);
+    registerWatchEventHandlers(watcher, log, "UDSPackage");
     await watcher.start();
   }
 }

--- a/src/pepr/operator/controllers/packages/packages.ts
+++ b/src/pepr/operator/controllers/packages/packages.ts
@@ -7,7 +7,7 @@ import { WatchPhase } from "kubernetes-fluent-client/dist/fluent/shared-types";
 import { K8s } from "pepr";
 import { Component, setupLogger } from "../../../logger";
 import { UDSPackage } from "../../crd";
-import { watchCfg } from "../utils";
+import { registerWatchEventHandlers, watchCfg } from "../utils";
 import { PackageStore } from "./package-store";
 /**
  * Processes exemptions based on the watch phase.
@@ -35,6 +35,7 @@ export async function startPackageWatch() {
     }, watchCfg);
     // This will run until the process is terminated or the watch is aborted
     log.debug("Starting package watch...");
+    registerWatchEventHandlers(watcher, log);
     await watcher.start();
   }
 }

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -33,25 +33,30 @@ export const watchCfg: WatchCfg = {
     : 600,
 };
 
-export function registerWatchEventHandlers(watcher: WatcherType<GenericClass>, log: Logger) {
+export function registerWatchEventHandlers(
+  watcher: WatcherType<GenericClass>,
+  log: Logger,
+  watchName: string,
+) {
   const eventHandlers: {
     [K in WatchEvent]?: (arg: WatchEventArgs<K, GenericClass>) => void;
   } = {
     [WatchEvent.GIVE_UP]: err => {
       // If failure continues, log and exit
       log.error(
-        `WatchEvent GiveUp Error: The watch has failed to start after several attempts: ${err.message}`,
+        `WatchEvent GiveUp (${watchName}): The watch has failed to start after several attempts: ${err.message}`,
       );
       process.exit(1);
     },
-    [WatchEvent.DATA_ERROR]: err => log.warn(`WatchEvent DataError Error: ${err.message}`),
+    [WatchEvent.DATA_ERROR]: err => log.warn(`WatchEvent DataError (${watchName}): ${err.message}`),
     [WatchEvent.RECONNECT]: retryCount =>
       log.debug(
-        `WatchEvent Reconnect: Reconnecting watch ${watcher} after ${retryCount} attempt${retryCount === 1 ? "" : "s"}`,
+        `WatchEvent Reconnect (${watchName}): Reconnecting watch after ${retryCount} attempt${retryCount === 1 ? "" : "s"}`,
       ),
-    [WatchEvent.ABORT]: err => log.warn(`WatchEvent Abort: ${err.message}`),
-    [WatchEvent.NETWORK_ERROR]: err => log.warn(`WatchEvent NetworkError: ${err.message}`),
-    [WatchEvent.LIST_ERROR]: err => log.warn(`WatchEvent ListError: ${err.message}`),
+    [WatchEvent.ABORT]: err => log.warn(`WatchEvent Abort (${watchName}): ${err.message}`),
+    [WatchEvent.NETWORK_ERROR]: err =>
+      log.warn(`WatchEvent NetworkError (${watchName}): ${err.message}`),
+    [WatchEvent.LIST_ERROR]: err => log.warn(`WatchEvent ListError (${watchName}): ${err.message}`),
   };
   Object.entries(eventHandlers).forEach(([event, handler]) => {
     watcher.events.on(event, handler);

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -4,8 +4,10 @@
  */
 
 import { V1OwnerReference } from "@kubernetes/client-node";
-import { GenericClass, GenericKind, WatchCfg } from "kubernetes-fluent-client";
+import { GenericClass, GenericKind, WatchCfg, WatchEvent } from "kubernetes-fluent-client";
+import { WatcherType } from "kubernetes-fluent-client/dist/fluent/types";
 import { K8s, kind } from "pepr";
+import { WatchEventArgs } from "pepr/dist/lib/processors/watch-processor";
 import { Logger } from "pino";
 import { UDSPackage } from "../crd";
 
@@ -30,6 +32,31 @@ export const watchCfg: WatchCfg = {
     ? parseInt(process.env.PEPR_RELIST_INTERVAL_SECONDS, 10)
     : 600,
 };
+
+export function registerWatchEventHandlers(watcher: WatcherType<GenericClass>, log: Logger) {
+  const eventHandlers: {
+    [K in WatchEvent]?: (arg: WatchEventArgs<K, GenericClass>) => void;
+  } = {
+    [WatchEvent.GIVE_UP]: err => {
+      // If failure continues, log and exit
+      log.error(
+        `WatchEvent GiveUp Error: The watch has failed to start after several attempts: ${err.message}`,
+      );
+      process.exit(1);
+    },
+    [WatchEvent.DATA_ERROR]: err => log.warn(`WatchEvent DataError Error: ${err.message}`),
+    [WatchEvent.RECONNECT]: retryCount =>
+      log.debug(
+        `WatchEvent Reconnect: Reconnecting watch ${watcher} after ${retryCount} attempt${retryCount === 1 ? "" : "s"}`,
+      ),
+    [WatchEvent.ABORT]: err => log.warn(`WatchEvent Abort: ${err.message}`),
+    [WatchEvent.NETWORK_ERROR]: err => log.warn(`WatchEvent NetworkError: ${err.message}`),
+    [WatchEvent.LIST_ERROR]: err => log.warn(`WatchEvent ListError: ${err.message}`),
+  };
+  Object.entries(eventHandlers).forEach(([event, handler]) => {
+    watcher.events.on(event, handler);
+  });
+}
 
 /**
  * Sanitize a resource name to make it a valid Kubernetes resource name.

--- a/src/pepr/policies/index.ts
+++ b/src/pepr/policies/index.ts
@@ -36,7 +36,7 @@ export async function startExemptionWatch() {
 
     // This will run until the process is terminated or the watch is aborted
     log.debug("Starting exemption watch...");
-    registerWatchEventHandlers(watcher, log);
+    registerWatchEventHandlers(watcher, log, "UDSExemption");
     await watcher.start();
   }
 }

--- a/src/pepr/policies/index.ts
+++ b/src/pepr/policies/index.ts
@@ -8,7 +8,7 @@ import { K8s } from "pepr";
 import { Component, setupLogger } from "../logger";
 import { ExemptionStore } from "../operator/controllers/exemptions/exemption-store";
 import { processExemptions } from "../operator/controllers/exemptions/exemptions";
-import { watchCfg } from "../operator/controllers/utils";
+import { registerWatchEventHandlers, watchCfg } from "../operator/controllers/utils";
 import { Matcher, Policy, UDSExemption } from "../operator/crd";
 import "./istio";
 import "./networking";
@@ -36,6 +36,7 @@ export async function startExemptionWatch() {
 
     // This will run until the process is terminated or the watch is aborted
     log.debug("Starting exemption watch...");
+    registerWatchEventHandlers(watcher, log);
     await watcher.start();
   }
 }


### PR DESCRIPTION
## Description

Nightly CI has indicated potential rate limiting on watches in AKS, this adds watch event handling (logging, crashing on giveup).

Also while reviewing some logs I noticed our pod mutation was logging empty/undefined pod names, since pods generally don't have a name when going through mutation (if controlled by a replicaset). I updated that logging to use `generateName` if set.

## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/issues/2021

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)
