### PR TITLE
fix: downgrade k8s-sidecar for Grafana to 1.30.10, pin helm unittest install

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -49,7 +49,7 @@ runs:
     - name: Install helm unittest plugin
       shell: bash
       # renovate: datasource=github-tags depName=helm-unittest/helm-unittest versioning=semver
-      run: HELM_UNITTEST_VERSION=v1.0.3 helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "$HELM_UNITTEST_VERSION"
+      run: export HELM_UNITTEST_VERSION="v1.0.2" && helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "${HELM_UNITTEST_VERSION}"
 
     - name: Iron Bank Login
       if: ${{ inputs.registry1Username != '' }}

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -49,7 +49,7 @@ runs:
     - name: Install helm unittest plugin
       shell: bash
       # renovate: datasource=github-tags depName=helm-unittest/helm-unittest versioning=semver
-      run: export HELM_UNITTEST_VERSION="v1.0.2" && helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "${HELM_UNITTEST_VERSION}"
+      run: export HELM_UNITTEST_VERSION="v1.0.3" && helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "${HELM_UNITTEST_VERSION}"
 
     - name: Iron Bank Login
       if: ${{ inputs.registry1Username != '' }}

--- a/src/grafana/common/zarf.yaml
+++ b/src/grafana/common/zarf.yaml
@@ -19,7 +19,7 @@ components:
           - ../chart/values.yaml
       - name: grafana
         url: https://grafana.github.io/helm-charts/
-        version: 10.3.0
+        version: 10.3.1
         namespace: grafana
         valuesFiles:
           - ../values/values.yaml

--- a/src/grafana/values/registry1-values.yaml
+++ b/src/grafana/values/registry1-values.yaml
@@ -21,4 +21,4 @@ sidecar:
   image:
     registry: registry1.dso.mil
     repository: ironbank/kiwigrid/k8s-sidecar
-    tag: 2.1.4
+    tag: 1.30.10

--- a/src/grafana/values/unicorn-values.yaml
+++ b/src/grafana/values/unicorn-values.yaml
@@ -21,4 +21,4 @@ sidecar:
   image:
     registry: quay.io
     repository: rfcurated/kiwigrid/k8s-sidecar
-    tag: 2.1.4-jammy-scratch-fips-rfcurated-rfhardened
+    tag: 1.30.10-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/grafana/values/upstream-values.yaml
+++ b/src/grafana/values/upstream-values.yaml
@@ -6,7 +6,7 @@ sidecar:
     # -- The Docker registry
     registry: ghcr.io
     repository: kiwigrid/k8s-sidecar
-    tag: 2.1.4
+    tag: 1.30.10
 
 image:
   registry: docker.io

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -69,6 +69,7 @@ grafana.ini:
     query_retries: 5
     transaction_retries: 5
     log_queries: true
+    skip_dashboard_uid_migration_on_startup: true
 
 # Add environment variables for PostgresQL connection from uds-config chart
 envFromSecret: "uds-grafana-config-postgresql"

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -66,8 +66,6 @@ grafana.ini:
   # Settings to optimize the internal sqlite DB
   database:
     wal: true
-  log:
-    level: "debug"
 
 # Add environment variables for PostgresQL connection from uds-config chart
 envFromSecret: "uds-grafana-config-postgresql"

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -63,8 +63,11 @@ grafana.ini:
     # @lulaEnd 58c54d48-11e4-422e-b386-ae61acfb2828
     # Automatically redirect to the SSO login page
     auto_login: true
+  # Settings to optimize the internal sqlite DB
   database:
     wal: true
+    query_retries: 5
+    transaction_retries: 5
 
 # Add environment variables for PostgresQL connection from uds-config chart
 envFromSecret: "uds-grafana-config-postgresql"

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -66,10 +66,8 @@ grafana.ini:
   # Settings to optimize the internal sqlite DB
   database:
     wal: true
-    query_retries: 5
-    transaction_retries: 5
-    log_queries: true
-    skip_dashboard_uid_migration_on_startup: true
+  log:
+    level: "debug"
 
 # Add environment variables for PostgresQL connection from uds-config chart
 envFromSecret: "uds-grafana-config-postgresql"

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -63,6 +63,8 @@ grafana.ini:
     # @lulaEnd 58c54d48-11e4-422e-b386-ae61acfb2828
     # Automatically redirect to the SSO login page
     auto_login: true
+  database:
+    wal: true
 
 # Add environment variables for PostgresQL connection from uds-config chart
 envFromSecret: "uds-grafana-config-postgresql"

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -68,6 +68,7 @@ grafana.ini:
     wal: true
     query_retries: 5
     transaction_retries: 5
+    log_queries: true
 
 # Add environment variables for PostgresQL connection from uds-config chart
 envFromSecret: "uds-grafana-config-postgresql"

--- a/src/grafana/zarf.yaml
+++ b/src/grafana/zarf.yaml
@@ -34,7 +34,7 @@ components:
       - docker.io/grafana/grafana:12.3.0
       - docker.io/curlimages/curl:8.17.0
       - docker.io/library/busybox:1.37.0
-      - ghcr.io/kiwigrid/k8s-sidecar:2.1.4
+      - ghcr.io/kiwigrid/k8s-sidecar:1.30.10
 
   - name: grafana
     required: true
@@ -49,7 +49,7 @@ components:
     images:
       - registry1.dso.mil/ironbank/opensource/grafana/grafana:12.3.0
       - registry1.dso.mil/ironbank/redhat/ubi/ubi9-minimal:9.7
-      - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:2.1.4
+      - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.30.10
 
   - name: grafana
     required: true
@@ -65,4 +65,4 @@ components:
       - quay.io/rfcurated/grafana:12.3.0-jammy-scratch-fips-rfcurated
       - quay.io/rfcurated/busybox:1.37.0-musl-rf.1-fips-rfcurated
       - quay.io/rfcurated/curl:8.17.0-jammy-scratch-fips-rfcurated
-      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.1.4-jammy-scratch-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/kiwigrid/k8s-sidecar:1.30.10-jammy-scratch-fips-rfcurated-rfhardened


### PR DESCRIPTION
## Description

This Pull Request fixes the `main` branch build. 

It root cause of the failures (like [this](https://github.com/defenseunicorns/uds-core/actions/runs/20259499091/job/58168267972)) was a combination of two things:

1. The `HELM_UNITTEST_VERSION=v1.0.3 helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "$HELM_UNITTEST_VERSION"` incorrectly propagates the environment variable. At the time of invoking the `helm` command the `$HELM_UNITTEST_VERSION` is undefined. This can be easily illustrated with the following script:

```bash
$ bash
$ set -x
$ TEST=ok true "$TEST"
+ TEST=ok
+ true '' <-- Note that this is empty, it's not "ok"!!!
```

2. The https://github.com/helm-unittest/helm-unittest/issues/790 introduced an incompatible with Helm 3 change which was causing the plugin installation to fail. Originally a previous release (1.0.3) was retagged, but this has since been reverted so that 1.0.3 can be pulled down.

This also includes the helm chart bump for Grafana 10.3.1, resolving [this issue](https://www.github.com/grafana/helm-charts/issues/4039) (this replaces https://github.com/defenseunicorns/uds-core/pull/2206) and [enables the WAL](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#wal) to allow for more seamless upgrades on the internal DB. Finally it downgrades the k8s-sidecar image due to a number of upstream issues with 2.x images.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Verified automatically

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed