### PR TITLE
fix: add wait condition for checkpoint deploy

### DIFF
--- a/packages/checkpoint-dev/zarf.yaml
+++ b/packages/checkpoint-dev/zarf.yaml
@@ -92,5 +92,13 @@ components:
                 --image ghcr.io/defenseunicorns/uds-core/checkpoint:latest ${ZARF_VAR_K3D_EXTRA_ARGS} \
                 ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"
+          # This action waits on Keycloak since it is the slowest pod to start after cluster creation. By waiting on it, we guarantee the cluster is healthy and usable after deployment.
+          - description: Keycloak to be Healthy
+            wait:
+              cluster:
+                kind: Pod
+                name: app.kubernetes.io/name=keycloak
+                namespace: keycloak
+                condition: Ready
         onSuccess:
           - cmd: rm -f uds-checkpoint.tar


### PR DESCRIPTION
## Description

Add a wait condition in the checkpoint deploy after creating the cluster to ensure that everything is healthy.

Waiting on the Keycloak pod(s) matches what we did historically before we had to add scale down/up behavior.

## Related Issue

Related to CI failure in https://github.com/defenseunicorns/uds-common/pull/594

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)