### PR TITLE
chore: update crds for new headers

### DIFF
--- a/src/pepr/operator/crd/generated/clusterconfig-v1alpha1.ts
+++ b/src/pepr/operator/crd/generated/clusterconfig-v1alpha1.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/pepr/operator/crd/generated/exemption-v1alpha1.ts
+++ b/src/pepr/operator/crd/generated/exemption-v1alpha1.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/pepr/operator/crd/generated/package-v1alpha1.ts
+++ b/src/pepr/operator/crd/generated/package-v1alpha1.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/pepr/uds-cluster-crds/templates/clusterconfig.uds.dev.yaml
+++ b/src/pepr/uds-cluster-crds/templates/clusterconfig.uds.dev.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 apiVersion: apiextensions.k8s.io/v1

--- a/src/velero/chart/templates/crds/backuprepositories.yaml
+++ b/src/velero/chart/templates/crds/backuprepositories.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/backups.yaml
+++ b/src/velero/chart/templates/crds/backups.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/backupstoragelocations.yaml
+++ b/src/velero/chart/templates/crds/backupstoragelocations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/datadownloads.yaml
+++ b/src/velero/chart/templates/crds/datadownloads.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/datauploads.yaml
+++ b/src/velero/chart/templates/crds/datauploads.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/deletebackuprequests.yaml
+++ b/src/velero/chart/templates/crds/deletebackuprequests.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/downloadrequests.yaml
+++ b/src/velero/chart/templates/crds/downloadrequests.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/podvolumebackups.yaml
+++ b/src/velero/chart/templates/crds/podvolumebackups.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/podvolumerestores.yaml
+++ b/src/velero/chart/templates/crds/podvolumerestores.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/restores.yaml
+++ b/src/velero/chart/templates/crds/restores.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/schedules.yaml
+++ b/src/velero/chart/templates/crds/schedules.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/serverstatusrequests.yaml
+++ b/src/velero/chart/templates/crds/serverstatusrequests.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---

--- a/src/velero/chart/templates/crds/volumesnapshotlocations.yaml
+++ b/src/velero/chart/templates/crds/volumesnapshotlocations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 ---


### PR DESCRIPTION
## Description
Autogen CI Job is failing because of the SPDX headers needing to be updated for 2026.

For reference, [this is an example of the failure](https://github.com/defenseunicorns/uds-core/actions/runs/20664238924/job/59469387155)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed