### PR TITLE
chore: switch to iso timestamps for pepr logs, redact config log

### DIFF
--- a/src/pepr/operator/controllers/config/config.ts
+++ b/src/pepr/operator/controllers/config/config.ts
@@ -451,7 +451,8 @@ function redactConfig() {
   const authserviceRedisUri = UDSConfig.authserviceRedisUri ? "****" : "";
   const dodCerts = UDSConfig.caBundle.dodCerts ? "****" : "";
   const publicCerts = UDSConfig.caBundle.publicCerts ? "****" : "";
-  const caBundle = { ...UDSConfig.caBundle, dodCerts, publicCerts };
+  const certs = UDSConfig.caBundle.certs ? "****" : "";
+  const caBundle = { ...UDSConfig.caBundle, dodCerts, publicCerts, certs };
   return { ...UDSConfig, authserviceRedisUri, caBundle };
 }
 

--- a/src/pepr/operator/controllers/config/config.ts
+++ b/src/pepr/operator/controllers/config/config.ts
@@ -443,13 +443,16 @@ export async function loadUDSConfig() {
 }
 
 /**
- * Creates a redacted copy of UDS config for logging (hides sensitive values)
+ * Creates a redacted copy of UDS config for logging (hides sensitive or large values)
  *
- * @returns UDS config with sensitive fields replaced with masked values
+ * @returns UDS config with sensitive or large fields replaced with masked values
  */
 function redactConfig() {
   const authserviceRedisUri = UDSConfig.authserviceRedisUri ? "****" : "";
-  return { ...UDSConfig, authserviceRedisUri };
+  const dodCerts = UDSConfig.caBundle.dodCerts ? "****" : "";
+  const publicCerts = UDSConfig.caBundle.publicCerts ? "****" : "";
+  const caBundle = { ...UDSConfig.caBundle, dodCerts, publicCerts };
+  return { ...UDSConfig, authserviceRedisUri, caBundle };
 }
 
 // Helper function to detect if 2 lists of CIDRs are equal, irrespective of order

--- a/src/pepr/values.yaml
+++ b/src/pepr/values.yaml
@@ -11,6 +11,8 @@ watcher:
       value: "kindNsName"
     - name: ZARF_REGISTRY_ADDRESS
       value: "###ZARF_REGISTRY###"
+    - name: "PINO_TIME_STAMP"
+      value: "iso"
     # Default envs from upstream
     - name: "PEPR_PRETTY_LOG"
       value: "false"
@@ -26,6 +28,8 @@ admission:
       value: "kindNsName"
     - name: ZARF_REGISTRY_ADDRESS
       value: "###ZARF_REGISTRY###"
+    - name: "PINO_TIME_STAMP"
+      value: "iso"
     # Default envs from upstream
     - name: "PEPR_PRETTY_LOG"
       value: "false"


### PR DESCRIPTION
## Description

This switches to the ISO timestamp format for pepr logs (https://docs.pepr.dev/user-guide/customization/#customizing-log-format) as well as redacting the CA cert values when printing the config log. While not sensitive these values are quite long and flood the pod logs on startup, so it seems wise to redact them. The values of read-in certs are pretty easy to identify elsewhere also (in resulting configmaps, source configmap, etc).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Deploy at minimum the base layer and review log output.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed