### PR TITLE
docs(adr): add uds core deprecation policy

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,6 +16,11 @@ When adding a deprecation, include:
 
 | Feature | PR | Deprecated In | Reason | Migration | Removal Target |
 |---------|-----|---------------|--------|-----------|----------------|
+| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | [#154](https://github.com/defenseunicorns/uds-core/pull/154) | 0.12.0 | Improve API naming and organization | Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | 1.0.0 |
+| Keycloak `fips` helm value | [#1518](https://github.com/defenseunicorns/uds-core/pull/1518) | 0.43.0 | FIPS mode is now enabled by default for all deployments | If you override `fips` to `false`, remove that override as soon as possible to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
+| Keycloak `x509LookupProvider`, `mtlsClientCert` helm values | [#1670](https://github.com/defenseunicorns/uds-core/pull/1670) | 0.47.0 | Values will be hardcoded; EnvoyFilter manages headers for third-party integrations | No action needed; remove any overrides of these values | 1.0.0 |
+| `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | [#1233](https://github.com/defenseunicorns/uds-core/pull/1233) | 0.48.0 | Moved to ClusterConfig CRD for centralized configuration | Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
+| `CA_CERT` Zarf variable | [#2167](https://github.com/defenseunicorns/uds-core/pull/2167) | 0.58.0 | Improved naming clarity for centralized trust bundle management | Use `CA_BUNDLE_CERTS` instead | 1.0.0 |
 | `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | 1.0.0 |
 
 ## Recently Removed

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,27 @@
+# UDS Core Deprecations
+
+This document tracks all currently deprecated features in UDS Core. Deprecated features remain functional but are scheduled for removal in a future major release.
+
+## Active Deprecations
+
+<!--
+When adding a deprecation, include:
+- Feature: What is being deprecated
+- PR: Link to the pull request that introduced the deprecation
+- Deprecated In: The version where deprecation was announced
+- Reason: Why it is being deprecated
+- Migration: The recommended replacement or migration path
+- Removal Target: The projected major version for removal
+-->
+
+| Feature | PR | Deprecated In | Reason | Migration | Removal Target |
+|---------|-----|---------------|--------|-----------|----------------|
+| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | 1.0.0 |
+
+## Recently Removed
+
+This section lists features that were removed in recent major releases for historical reference.
+
+| Feature | Deprecated In | Removed In | Migration |
+|---------|---------------|------------|-----------|
+| _None_ | - | - | - |

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -52,6 +52,18 @@ The following changes would be considered breaking changes and would require a m
 3. Removing a field from the Package CRD (i.e. removing `monitor[].path`)
 4. Removing/replacing a component (i.e. the tooling used for monitoring) from the published UDS Core package
 
+### Security Exception
+
+As a security-first platform, UDS Core reserves the right to release security-related breaking changes in minor versions when the security benefit to users outweighs the disruption of waiting for a major release. These changes will still be clearly advertised as breaking changes in the changelog and release notes.
+
+We will always strive to minimize the impact on users and will only exercise this exception when we believe the security improvement is necessary and urgent. Examples of when this exception may be applied include:
+
+- Removing or changing default behaviors that pose a security risk
+- Enforcing stricter security policies to address discovered vulnerabilities
+- Updating security integrations that require configuration changes
+
+Users should review release notes carefully for any security-related breaking changes, even in minor releases.
+
 ### Non-Breaking Changes (Compatible with Minor or Patch Version Bumps)
 
 The following changes are compatible with a minor version bump (new features) or patch version bump (bug fixes):

--- a/adrs/0006-deprecation-policy.md
+++ b/adrs/0006-deprecation-policy.md
@@ -1,4 +1,4 @@
-# 6. Deprcation Policy
+# 6. Deprecation Policy
 
 Date: 2026-01-13
 
@@ -20,15 +20,16 @@ UDS Core will adopt a **time-based deprecation model aligned with minor releases
 
 The policy is defined as follows:
 
-- Deprecated features will remain supported for **at least three minor releases** following their deprecation announcement.
+- Deprecated features will remain supported for **at least three subsequent minor releases** following their deprecation announcement.
 - Deprecated features **may be removed** in:
   - The next minor release after the three-minor deprecation window has elapsed, **or**
   - Any new major release.
 - Removal of deprecated functionality is considered a **breaking change**, even when it occurs in a minor release.
 - Breaking changes **must not** occur in minor releases unless they are the explicit removal of previously deprecated functionality.
 - Patch releases will never introduce deprecations or remove deprecated functionality.
+- **Users are expected to resolve all deprecation warnings before upgrading beyond the guaranteed support window** to avoid encountering breaking changes.
 
-**Example:** If a feature is deprecated in version `0.30.0`, it must remain supported through versions `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
+**Example:** If a feature is deprecated in version `0.30.0`, it must remain supported through the three subsequent minor releases: `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
 
 This approach aligns deprecation timelines with UDS Core’s existing backport and support policy, providing users with clear expectations and sufficient time to migrate.
 

--- a/adrs/0006-deprecation-policy.md
+++ b/adrs/0006-deprecation-policy.md
@@ -1,0 +1,67 @@
+# 6. Deprcation Policy
+
+Date: 2026-01-13
+
+## Status
+
+Accepted
+
+## Context
+
+UDS Core follows Semantic Versioning and provides regular minor releases on a two-week cadence, with patch support for the latest three minor versions. The platform exposes a broad, Kubernetes-native API surface (CRDs, configuration, defaults, and packaging) that is consumed by long-lived clusters and mission applications.
+
+Strict adherence to SemVer—requiring a major release for all breaking changes—would significantly slow iteration and create pressure to batch unrelated changes into infrequent major releases. This model does not align well with Kubernetes ecosystem norms, where breaking removals commonly occur in minor releases after a well-defined deprecation period.
+
+At the same time, removing deprecated functionality without clear guarantees would erode user trust and complicate upgrade planning. A clear, predictable deprecation policy is required to balance platform evolution, security posture improvements, and operator stability.
+
+## Decision
+
+UDS Core will adopt a **time-based deprecation model aligned with minor releases**, rather than requiring a major release for all breaking removals.
+
+The policy is defined as follows:
+
+- Deprecated features will remain supported for **at least three minor releases** following their deprecation announcement.
+- Deprecated features **may be removed** in:
+  - The next minor release after the three-minor deprecation window has elapsed, **or**
+  - Any new major release.
+- Removal of deprecated functionality is considered a **breaking change**, even when it occurs in a minor release.
+- Breaking changes **must not** occur in minor releases unless they are the explicit removal of previously deprecated functionality.
+- Patch releases will never introduce deprecations or remove deprecated functionality.
+
+**Example:** If a feature is deprecated in version `0.30.0`, it must remain supported through versions `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
+
+This approach aligns deprecation timelines with UDS Core’s existing backport and support policy, providing users with clear expectations and sufficient time to migrate.
+
+## Consequences
+
+### Positive
+
+- Predictable Upgrades: Users can rely on a fixed, well-documented deprecation window tied to minor releases.
+- Faster Evolution: Enables timely cleanup of deprecated APIs without waiting for infrequent major releases.
+- Ecosystem Alignment: Matches common practices in Kubernetes and CNCF-adjacent projects.
+- Security Agility: Allows removal of deprecated or risky functionality without long-term stagnation.
+- Policy Consistency: Aligns deprecation guarantees with the existing three-minor support model.
+
+### Negative
+
+- SemVer Strictness: This approach deviates from strict SemVer expectations where all breaking changes require a major version bump.
+- Operator Awareness Required: Users must actively track deprecations in changelogs and release notes to avoid surprise breakage.
+- Increased Documentation Burden: Deprecations and removals must be clearly and consistently communicated to maintain trust.
+
+## Alternatives Considered
+
+### Require Major Releases for All Breaking Changes
+
+Rejected. This would force either very frequent major releases or long-lived deprecated functionality, neither of which aligns with UDS Core’s release cadence, security posture, or Kubernetes platform norms.
+
+### Indefinite Deprecation Until Major Release Is “Warranted”
+
+Rejected. This introduces ambiguity and inconsistency, making it difficult for users to predict when deprecated features will be removed and increasing long-term maintenance burden.
+
+### Immediate Removal in Minor Releases Without Deprecation
+
+Rejected. This would introduce unexpected breaking changes and significantly undermine upgrade safety and user confidence.
+
+## Notes
+
+This ADR defines **policy**, not implementation details. All deprecations and removals will continue to be clearly documented in `CHANGELOG.md`, GitHub release notes, and relevant upgrade documentation.

--- a/adrs/0006-deprecation-policy.md
+++ b/adrs/0006-deprecation-policy.md
@@ -20,15 +20,17 @@ UDS Core will adopt a **deprecation model that requires major releases for all d
 
 The policy is defined as follows:
 
+- Removal of deprecated functionality is considered a **breaking change** and will only occur in major releases.
 - Deprecated features will remain supported for **at least three subsequent minor releases** following their deprecation announcement.
 - Deprecated features **may only be removed** in major releases, and only after the three-minor-release window has elapsed.
-- Removal of deprecated functionality is considered a **breaking change** and will only occur in major releases.
 - Patch releases will never introduce deprecations or remove deprecated functionality.
 - **Users are expected to resolve all deprecation warnings before upgrading to the next major version** to avoid encountering breaking changes.
 
 **Example:** If a feature is deprecated in version `0.30.0`, it must remain supported through at least the three subsequent minor releases: `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `1.0.0` (assuming `1.0.0` is released after `0.33.0`). If a major release were planned before the three-minor window elapsed, the deprecated feature would remain and could not be removed until the following major release.
 
 This approach provides users with clear, predictable upgrade paths, ensures adequate migration time, and aligns with strict Semantic Versioning expectations.
+
+Additionally, UDS Core adopts a **security exception** that permits security-related breaking changes in minor releases when the security benefit outweighs the disruption. This exception is documented in [VERSIONING.md](https://github.com/defenseunicorns/uds-core/blob/main/VERSIONING.md#security-exception).
 
 ## Implementation
 

--- a/adrs/0006-deprecation-policy.md
+++ b/adrs/0006-deprecation-policy.md
@@ -10,59 +10,99 @@ Accepted
 
 UDS Core follows Semantic Versioning and provides regular minor releases on a two-week cadence, with patch support for the latest three minor versions. The platform exposes a broad, Kubernetes-native API surface (CRDs, configuration, defaults, and packaging) that is consumed by long-lived clusters and mission applications.
 
-Strict adherence to SemVer—requiring a major release for all breaking changes—would significantly slow iteration and create pressure to batch unrelated changes into infrequent major releases. This model does not align well with Kubernetes ecosystem norms, where breaking removals commonly occur in minor releases after a well-defined deprecation period.
+Users of UDS Core expect predictable upgrade paths and clear boundaries for breaking changes. Removing deprecated functionality without clear guarantees would erode user trust and complicate upgrade planning. Strict adherence to Semantic Versioning—requiring a major release for all breaking changes—provides users with confidence that minor version upgrades will not break their deployments.
 
-At the same time, removing deprecated functionality without clear guarantees would erode user trust and complicate upgrade planning. A clear, predictable deprecation policy is required to balance platform evolution, security posture improvements, and operator stability.
+A clear, predictable deprecation policy is required to balance platform evolution with user stability, ensuring adequate migration time while maintaining the flexibility to evolve the platform.
 
 ## Decision
 
-UDS Core will adopt a **time-based deprecation model aligned with minor releases**, rather than requiring a major release for all breaking removals.
+UDS Core will adopt a **deprecation model that requires major releases for all deprecation removals**, aligning with strict Semantic Versioning principles while ensuring users have adequate time to migrate.
 
 The policy is defined as follows:
 
 - Deprecated features will remain supported for **at least three subsequent minor releases** following their deprecation announcement.
-- Deprecated features **may be removed** in:
-  - The next minor release after the three-minor deprecation window has elapsed, **or**
-  - Any new major release.
-- Removal of deprecated functionality is considered a **breaking change**, even when it occurs in a minor release.
-- Breaking changes **must not** occur in minor releases unless they are the explicit removal of previously deprecated functionality.
+- Deprecated features **may only be removed** in major releases, and only after the three-minor-release window has elapsed.
+- Removal of deprecated functionality is considered a **breaking change** and will only occur in major releases.
 - Patch releases will never introduce deprecations or remove deprecated functionality.
-- **Users are expected to resolve all deprecation warnings before upgrading beyond the guaranteed support window** to avoid encountering breaking changes.
+- **Users are expected to resolve all deprecation warnings before upgrading to the next major version** to avoid encountering breaking changes.
 
-**Example:** If a feature is deprecated in version `0.30.0`, it must remain supported through the three subsequent minor releases: `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
+**Example:** If a feature is deprecated in version `0.30.0`, it must remain supported through at least the three subsequent minor releases: `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `1.0.0` (assuming `1.0.0` is released after `0.33.0`). If a major release were planned before the three-minor window elapsed, the deprecated feature would remain and could not be removed until the following major release.
 
-This approach aligns deprecation timelines with UDS Core’s existing backport and support policy, providing users with clear expectations and sufficient time to migrate.
+This approach provides users with clear, predictable upgrade paths, ensures adequate migration time, and aligns with strict Semantic Versioning expectations.
+
+## Implementation
+
+This section defines how deprecations are tracked and communicated.
+
+### Commit Convention
+
+Deprecations are introduced using the conventional commit format with a `(deprecation)` scope:
+
+```
+feat(deprecation): deprecate monitor[].path field in Package CRD
+```
+
+This ensures deprecations are visible in the commit history and automatically included in GitHub release notes.
+
+### GitHub Releases
+
+Deprecations will be advertised in GitHub release notes. The release automation will pick up `feat(deprecation)` commits and include them in the release notes.
+
+### DEPRECATIONS.md
+
+A `DEPRECATIONS.md` file in the repository root tracks all active deprecations. When introducing a deprecation, developers must:
+
+1. Add an entry to `DEPRECATIONS.md` with:
+   - The deprecated feature or API
+   - A link to the pull request introducing the deprecation
+   - The version in which it was deprecated
+   - The reason for deprecation
+   - The recommended migration path or replacement
+   - The projected major version in which it will be removed
+
+2. When a deprecated feature is removed in a major release, remove its entry from `DEPRECATIONS.md`.
+
+**Developer Checklist for Deprecations:**
+
+1. Create a commit using `feat(deprecation): <description>`
+2. Update `DEPRECATIONS.md` with the new deprecation entry
+3. Add any necessary migration guidance to documentation
+4. Ensure the deprecation is mentioned in the PR description
 
 ## Consequences
 
 ### Positive
 
-- Predictable Upgrades: Users can rely on a fixed, well-documented deprecation window tied to minor releases.
-- Faster Evolution: Enables timely cleanup of deprecated APIs without waiting for infrequent major releases.
-- Ecosystem Alignment: Matches common practices in Kubernetes and CNCF-adjacent projects.
-- Security Agility: Allows removal of deprecated or risky functionality without long-term stagnation.
-- Policy Consistency: Aligns deprecation guarantees with the existing three-minor support model.
+- Predictable Upgrades: Users can rely on major version boundaries for all breaking changes from deprecation removals.
+- SemVer Compliance: Aligns with strict Semantic Versioning expectations where breaking changes require a major version bump.
+- Adequate Migration Time: The three-minor-release minimum ensures users have sufficient time to migrate before removal.
+- Clear Tracking: The `DEPRECATIONS.md` file provides a single source of truth for all active deprecations.
+- Transparent Communication: Commit conventions and GitHub releases make deprecations visible and trackable.
 
 ### Negative
 
-- SemVer Strictness: This approach deviates from strict SemVer expectations where all breaking changes require a major version bump.
-- Operator Awareness Required: Users must actively track deprecations in changelogs and release notes to avoid surprise breakage.
-- Increased Documentation Burden: Deprecations and removals must be clearly and consistently communicated to maintain trust.
+- Slower Evolution: Deprecated functionality may persist longer, as removal requires waiting for a major release.
+- Major Release Pressure: May create pressure to batch multiple deprecation removals into major releases.
+- Manual Maintenance: Developers must manually update `DEPRECATIONS.md` when introducing or removing deprecations.
 
 ## Alternatives Considered
 
-### Require Major Releases for All Breaking Changes
+### Allow Deprecation Removals in Minor Releases
 
-Rejected. This would force either very frequent major releases or long-lived deprecated functionality, neither of which aligns with UDS Core’s release cadence, security posture, or Kubernetes platform norms.
+Rejected. While this would enable faster cleanup of deprecated APIs, it deviates from strict Semantic Versioning and could surprise users who expect breaking changes only in major releases. The predictability of major-version-only removals outweighs the benefit of faster deprecation cycles.
 
-### Indefinite Deprecation Until Major Release Is “Warranted”
+### Indefinite Deprecation Until Major Release Is "Warranted"
 
-Rejected. This introduces ambiguity and inconsistency, making it difficult for users to predict when deprecated features will be removed and increasing long-term maintenance burden.
+Rejected. This introduces ambiguity and inconsistency, making it difficult for users to predict when deprecated features will be removed and increasing long-term maintenance burden. The three-minor-release minimum provides a clear, predictable timeline.
 
 ### Immediate Removal in Minor Releases Without Deprecation
 
 Rejected. This would introduce unexpected breaking changes and significantly undermine upgrade safety and user confidence.
 
+### Track Deprecations Only in Changelog
+
+Rejected. While changelogs capture deprecations, a dedicated `DEPRECATIONS.md` file provides a single, easy-to-reference source of truth for all active deprecations, their migration paths, and projected removal versions.
+
 ## Notes
 
-This ADR defines **policy**, not implementation details. All deprecations and removals will continue to be clearly documented in `CHANGELOG.md`, GitHub release notes, and relevant upgrade documentation.
+This ADR defines both **policy and implementation**. Deprecations are tracked in `DEPRECATIONS.md`, communicated via `feat(deprecation)` commits in GitHub release notes, and removals are documented in `CHANGELOG.md` as breaking changes in major releases.

--- a/docs/reference/uds-core/release-overview.md
+++ b/docs/reference/uds-core/release-overview.md
@@ -45,6 +45,53 @@ While UDS Core has not yet reached version 1.0, it is considered production-read
 
 UDS Core provides patch support for the latest three minor versions (the current minor and the two previous minors), where applicable. Minor and major releases are cut from `main`, while patch releases are published from dedicated `release/X.Y` branches for each supported minor stream. Patch releases follow the [patch policy](#patch-policy) and are not present in the main repository changelog (but are documented in GitHub releases).
 
+## Deprecation Policy
+
+UDS Core uses a time-based deprecation process to evolve the platform safely while providing clear, predictable upgrade paths for users. Deprecations signal upcoming breaking changes and allow sufficient time for migration before removal.
+
+### Scope
+
+This policy applies to all elements of the UDS Core public API, as defined in the [Versioning](https://github.com/defenseunicorns/uds-core/blob/main/VERSIONING.md) document, including:
+
+- Custom Resource Definitions (CRDs), CRD versions, fields, and behaviors
+- UDS Core configuration values and defaults
+- Exposed Zarf variables
+- Default-enabled components or integrations
+- Default behaviors that are planned to change or be removed
+
+Internal implementation details are not subject to this policy.
+
+### How Deprecations Are Announced
+
+All deprecations are documented in the [CHANGELOG.md](https://github.com/defenseunicorns/uds-core/blob/main/CHANGELOG.md) under a `⚠ DEPRECATIONS` header and included in the GitHub release notes. Each deprecation announcement includes:
+
+- What is being deprecated
+- Why it is being deprecated
+- The recommended replacement or migration path
+- When the feature is eligible for removal (minimum three minor releases after deprecation)
+
+Migration or replacement guidance is provided where applicable to ensure smooth transitions.
+
+### Support Period
+
+Deprecated features remain supported for **at least three minor releases** following their deprecation announcement. They continue to function without behavioral changes during this period and may receive bug fixes and security fixes when feasible.
+
+After the three-minor-release window has elapsed, deprecated features may be removed in:
+- The next minor release, **or**
+- Any new major release
+
+For example, if a feature is deprecated in version `0.30.0`, it must remain supported through versions `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
+
+Removal of deprecated functionality is considered a breaking change and is clearly documented in the changelog and release notes. Patch releases never introduce deprecations or remove deprecated functionality.
+
+### CRD-Specific Guarantees
+
+Because CRDs represent a primary API boundary for UDS Core, they receive the same deprecation guarantees:
+
+- Deprecated CRD fields and versions remain accepted for at least three minor releases after deprecation
+- New CRD versions may be introduced without removing older versions
+- CRD version or field removal follows the standard deprecation lifecycle
+
 ## Release Process
 
 ### Official Releases

--- a/docs/reference/uds-core/release-overview.md
+++ b/docs/reference/uds-core/release-overview.md
@@ -37,19 +37,23 @@ For a more detailed review of how UDS Core applies Semantic Versioning, see the 
 
 Breaking changes are clearly documented in the [CHANGELOG.md](https://github.com/defenseunicorns/uds-core/blob/main/CHANGELOG.md) with the `⚠ BREAKING CHANGES` header (and in the [GitHub release notes](https://github.com/defenseunicorns/uds-core/releases)). Each breaking change includes specific upgrade steps required when applicable.
 
+#### Security Exception
+
+As a security-first platform, UDS Core reserves the right to release security-related breaking changes in minor versions when the security benefit to users outweighs the disruption of waiting for a major release. These changes will still be clearly advertised as breaking changes. We will always strive to minimize the impact on users and will only exercise this exception when the security improvement is necessary and urgent.
+
 ### Current Stability Status
 
 While UDS Core has not yet reached version 1.0, it is considered production-ready and stable. The pre-1.0 versioning reflects our commitment to maintaining flexibility as we continue to enhance our security posture.
 
-## Version Support
+### Version Support
 
 UDS Core provides patch support for the latest three minor versions (the current minor and the two previous minors), where applicable. Minor and major releases are cut from `main`, while patch releases are published from dedicated `release/X.Y` branches for each supported minor stream. Patch releases follow the [patch policy](#patch-policy) and are not present in the main repository changelog (but are documented in GitHub releases).
 
-## Deprecation Policy
+### Deprecation Policy
 
-UDS Core uses a time-based deprecation process to evolve the platform safely while providing clear, predictable upgrade paths for users. Deprecations signal upcoming breaking changes and allow sufficient time for migration before removal.
+UDS Core uses a deprecation process to evolve the platform safely while providing clear, predictable upgrade paths for users. Deprecations signal upcoming breaking changes and allow sufficient time for migration before removal in a major release.
 
-### Scope
+#### Scope
 
 This policy applies to all elements of the UDS Core public API, as defined in the [Versioning](https://github.com/defenseunicorns/uds-core/blob/main/VERSIONING.md) document, including:
 
@@ -61,40 +65,36 @@ This policy applies to all elements of the UDS Core public API, as defined in th
 
 Internal implementation details are not subject to this policy.
 
-### How Deprecations Are Announced
+#### How Deprecations Are Announced
 
-All deprecations are documented in the [CHANGELOG.md](https://github.com/defenseunicorns/uds-core/blob/main/CHANGELOG.md) under a `⚠ DEPRECATIONS` header and included in the GitHub release notes. Each deprecation announcement includes:
+Deprecations are introduced via commits using the `feat(deprecation)` conventional commit format and are included in GitHub release notes. Each deprecation includes:
 
 - What is being deprecated
 - Why it is being deprecated
 - The recommended replacement or migration path
-- When the feature is eligible for removal (minimum three minor releases after deprecation)
+- The projected major version in which it will be removed
 
-Migration or replacement guidance is provided where applicable to ensure smooth transitions.
+All active deprecations are tracked in the [DEPRECATIONS.md](https://github.com/defenseunicorns/uds-core/blob/main/DEPRECATIONS.md) file, which serves as a single source of truth for deprecated features, their deprecation version, and projected removal version.
 
-### Support Period
+#### Support Period
 
-Deprecated features remain supported for **at least three subsequent minor releases** following their deprecation announcement. They continue to function without behavioral changes during this period and may receive bug fixes and security fixes when feasible.
+Deprecated features remain supported for **at least three subsequent minor releases** following their deprecation announcement and **may only be removed in a major release**. They continue to function without behavioral changes during this period and may receive bug fixes and security fixes when feasible.
 
-After the three-minor-release window has elapsed, deprecated features may be removed in:
-- The next minor release, **or**
-- Any new major release
+For example, if a feature is deprecated in version `0.30.0`, it must remain supported through at least the three subsequent minor releases: `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `1.0.0` (assuming `1.0.0` is released after `0.33.0`). If a major release were planned before the three-minor window elapsed, the deprecated feature would remain and could not be removed until the following major release.
 
-For example, if a feature is deprecated in version `0.30.0`, it must remain supported through the three subsequent minor releases: `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
-
-Removal of deprecated functionality is considered a breaking change and is clearly documented in the changelog and release notes. Patch releases never introduce deprecations or remove deprecated functionality.
+Removal of deprecated functionality is considered a breaking change and will only occur in major releases. Patch releases never introduce deprecations or remove deprecated functionality.
 
 :::caution
-Users are expected to resolve all deprecation warnings before upgrading beyond the guaranteed support window to avoid encountering breaking changes.
+Users are expected to resolve all deprecation warnings before upgrading to the next major version to avoid encountering breaking changes.
 :::
 
-### CRD-Specific Guarantees
+#### CRD-Specific Guarantees
 
 Because CRDs represent a primary API boundary for UDS Core, they receive the same deprecation guarantees:
 
 - Deprecated CRD fields and versions remain accepted for at least three minor releases after deprecation
 - New CRD versions may be introduced without removing older versions
-- CRD version or field removal follows the standard deprecation lifecycle
+- CRD version or field removal follows the standard deprecation lifecycle and only occurs in major releases
 
 ## Release Process
 

--- a/docs/reference/uds-core/release-overview.md
+++ b/docs/reference/uds-core/release-overview.md
@@ -74,15 +74,19 @@ Migration or replacement guidance is provided where applicable to ensure smooth 
 
 ### Support Period
 
-Deprecated features remain supported for **at least three minor releases** following their deprecation announcement. They continue to function without behavioral changes during this period and may receive bug fixes and security fixes when feasible.
+Deprecated features remain supported for **at least three subsequent minor releases** following their deprecation announcement. They continue to function without behavioral changes during this period and may receive bug fixes and security fixes when feasible.
 
 After the three-minor-release window has elapsed, deprecated features may be removed in:
 - The next minor release, **or**
 - Any new major release
 
-For example, if a feature is deprecated in version `0.30.0`, it must remain supported through versions `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
+For example, if a feature is deprecated in version `0.30.0`, it must remain supported through the three subsequent minor releases: `0.31.0`, `0.32.0`, and `0.33.0`. It becomes eligible for removal starting in `0.34.0` or any subsequent release (including a hypothetical `1.0.0`).
 
 Removal of deprecated functionality is considered a breaking change and is clearly documented in the changelog and release notes. Patch releases never introduce deprecations or remove deprecated functionality.
+
+:::caution
+Users are expected to resolve all deprecation warnings before upgrading beyond the guaranteed support window to avoid encountering breaking changes.
+:::
 
 ### CRD-Specific Guarantees
 

--- a/docs/reference/uds-core/release-overview.md
+++ b/docs/reference/uds-core/release-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Release Overview
 tableOfContents:
-  maxHeadingLevel: 3
+  maxHeadingLevel: 4
 ---
 
 This document outlines how UDS Core is versioned, released, tested, and maintained.


### PR DESCRIPTION
## Description

Adds an ADR and docs around UDS Core's deprecation policy.

## Related Issue

Fixes #2087 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed