### PR TITLE
fix: switch grafana sidecars to native k8s sidecars

### DIFF
--- a/src/grafana/values/unicorn-values.yaml
+++ b/src/grafana/values/unicorn-values.yaml
@@ -21,4 +21,4 @@ sidecar:
   image:
     registry: quay.io
     repository: rfcurated/kiwigrid/k8s-sidecar
-    tag: 2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+    tag: 2.2.3-jammy-scratch-fips-rfcurated

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -6,9 +6,13 @@ sidecar:
     enabled: true
     label: grafana_dashboard
     searchNamespace: ALL
+    initDashboards: true
+    restartPolicy: Always
   datasources:
     enabled: true
     label: grafana_datasource
+    initDatasources: true
+    restartPolicy: Always
 
 extraSecretMounts:
   - name: auth-generic-oauth-secret-mount

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -8,13 +8,25 @@ sidecar:
     searchNamespace: ALL
     initDashboards: true
     restartPolicy: Always
-    logLevel: DEBUG
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 60 # 5 minutes
   datasources:
     enabled: true
     label: grafana_datasource
     initDatasources: true
     restartPolicy: Always
-    logLevel: DEBUG
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: 8081
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 60 # 5 minutes
 
 extraSecretMounts:
   - name: auth-generic-oauth-secret-mount
@@ -32,8 +44,6 @@ extraConfigmapMounts:
     optional: true
 
 grafana.ini:
-  log:
-    level: "debug"
   server:
     root_url: https://grafana.{{ "###ZARF_VAR_ADMIN_DOMAIN###" | default "admin.###ZARF_VAR_DOMAIN###" }}
   # Disable telemetry that doesn't function in the airgap

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -8,11 +8,13 @@ sidecar:
     searchNamespace: ALL
     initDashboards: true
     restartPolicy: Always
+    logLevel: DEBUG
   datasources:
     enabled: true
     label: grafana_datasource
     initDatasources: true
     restartPolicy: Always
+    logLevel: DEBUG
 
 extraSecretMounts:
   - name: auth-generic-oauth-secret-mount
@@ -30,6 +32,8 @@ extraConfigmapMounts:
     optional: true
 
 grafana.ini:
+  log:
+    level: "debug"
   server:
     root_url: https://grafana.{{ "###ZARF_VAR_ADMIN_DOMAIN###" | default "admin.###ZARF_VAR_DOMAIN###" }}
   # Disable telemetry that doesn't function in the airgap

--- a/src/grafana/zarf.yaml
+++ b/src/grafana/zarf.yaml
@@ -65,4 +65,4 @@ components:
       - quay.io/rfcurated/grafana:12.3.1-jammy-scratch-fips-rfcurated
       - quay.io/rfcurated/busybox:1.37.0-musl-rf.1-fips-rfcurated
       - quay.io/rfcurated/curl:8.17.0-jammy-scratch-fips-rfcurated
-      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated

--- a/src/loki/values/unicorn-values.yaml
+++ b/src/loki/values/unicorn-values.yaml
@@ -18,4 +18,4 @@ memcached:
 sidecar:
   image:
     repository: quay.io/rfcurated/kiwigrid/k8s-sidecar
-    tag: 2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+    tag: 2.2.3-jammy-scratch-fips-rfcurated

--- a/src/loki/zarf.yaml
+++ b/src/loki/zarf.yaml
@@ -62,4 +62,4 @@ components:
       - quay.io/rfcurated/grafana/loki:3.6.3-jammy-fips-rfcurated-rfhardened
       - quay.io/rfcurated/nginx:1.29.4-slim-jammy-fips-rfcurated-rfhardened
       - quay.io/rfcurated/memcached:1.6.40-jammy-fips-rfcurated-rfhardened
-      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated


### PR DESCRIPTION
## Description

This migrates the existing k8s-sidecars for grafana dashboards and datasources to k8s native sidecars (initcontainers with `Always` restart policy):
- Switches to k8s native sidecars
- Adds startup probe (upstream defaults) to enforce startup ordering
- Switches to non-hardened k8s-sidecar for unicorn flavor due to a missing dependency for probe (same CVE/FIPS/STIG posture)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Deploy monitoring single layer and check grafana for dashboards and datasources populating.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed