### PR TITLE
fix: switch grafana sidecars to native k8s sidecars (#2266) (backport-0.59)

### DIFF
--- a/src/grafana/values/unicorn-values.yaml
+++ b/src/grafana/values/unicorn-values.yaml
@@ -21,4 +21,4 @@ sidecar:
   image:
     registry: quay.io
     repository: rfcurated/kiwigrid/k8s-sidecar
-    tag: 2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+    tag: 2.2.3-jammy-scratch-fips-rfcurated

--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -6,9 +6,27 @@ sidecar:
     enabled: true
     label: grafana_dashboard
     searchNamespace: ALL
+    initDashboards: true
+    restartPolicy: Always
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 60 # 5 minutes
   datasources:
     enabled: true
     label: grafana_datasource
+    initDatasources: true
+    restartPolicy: Always
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: 8081
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 60 # 5 minutes
 
 extraSecretMounts:
   - name: auth-generic-oauth-secret-mount

--- a/src/grafana/zarf.yaml
+++ b/src/grafana/zarf.yaml
@@ -65,4 +65,4 @@ components:
       - quay.io/rfcurated/grafana:12.3.1-jammy-scratch-fips-rfcurated
       - quay.io/rfcurated/busybox:1.37.0-musl-rf.1-fips-rfcurated
       - quay.io/rfcurated/curl:8.17.0-jammy-scratch-fips-rfcurated
-      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated

--- a/src/loki/values/unicorn-values.yaml
+++ b/src/loki/values/unicorn-values.yaml
@@ -18,4 +18,4 @@ memcached:
 sidecar:
   image:
     repository: quay.io/rfcurated/kiwigrid/k8s-sidecar
-    tag: 2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+    tag: 2.2.3-jammy-scratch-fips-rfcurated

--- a/src/loki/zarf.yaml
+++ b/src/loki/zarf.yaml
@@ -62,4 +62,4 @@ components:
       - quay.io/rfcurated/grafana/loki:3.6.3-jammy-fips-rfcurated-rfhardened
       - quay.io/rfcurated/nginx:1.29.4-slim-jammy-fips-rfcurated-rfhardened
       - quay.io/rfcurated/memcached:1.6.40-jammy-fips-rfcurated-rfhardened
-      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/kiwigrid/k8s-sidecar:2.2.3-jammy-scratch-fips-rfcurated


### PR DESCRIPTION
Backport of commit: fcb2eed