### PR TITLE
feat: import custom image when running uds run

### DIFF
--- a/packages/checkpoint-dev/zarf.yaml
+++ b/packages/checkpoint-dev/zarf.yaml
@@ -11,6 +11,10 @@ metadata:
   # x-release-please-end
 
 variables:
+  - name: IMPORT_IMAGE
+    description: "Custom image to preload into the k3d cluster"
+    default: ""
+
   - name: CLUSTER_NAME
     description: "Name of the cluster"
     default: "uds"
@@ -91,6 +95,11 @@ components:
                 -v "${DATA_DIR}/k3s_data:/var/lib/rancher/k3s@server:*" \
                 --image ghcr.io/defenseunicorns/uds-core/checkpoint:latest ${ZARF_VAR_K3D_EXTRA_ARGS} \
                 ${ZARF_VAR_CLUSTER_NAME}
+
+                if [[ -n "${ZARF_VAR_IMPORT_IMAGE:-}" ]]; then
+                  k3d image import "${ZARF_VAR_IMPORT_IMAGE}" -c "${ZARF_VAR_CLUSTER_NAME}"
+                fi
+
             description: "Create the cluster"
           # This action waits on Keycloak since it is the slowest pod to start after cluster creation. By waiting on it, we guarantee the cluster is healthy and usable after deployment.
           - description: Keycloak to be Healthy


### PR DESCRIPTION
## Description

I need to run quick and consecutive tests against UDS Core. This gives me the ability to import a testing image into the k3d cluster instead of needing to publish it to an external registry. This is for Pepr but I think a generic implementation so you can import any image into the cluster.

## Related Issue

Fixes #2279 
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed