### PR TITLE
fix: remove null storage class

### DIFF
--- a/src/prometheus-stack/values/values.yaml
+++ b/src/prometheus-stack/values/values.yaml
@@ -52,7 +52,6 @@ prometheus:
           resources:
             requests:
               storage: 50Gi
-          storageClassName: null
     enableRemoteWriteReceiver: true # enable Prometheus remote write receiver (needed by loki ruler for recording rules)
 prometheus-node-exporter:
   containerSecurityContext:


### PR DESCRIPTION
## Description

Once Zarf updates to helm 4, there will be stricter CRD validation. This updates the chart ahead of time to avoid the issue
```bash
ERROR:  failed to deploy bundle: unable to deploy component "kube-prometheus-stack": unable to install chart [Prometheus.monitoring.coreos.com](http://prometheus.monitoring.coreos.com/) "kube-prometheus-stack-prometheus" is invalid: spec.storage.volumeClaimTemplate.spec.storageClassName: Invalid value: "null": spec.storage.volumeClaimTemplate.spec.storageClassName in body must be of type string: "null": if you need to remove the failed chart, use `zarf package remove`
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed