### PR TITLE
chore: bump IAC clusters to k8s 1.34

### DIFF
--- a/.github/test-infra/aws/eks/variables.tf
+++ b/.github/test-infra/aws/eks/variables.tf
@@ -82,7 +82,7 @@ variable "databases" {
 variable "kubernetes_version" {
   description = "Kubernetes version to use for the EKS cluster"
   type        = string
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "vpc_name" {

--- a/.github/test-infra/aws/rke2/terraform.tfvars
+++ b/.github/test-infra/aws/rke2/terraform.tfvars
@@ -4,4 +4,4 @@ os_distro    = "rhel"
 # Need to allow in from internet for github runner to connect to node
 allowed_in_cidrs = ["0.0.0.0/0"]
 
-rke2_version = "1.33"
+rke2_version = "1.34"

--- a/.github/test-infra/azure/aks/variables.tf
+++ b/.github/test-infra/azure/aks/variables.tf
@@ -37,7 +37,7 @@ variable "sku_tier" {
 
 variable "kubernetes_version" {
   description = "Specifies the AKS Kubernetes version"
-  default     = "1.33"
+  default     = "1.34"
   type        = string
 }
 


### PR DESCRIPTION
## Description

This bumps all versions to 1.34 to be in sync with [k3s/k3d](https://github.com/defenseunicorns/uds-k3d/blob/main/zarf.yaml#L20). This will also be required for rke2 since older AMIs got pruned.