### PR TITLE
fix: broken dev setup because of missing trust bundle initialization

### DIFF
--- a/hack/dev-manifests/uds-trust-bundle.yaml
+++ b/hack/dev-manifests/uds-trust-bundle.yaml
@@ -1,0 +1,10 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uds-trust-bundle
+  namespace: istio-system
+data:
+  extra.pem: ""

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -47,10 +47,6 @@ tasks:
           uds zarf tools kubectl apply -f src/pepr/uds-cluster-crds/templates/clusterconfig.uds.dev.yaml
           uds zarf tools kubectl apply -f hack/dev-manifests/
 
-      - description: "Create uds-trust-bundle ConfigMap for Istio"
-        cmd: |
-          uds zarf tools kubectl create configmap uds-trust-bundle -n istio-system --from-literal=extra.pem="" --dry-run=client -o yaml | uds zarf tools kubectl apply -f -
-
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
         cmd: "uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --no-progress --components=${{ .inputs.istio_components }}"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -47,6 +47,10 @@ tasks:
           uds zarf tools kubectl apply -f src/pepr/uds-cluster-crds/templates/clusterconfig.uds.dev.yaml
           uds zarf tools kubectl apply -f hack/dev-manifests/
 
+      - description: "Create uds-trust-bundle ConfigMap for Istio"
+        cmd: |
+          uds zarf tools kubectl create configmap uds-trust-bundle -n istio-system --from-literal=extra.pem="" --dry-run=client -o yaml | uds zarf tools kubectl apply -f -
+
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
         cmd: "uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --no-progress --components=${{ .inputs.istio_components }}"


### PR DESCRIPTION
## Description
In the dev-setup task, istio is deployed before pepr, meaning the magic that pepr provides for istio doesnt happen causing a failed dev-setup because istiod never completely deploys. This bootstraps a blank trust-bundle configmap for the dev-setup task to successfully complete. Pepr will manage the configmap later if it needs updating.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed