### PR TITLE
chore: revert bump IAC clusters to k8s 1.34"

### DIFF
--- a/.github/test-infra/aws/eks/variables.tf
+++ b/.github/test-infra/aws/eks/variables.tf
@@ -82,7 +82,7 @@ variable "databases" {
 variable "kubernetes_version" {
   description = "Kubernetes version to use for the EKS cluster"
   type        = string
-  default     = "1.34"
+  default     = "1.33"
 }
 
 variable "vpc_name" {

--- a/.github/test-infra/aws/rke2/terraform.tfvars
+++ b/.github/test-infra/aws/rke2/terraform.tfvars
@@ -4,4 +4,4 @@ os_distro    = "rhel"
 # Need to allow in from internet for github runner to connect to node
 allowed_in_cidrs = ["0.0.0.0/0"]
 
-rke2_version = "1.34"
+rke2_version = "1.33"

--- a/.github/test-infra/azure/aks/variables.tf
+++ b/.github/test-infra/azure/aks/variables.tf
@@ -37,7 +37,7 @@ variable "sku_tier" {
 
 variable "kubernetes_version" {
   description = "Specifies the AKS Kubernetes version"
-  default     = "1.34"
+  default     = "1.33"
   type        = string
 }
 


### PR DESCRIPTION
Reverts defenseunicorns/uds-core#2299