### PR TITLE
chore(deps): revert istio to 1.28.2

### DIFF
--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -20,11 +20,11 @@ components:
     charts:
       - name: base
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         namespace: istio-system
       - name: istiod
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         namespace: istio-system
         valuesFiles:
           - "../values/base-istiod.yaml"
@@ -43,13 +43,13 @@ components:
           - "chart/values.yaml"
       - name: cni
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         namespace: istio-system
         valuesFiles:
           - "../values/base-cni.yaml"
       - name: ztunnel
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         namespace: istio-system
         valuesFiles:
           - "../values/base-ztunnel.yaml"

--- a/src/istio/values/registry1/cni.yaml
+++ b/src/istio/values/registry1/cni.yaml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 cni:
-  image: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.28.3-fips
+  image: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.28.2-fips

--- a/src/istio/values/registry1/istiod.yaml
+++ b/src/istio/values/registry1/istiod.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 pilot:
-  image: registry1.dso.mil/ironbank/tetrate/istio/pilot:1.28.3-fips
+  image: registry1.dso.mil/ironbank/tetrate/istio/pilot:1.28.2-fips
 global:
   proxy_init:
     # renovate: image=registry1.dso.mil/ironbank/tetrate/istio/proxyv2
-    image: "###ZARF_REGISTRY###/ironbank/tetrate/istio/proxyv2:1.28.3-fips"
+    image: "###ZARF_REGISTRY###/ironbank/tetrate/istio/proxyv2:1.28.2-fips"
   proxy:
     # renovate: image=registry1.dso.mil/ironbank/tetrate/istio/proxyv2
-    image: "###ZARF_REGISTRY###/ironbank/tetrate/istio/proxyv2:1.28.3-fips"
+    image: "###ZARF_REGISTRY###/ironbank/tetrate/istio/proxyv2:1.28.2-fips"

--- a/src/istio/values/registry1/ztunnel.yaml
+++ b/src/istio/values/registry1/ztunnel.yaml
@@ -1,4 +1,4 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-image: registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.28.3-fips
+image: registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.28.2-fips

--- a/src/istio/values/unicorn/cni.yaml
+++ b/src/istio/values/unicorn/cni.yaml
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 cni:
-  image: quay.io/rfcurated/istio/install-cni:1.28.3-jammy-fips-rfcurated-rfhardened
+  image: quay.io/rfcurated/istio/install-cni:1.28.2-jammy-fips-rfcurated-rfhardened

--- a/src/istio/values/unicorn/istiod.yaml
+++ b/src/istio/values/unicorn/istiod.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 pilot:
-  image: "quay.io/rfcurated/istio/pilot:1.28.3-jammy-fips-rfcurated-rfhardened"
+  image: "quay.io/rfcurated/istio/pilot:1.28.2-jammy-fips-rfcurated-rfhardened"
 global:
   proxy_init:
     # renovate: image=quay.io/rfcurated/istio/proxyv2
-    image: "###ZARF_REGISTRY###/rfcurated/istio/proxyv2:1.28.3-jammy-fips-rfcurated-rfhardened"
+    image: "###ZARF_REGISTRY###/rfcurated/istio/proxyv2:1.28.2-jammy-fips-rfcurated-rfhardened"
   proxy:
     # renovate: image=quay.io/rfcurated/istio/proxyv2
-    image: "###ZARF_REGISTRY###/rfcurated/istio/proxyv2:1.28.3-jammy-fips-rfcurated-rfhardened"
+    image: "###ZARF_REGISTRY###/rfcurated/istio/proxyv2:1.28.2-jammy-fips-rfcurated-rfhardened"

--- a/src/istio/values/unicorn/ztunnel.yaml
+++ b/src/istio/values/unicorn/ztunnel.yaml
@@ -1,4 +1,4 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-image: quay.io/rfcurated/istio/ztunnel:1.28.3-jammy-scratch-fips-rfcurated
+image: quay.io/rfcurated/istio/ztunnel:1.28.2-jammy-scratch-fips-rfcurated

--- a/src/istio/values/upstream/cni.yaml
+++ b/src/istio/values/upstream/cni.yaml
@@ -1,4 +1,4 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 cni:
-  image: docker.io/istio/install-cni:1.28.3-distroless
+  image: docker.io/istio/install-cni:1.28.2-distroless

--- a/src/istio/values/upstream/istiod.yaml
+++ b/src/istio/values/upstream/istiod.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 pilot:
-  image: "docker.io/istio/pilot:1.28.3-distroless"
+  image: "docker.io/istio/pilot:1.28.2-distroless"
 global:
   proxy_init:
     # renovate: image=docker.io/istio/proxyv2
-    image: "###ZARF_REGISTRY###/istio/proxyv2:1.28.3-distroless"
+    image: "###ZARF_REGISTRY###/istio/proxyv2:1.28.2-distroless"
   proxy:
     # renovate: image=docker.io/istio/proxyv2
-    image: "###ZARF_REGISTRY###/istio/proxyv2:1.28.3-distroless"
+    image: "###ZARF_REGISTRY###/istio/proxyv2:1.28.2-distroless"

--- a/src/istio/values/upstream/ztunnel.yaml
+++ b/src/istio/values/upstream/ztunnel.yaml
@@ -1,4 +1,4 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-image: docker.io/istio/ztunnel:1.28.3-distroless
+image: docker.io/istio/ztunnel:1.28.2-distroless

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -35,10 +35,10 @@ components:
         valuesFiles:
           - "values/upstream/ztunnel.yaml"
     images:
-      - "docker.io/istio/pilot:1.28.3-distroless"
-      - "docker.io/istio/proxyv2:1.28.3-distroless"
-      - "docker.io/istio/install-cni:1.28.3-distroless"
-      - "docker.io/istio/ztunnel:1.28.3-distroless"
+      - "docker.io/istio/pilot:1.28.2-distroless"
+      - "docker.io/istio/proxyv2:1.28.2-distroless"
+      - "docker.io/istio/install-cni:1.28.2-distroless"
+      - "docker.io/istio/ztunnel:1.28.2-distroless"
 
   - name: istio-controlplane
     required: true
@@ -58,10 +58,10 @@ components:
           - "values/registry1/ztunnel.yaml"
     # @lulaStart b4367e52-bef0-4463-a906-e5af6b4aa015
     images:
-      - registry1.dso.mil/ironbank/tetrate/istio/proxyv2:1.28.3-fips
-      - registry1.dso.mil/ironbank/tetrate/istio/pilot:1.28.3-fips
-      - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.28.3-fips
-      - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.28.3-fips
+      - registry1.dso.mil/ironbank/tetrate/istio/proxyv2:1.28.2-fips
+      - registry1.dso.mil/ironbank/tetrate/istio/pilot:1.28.2-fips
+      - registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.28.2-fips
+      - registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.28.2-fips
     # @lulaEnd b4367e52-bef0-4463-a906-e5af6b4aa015
 
   - name: istio-controlplane
@@ -82,10 +82,10 @@ components:
           - "values/unicorn/ztunnel.yaml"
     # @lulaStart b4367e52-bef0-4463-a906-e5af6b4aa015
     images:
-      - quay.io/rfcurated/istio/pilot:1.28.3-jammy-fips-rfcurated-rfhardened
-      - quay.io/rfcurated/istio/proxyv2:1.28.3-jammy-fips-rfcurated-rfhardened
-      - quay.io/rfcurated/istio/install-cni:1.28.3-jammy-fips-rfcurated-rfhardened
-      - quay.io/rfcurated/istio/ztunnel:1.28.3-jammy-scratch-fips-rfcurated
+      - quay.io/rfcurated/istio/pilot:1.28.2-jammy-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/istio/proxyv2:1.28.2-jammy-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/istio/install-cni:1.28.2-jammy-fips-rfcurated-rfhardened
+      - quay.io/rfcurated/istio/ztunnel:1.28.2-jammy-scratch-fips-rfcurated
     # @lulaEnd b4367e52-bef0-4463-a906-e5af6b4aa015
 
   - name: gateway-api-crds
@@ -98,7 +98,7 @@ components:
     charts:
       - name: gateway
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         releaseName: admin-ingressgateway
         namespace: istio-admin-gateway
       - name: uds-istio-config
@@ -113,7 +113,7 @@ components:
     charts:
       - name: gateway
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         releaseName: tenant-ingressgateway
         namespace: istio-tenant-gateway
       - name: uds-istio-config
@@ -128,7 +128,7 @@ components:
     charts:
       - name: gateway
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         releaseName: passthrough-ingressgateway
         namespace: istio-passthrough-gateway
       - name: uds-istio-config
@@ -155,7 +155,7 @@ components:
     charts:
       - name: gateway
         url: https://istio-release.storage.googleapis.com/charts
-        version: 1.28.3
+        version: 1.28.2
         releaseName: egressgateway
         namespace: istio-egress-gateway
         valuesFiles:


### PR DESCRIPTION
Reverts defenseunicorns/uds-core#2285

We are seeing issues with the registry1 ztunnel image on EKS.  Reverting for now until we get a fix out.

Error message:
```
istio-system 15m Warning FailedCreatePodSandBox pod/ztunnel-kc98c Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "e9441990d12eec98fe8f19b385b1ec8c3fb1829c2156b3abf3d5b3b6a9d068ec": plugin type="istio-cni" name="istio-cni" failed (add): netplugin failed: "panic: fips140: FIPS 140-3 mode is incompatible with GOEXPERIMENT=boringcrypto\n\ngoroutine 1 [running]:\ncrypto/internal/fips140/check.init.0()\n\tcrypto/internal/fips140/check/check.go:60 +0x6b\n"
```