### PR TITLE
chore: pin bottlerocket eks to 1.53.0

### DIFF
--- a/.github/test-infra/aws/eks/cluster.tf
+++ b/.github/test-infra/aws/eks/cluster.tf
@@ -1,6 +1,22 @@
 # Copyright 2025 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
+locals {
+  # renovate: datasource=github-releases depName=bottlerocket-os/bottlerocket
+  bottlerocket_ami_version = "v1.53.0"
+}
+
+data "aws_ami" "eks_bottlerocket_ami" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name = "name"
+    values = [ // Only default to use fips image in govcloud
+      "bottlerocket-aws-k8s-${var.kubernetes_version}-fips-x86_64-${local.bottlerocket_ami_version}-*"
+    ]
+  }
+}
 
 # Create EKS Cluster
 module "eks" {
@@ -79,7 +95,7 @@ module "eks" {
     main = {
       name           = var.name
       instance_types = [var.instance_type]
-      ami_type       = "BOTTLEROCKET_x86_64_FIPS"
+      ami_id         = data.aws_ami.eks_bottlerocket_ami.id
 
       min_size     = var.node_group_min_size
       max_size     = var.node_group_max_size

--- a/.github/test-infra/aws/eks/cluster.tf
+++ b/.github/test-infra/aws/eks/cluster.tf
@@ -12,7 +12,7 @@ data "aws_ami" "eks_bottlerocket_ami" {
 
   filter {
     name = "name"
-    values = [ // Only default to use fips image in govcloud
+    values = [
       "bottlerocket-aws-k8s-${var.kubernetes_version}-fips-x86_64-${local.bottlerocket_ami_version}-*"
     ]
   }
@@ -95,6 +95,7 @@ module "eks" {
     main = {
       name           = var.name
       instance_types = [var.instance_type]
+      ami_type       = "BOTTLEROCKET_x86_64_FIPS"
       ami_id         = data.aws_ami.eks_bottlerocket_ami.id
 
       min_size     = var.node_group_min_size


### PR DESCRIPTION
## Description

Pins bottlerocket to 1.53.0.  1.54.0 introduces some FIPs validation that is failing for the registry1 image of istio.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed