### PR TITLE
fix: ensure ambient mode is the default in all operator code

### DIFF
--- a/src/pepr/operator/controllers/istio/ambient-waypoint.ts
+++ b/src/pepr/operator/controllers/istio/ambient-waypoint.ts
@@ -213,11 +213,8 @@ export async function reconcileService(svc: a.Service): Promise<void> {
   }
 
   const pkg = PackageStore.getPackageByNamespace(namespace);
-  if (
-    !pkg ||
-    pkg.metadata?.deletionTimestamp ||
-    pkg.spec?.network?.serviceMesh?.mode !== Mode.Ambient
-  ) {
+  const istioMode = pkg?.spec?.network?.serviceMesh?.mode || Mode.Ambient;
+  if (!pkg || pkg.metadata?.deletionTimestamp || istioMode !== Mode.Ambient) {
     return;
   }
 
@@ -270,11 +267,8 @@ export async function reconcilePod(pod: a.Pod): Promise<void> {
   }
 
   const pkg = PackageStore.getPackageByNamespace(namespace);
-  if (
-    !pkg ||
-    pkg.metadata?.deletionTimestamp ||
-    pkg.spec?.network?.serviceMesh?.mode !== Mode.Ambient
-  ) {
+  const istioMode = pkg?.spec?.network?.serviceMesh?.mode || Mode.Ambient;
+  if (!pkg || pkg.metadata?.deletionTimestamp || istioMode !== Mode.Ambient) {
     return;
   }
 

--- a/src/pepr/operator/controllers/istio/waypoint-utils.spec.ts
+++ b/src/pepr/operator/controllers/istio/waypoint-utils.spec.ts
@@ -93,7 +93,7 @@ describe("shouldUseAmbientWaypoint", () => {
       expected: false,
     },
     {
-      name: "should return false when no serviceMesh config exists",
+      name: "should return true when no serviceMesh config exists (ambient default)",
       pkg: {
         metadata: { name: "test", namespace: "test" },
         spec: {
@@ -106,7 +106,7 @@ describe("shouldUseAmbientWaypoint", () => {
           ],
         },
       } as UDSPackage,
-      expected: false,
+      expected: true,
     },
   ];
 

--- a/src/pepr/operator/controllers/istio/waypoint-utils.ts
+++ b/src/pepr/operator/controllers/istio/waypoint-utils.ts
@@ -14,7 +14,8 @@ const WAYPOINT_SUFFIX = "-waypoint"; // Suffix for waypoint resource names
  * Determines if a package should use ambient waypoint networking
  */
 export const shouldUseAmbientWaypoint = (pkg: UDSPackage): boolean => {
-  return pkg.spec?.network?.serviceMesh?.mode === Mode.Ambient && hasAuthserviceSSO(pkg);
+  const istioMode = pkg.spec?.network?.serviceMesh?.mode || Mode.Ambient;
+  return istioMode === Mode.Ambient && hasAuthserviceSSO(pkg);
 };
 
 /**

--- a/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
@@ -1145,6 +1145,19 @@ describe("findMatchingSsoClient", () => {
     expect(findMatchingSsoClient(pkg, { app: "a" })).toBeUndefined();
   });
 
+  test("defaults to ambient when serviceMesh.mode is undefined", () => {
+    const pkg: UDSPackage = {
+      metadata: { name: "app", namespace: "ns" },
+      spec: {
+        // No serviceMesh block -> defaults to Ambient
+        sso: [{ clientId: "c1", name: "", enableAuthserviceSelector: { app: "a" } }],
+        network: {},
+      },
+    };
+
+    expect(findMatchingSsoClient(pkg, { app: "a" })).toMatchObject({ clientId: "c1" });
+  });
+
   test("prefilters to enabled clients only (missing/null/undefined selector are ignored)", () => {
     const pkg: UDSPackage = {
       metadata: { name: "app", namespace: "ns" },

--- a/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
@@ -273,6 +273,9 @@ describe("authorization policy generation", () => {
           },
         ],
         network: {
+          serviceMesh: {
+            mode: Mode.Sidecar,
+          },
           expose: [
             {
               service: "httpbin",

--- a/src/pepr/operator/controllers/network/authorizationPolicies.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.ts
@@ -424,7 +424,8 @@ export function findMatchingSsoClient(
   pkg: UDSPackage,
   selector: Record<string, string> | undefined,
 ) {
-  if (!selector || pkg.spec?.network?.serviceMesh?.mode !== Mode.Ambient) {
+  const istioMode = pkg.spec?.network?.serviceMesh?.mode || Mode.Ambient;
+  if (!selector || istioMode !== Mode.Ambient) {
     return undefined;
   }
 

--- a/src/pepr/operator/controllers/packages/package-store.spec.ts
+++ b/src/pepr/operator/controllers/packages/package-store.spec.ts
@@ -224,16 +224,16 @@ describe("Package Store", () => {
       const ambientPkg2 = makeMockReq({
         metadata: { namespace: "ns2", name: "ambient2" },
         spec: {
-          network: {
-            serviceMesh: { mode: Mode.Ambient },
-          },
+          network: {},
         },
       }).Raw;
 
       const nonAmbientPkg = makeMockReq({
         metadata: { namespace: "ns3", name: "non-ambient" },
         spec: {
-          network: {},
+          network: {
+            serviceMesh: { mode: Mode.Sidecar },
+          },
         },
       }).Raw;
 

--- a/src/pepr/operator/controllers/packages/package-store.ts
+++ b/src/pepr/operator/controllers/packages/package-store.ts
@@ -182,7 +182,8 @@ function getAmbientPackages(): UDSPackage[] {
   const result: UDSPackage[] = [];
   for (const namespaceMap of packageNamespaceMap.values()) {
     for (const pkg of namespaceMap.values()) {
-      if (pkg.spec?.network?.serviceMesh?.mode === Mode.Ambient) {
+      const istioMode = pkg.spec?.network?.serviceMesh?.mode || Mode.Ambient;
+      if (istioMode === Mode.Ambient) {
         result.push(pkg);
       }
     }

--- a/src/test/chart/templates/package.yaml
+++ b/src/test/chart/templates/package.yaml
@@ -8,8 +8,9 @@ metadata:
   namespace: podinfo
 spec:
   network:
-    serviceMesh:
-      mode: ambient
+    # Relying on default mesh mode
+    # serviceMesh:
+    #   mode: ambient
     expose:
       - service: podinfo
         selector:

--- a/test/playwright/podinfo.test.ts
+++ b/test/playwright/podinfo.test.ts
@@ -45,6 +45,10 @@ test.describe("Podinfo Authservice protection and metrics behavior", () => {
 
       // Basic sanity check that podinfo content is rendered
       await expect(page).toHaveURL(podinfoUrl, { timeout: 10000 });
+
+      // Verify non-error response (indicates successful JWT validation)
+      const response = await page.reload();
+      expect(response?.status()).toBeLessThan(400);
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## Description

Updates operator code to ensure Ambient mode is set as the default mode in all places checking `pkg.spec.network.serviceMesh.mode`.

## Related Issue

Known issues in 0.60.0

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed