### PR TITLE
chore: bump eks/aks k8s to 1.34

### DIFF
--- a/.github/test-infra/aws/eks/variables.tf
+++ b/.github/test-infra/aws/eks/variables.tf
@@ -82,7 +82,7 @@ variable "databases" {
 variable "kubernetes_version" {
   description = "Kubernetes version to use for the EKS cluster"
   type        = string
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "vpc_name" {

--- a/.github/test-infra/azure/aks/variables.tf
+++ b/.github/test-infra/azure/aks/variables.tf
@@ -37,7 +37,7 @@ variable "sku_tier" {
 
 variable "kubernetes_version" {
   description = "Specifies the AKS Kubernetes version"
-  default     = "1.33"
+  default     = "1.34"
   type        = string
 }
 


### PR DESCRIPTION
## Description

Bumps EKS/AKS versions to 1.34.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- iac ci tests

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed