### PR TITLE
chore: remove deprecated devDep for root-ca script

### DIFF
--- a/scripts/root-ca-retriever/package-lock.json
+++ b/scripts/root-ca-retriever/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",
-        "@types/csv-parse": "^1.1.12",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.0.0",
         "adm-zip": "^0.5.16",
@@ -867,17 +866,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/csv-parse": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/csv-parse/-/csv-parse-1.2.5.tgz",
-      "integrity": "sha512-3PoFyWeuFGqale09vFydLQ6IGdvD+mizcXcB8s6ImWv+830IF0HckvewgcGVfGnTFImqvfvhpYZYod2QqGGGdg==",
-      "deprecated": "This is a stub types definition. csv-parse provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csv-parse": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -905,7 +893,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1297,7 +1284,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1501,7 +1487,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1530,7 +1515,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/scripts/root-ca-retriever/package.json
+++ b/scripts/root-ca-retriever/package.json
@@ -12,7 +12,6 @@
     "typescript": "^5.3.3",
     "vitest": "^4.0.0",
     "@types/adm-zip": "^0.5.7",
-    "@types/csv-parse": "^1.1.12",
     "adm-zip": "^0.5.16",
     "csv-parse": "^6.1.0",
     "js-yaml": "^4.1.1",

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 variables:
@@ -204,3 +204,16 @@ tasks:
     description: "Updates CA certificates"
     actions:
       - cmd: npx ts-node --project scripts/root-ca-retriever/tsconfig.json scripts/root-ca-retriever/index.ts
+      - description: "Add license headers to generated CA configmap"
+        shell:
+          darwin: bash
+          linux: bash
+        cmd: |
+          # check for addlicense bin
+          if [ -x "$HOME/go/bin/addlicense" ]; then
+            echo "addlicense installed in $HOME/go/bin"
+          else
+            echo "Error: addlicense is not installed in $HOME/go/bin" >&2
+            exit 1
+          fi
+          $HOME/go/bin/addlicense -l "AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial" -s=only -v -c "Defense Unicorns" src/pepr/uds-operator-config/templates/uds-ca-certs.yaml


### PR DESCRIPTION
## Description

Noticed in reviewing our renovate dashboard that `@types/csv-parse` is noted as deprecated now (types directly in the `csv-parse` package): https://www.npmjs.com/package/@types/csv-parse.

This PR removes it and adds an extra action for addlicense on the generated CAs.