### PR TITLE
fix: validate authservice callback uri + redirect uri

### DIFF
--- a/docs/reference/configuration/single-sign-on/auth-service.md
+++ b/docs/reference/configuration/single-sign-on/auth-service.md
@@ -29,6 +29,50 @@ spec:
 The UDS Operator uses the first `redirectUris` to populate the `match.prefix` hostname and `callback_uri` in the authservice chain.
 :::
 
+:::warning
+### Redirect URI Validation
+
+When using `enableAuthserviceSelector`, the UDS Operator validates the `redirectUris` array to ensure proper configuration:
+
+- **Root paths (`/` or `/*`) are not allowed** in `redirectUris` for authservice clients
+- **Valid redirect URIs must be fully qualified URLs** (e.g., `https://example.com/callback`)
+- **Non-authservice clients are not affected** by this validation
+
+#### Examples:
+
+✅ **Valid:**
+```yaml
+sso:
+  - name: "My App"
+    clientId: my-app
+    redirectUris: ["https://myapp.example.com/login"]
+    enableAuthserviceSelector:
+      app: myapp
+```
+
+❌ **Invalid:**
+```yaml
+sso:
+  - name: "My App"
+    clientId: my-app
+    redirectUris: ["/"]  # Root path not allowed
+    enableAuthserviceSelector:
+      app: myapp
+```
+
+❌ **Invalid:**
+```yaml
+sso:
+  - name: "My App"
+    clientId: my-app
+    redirectUris: ["https://myapp.example.com/login", "/"]  # Mixed with root path
+    enableAuthserviceSelector:
+      app: myapp
+```
+
+If invalid redirect URIs are detected, the Package will be denied with an error message indicating the issue.
+:::
+
 For complete examples, see [app-ambient-authservice-tenant.yaml](https://github.com/defenseunicorns/uds-core/blob/main/src/test/app-ambient-authservice-tenant.yaml) and [app-sidecar-authservice-tenant.yaml](https://github.com/defenseunicorns/uds-core/blob/main/src/test/app-sidecar-authservice-tenant.yaml)
 
 ## Multiple Services and Selectors

--- a/docs/reference/configuration/single-sign-on/auth-service.md
+++ b/docs/reference/configuration/single-sign-on/auth-service.md
@@ -55,7 +55,7 @@ sso:
 sso:
   - name: "My App"
     clientId: my-app
-    redirectUris: ["/"]  # Root path not allowed
+    redirectUris: ["https://myapp.example.com/"]  # Root path not allowed
     enableAuthserviceSelector:
       app: myapp
 ```

--- a/docs/reference/configuration/single-sign-on/auth-service.md
+++ b/docs/reference/configuration/single-sign-on/auth-service.md
@@ -65,7 +65,7 @@ sso:
 sso:
   - name: "My App"
     clientId: my-app
-    redirectUris: ["https://myapp.example.com/login", "/"]  # Mixed with root path
+    redirectUris: ["https://myapp.example.com/login", "https://myapp.example.com/"]  # Mixed with root path
     enableAuthserviceSelector:
       app: myapp
 ```

--- a/src/pepr/operator/crd/validators/package-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/package-validator.spec.ts
@@ -843,6 +843,7 @@ describe("Test validation of Package CRs", () => {
     expect(mockReq.Deny).toHaveBeenCalledWith(
       'The client ID "test-client" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.',
     );
+    expect(mockReq.Approve).not.toHaveBeenCalled();
   });
 
   it("denies authservice clients with redirectUris containing URLs with wildcard root paths", async () => {
@@ -866,6 +867,55 @@ describe("Test validation of Package CRs", () => {
     expect(mockReq.Deny).toHaveBeenCalledWith(
       'The client ID "test-client" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.',
     );
+    expect(mockReq.Approve).not.toHaveBeenCalled();
+  });
+
+  it("denies authservice clients with missing redirectUris", async () => {
+    const mockReq = makeMockReq(
+      {},
+      [],
+      [],
+      [
+        {
+          clientId: "test-client",
+          enableAuthserviceSelector: {
+            app: "test",
+          },
+          redirectUris: [],
+        },
+      ],
+      [],
+    );
+    await validator(mockReq);
+    expect(mockReq.Deny).toHaveBeenCalledTimes(1);
+    expect(mockReq.Deny).toHaveBeenCalledWith(
+      'The client ID "test-client" requires at least one redirect URI when enableAuthserviceSelector is true',
+    );
+    expect(mockReq.Approve).not.toHaveBeenCalled();
+  });
+
+  it("denies authservice clients with empty redirectUris array", async () => {
+    const mockReq = makeMockReq(
+      {},
+      [],
+      [],
+      [
+        {
+          clientId: "test-client",
+          enableAuthserviceSelector: {
+            app: "test",
+          },
+          redirectUris: [],
+        },
+      ],
+      [],
+    );
+    await validator(mockReq);
+    expect(mockReq.Deny).toHaveBeenCalledTimes(1);
+    expect(mockReq.Deny).toHaveBeenCalledWith(
+      'The client ID "test-client" requires at least one redirect URI when enableAuthserviceSelector is true',
+    );
+    expect(mockReq.Approve).not.toHaveBeenCalled();
   });
 
   it("allows authservice clients with valid redirectUris", async () => {
@@ -909,6 +959,7 @@ describe("Test validation of Package CRs", () => {
     expect(mockReq.Deny).toHaveBeenCalledWith(
       'The client ID "test-client" has an invalid redirect URI "/". Redirect URIs must be valid URLs.',
     );
+    expect(mockReq.Approve).not.toHaveBeenCalled();
   });
 
   it("allows non-authservice clients with root-only redirectUris", async () => {

--- a/src/pepr/operator/crd/validators/package-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/package-validator.spec.ts
@@ -889,7 +889,7 @@ describe("Test validation of Package CRs", () => {
     await validator(mockReq);
     expect(mockReq.Deny).toHaveBeenCalledTimes(1);
     expect(mockReq.Deny).toHaveBeenCalledWith(
-      'The client ID "test-client" requires at least one redirect URI when enableAuthserviceSelector is true',
+      'The client ID "test-client" must specify redirectUris if standardFlowEnabled is turned on (it is enabled by default)',
     );
     expect(mockReq.Approve).not.toHaveBeenCalled();
   });
@@ -913,7 +913,7 @@ describe("Test validation of Package CRs", () => {
     await validator(mockReq);
     expect(mockReq.Deny).toHaveBeenCalledTimes(1);
     expect(mockReq.Deny).toHaveBeenCalledWith(
-      'The client ID "test-client" requires at least one redirect URI when enableAuthserviceSelector is true',
+      'The client ID "test-client" must specify redirectUris if standardFlowEnabled is turned on (it is enabled by default)',
     );
     expect(mockReq.Approve).not.toHaveBeenCalled();
   });

--- a/src/pepr/operator/crd/validators/package-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/package-validator.spec.ts
@@ -822,7 +822,7 @@ describe("Test validation of Package CRs", () => {
     expect(mockReq.Approve).toHaveBeenCalledTimes(1);
   });
 
-  it("denies authservice clients with redirectUris containing any root paths", async () => {
+  it("denies authservice clients with redirectUris containing URLs with root paths", async () => {
     const mockReq = makeMockReq(
       {},
       [],
@@ -833,7 +833,7 @@ describe("Test validation of Package CRs", () => {
           enableAuthserviceSelector: {
             app: "test",
           },
-          redirectUris: ["/"],
+          redirectUris: ["https://google.com/"],
         },
       ],
       [],
@@ -845,7 +845,7 @@ describe("Test validation of Package CRs", () => {
     );
   });
 
-  it("denies authservice clients with redirectUris containing any /* root paths", async () => {
+  it("denies authservice clients with redirectUris containing URLs with wildcard root paths", async () => {
     const mockReq = makeMockReq(
       {},
       [],
@@ -856,30 +856,7 @@ describe("Test validation of Package CRs", () => {
           enableAuthserviceSelector: {
             app: "test",
           },
-          redirectUris: ["/*"],
-        },
-      ],
-      [],
-    );
-    await validator(mockReq);
-    expect(mockReq.Deny).toHaveBeenCalledTimes(1);
-    expect(mockReq.Deny).toHaveBeenCalledWith(
-      'The client ID "test-client" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.',
-    );
-  });
-
-  it("denies authservice clients with redirectUris containing mixed root paths", async () => {
-    const mockReq = makeMockReq(
-      {},
-      [],
-      [],
-      [
-        {
-          clientId: "test-client",
-          enableAuthserviceSelector: {
-            app: "test",
-          },
-          redirectUris: ["/", "/*"],
+          redirectUris: ["https://google.com/*"],
         },
       ],
       [],

--- a/src/pepr/operator/crd/validators/package-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/package-validator.spec.ts
@@ -888,7 +888,7 @@ describe("Test validation of Package CRs", () => {
     expect(mockReq.Approve).toHaveBeenCalledTimes(1);
   });
 
-  it("denies authservice clients with mixed valid and root redirectUris", async () => {
+  it("url parsing failure when redirectUri is not a valid URL", async () => {
     const mockReq = makeMockReq(
       {},
       [],
@@ -907,7 +907,7 @@ describe("Test validation of Package CRs", () => {
     await validator(mockReq);
     expect(mockReq.Deny).toHaveBeenCalledTimes(1);
     expect(mockReq.Deny).toHaveBeenCalledWith(
-      'The client ID "test-client" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.',
+      'The client ID "test-client" has an invalid redirect URI "/". Redirect URIs must be valid URLs.',
     );
   });
 

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -262,7 +262,7 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
       );
     }
     // If standardFlowEnabled is undefined (defaults to `true`) or explicitly true and there are no redirectUris set, deny the req
-    if (client.standardFlowEnabled !== false && !client.redirectUris) {
+    if (client.standardFlowEnabled !== false && !client.redirectUris?.length) {
       return req.Deny(
         `The client ID "${client.clientId}" must specify redirectUris if standardFlowEnabled is turned on (it is enabled by default)`,
       );
@@ -307,13 +307,7 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
     }
 
     // If this is an authservice client, deny redirectUris that contain any root paths
-    if (client.enableAuthserviceSelector) {
-      if (!client.redirectUris || client.redirectUris.length === 0) {
-        return req.Deny(
-          `The client ID "${client.clientId}" requires at least one redirect URI when enableAuthserviceSelector is true`,
-        );
-      }
-
+    if (client.enableAuthserviceSelector && client.redirectUris?.length) {
       for (const uri of client.redirectUris) {
         let url: URL;
         try {

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -305,6 +305,16 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
         `The client ID "${client.clientId}" is invalid as an Authservice client - Authservice does not support client IDs with the ":" character`,
       );
     }
+
+    // If this is an authservice client, deny redirectUris that contain any root paths
+    if (client.enableAuthserviceSelector && client.redirectUris) {
+      const hasRootPaths = client.redirectUris.some(uri => uri === "/" || uri === "/*");
+      if (hasRootPaths) {
+        return req.Deny(
+          `The client ID "${client.clientId}" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.`,
+        );
+      }
+    }
   }
 
   const monitors = pkg.spec?.monitor ?? [];

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -310,18 +310,15 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
     if (client.enableAuthserviceSelector && client.redirectUris) {
       const hasRootPaths = client.redirectUris.some(uri => {
         try {
-          // Check for exact root path matches first
-          if (uri === "/" || uri === "/*") {
-            return true;
-          }
-
           // Try to parse as URL to check the path component
           const url = new URL(uri);
           const path = url.pathname;
           return path === "/" || path === "/*";
         } catch {
-          // If URL parsing fails, fall back to checking if it's a root path
-          return uri === "/" || uri === "/*";
+          // If URL parsing fails, reject the invalid URI
+          return req.Deny(
+            `The client ID "${client.clientId}" has an invalid redirect URI "${uri}". Redirect URIs must be valid URLs.`,
+          );
         }
       });
       if (hasRootPaths) {


### PR DESCRIPTION
## Description
We cannot allow for root path URI's otherwise authservice will break. This PR add validation that doesn't allow authservice enabled apps to also have root path uri's defined in the redirect uri array field.

## Related Issue

Fixes #2333 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed