### PR TITLE
chore: separate IAC support dependencies in renovate

### DIFF
--- a/.github/actions/renovate-readiness/action.yaml
+++ b/.github/actions/renovate-readiness/action.yaml
@@ -50,9 +50,9 @@ runs:
           echo "package=pepr" >> $GITHUB_OUTPUT
           echo "is_pepr=true" >> $GITHUB_OUTPUT
           echo "needs_comparison=false" >> $GITHUB_OUTPUT
-        elif [[ "$PACKAGE_NAME" == "support-deps" ]]; then
+        elif [[ "$PACKAGE_NAME" == "support-deps" ]] || [[ "$PACKAGE_NAME" == "iac-support-deps" ]]; then
           echo "Detected support dependencies update"
-          echo "package=support-deps" >> $GITHUB_OUTPUT
+          echo "package=$PACKAGE_NAME" >> $GITHUB_OUTPUT
           echo "is_support_deps=true" >> $GITHUB_OUTPUT
           echo "needs_comparison=false" >> $GITHUB_OUTPUT
         elif [[ "$PACKAGE_NAME" == "operator-deps" ]]; then

--- a/renovate.json
+++ b/renovate.json
@@ -75,6 +75,23 @@
       "commitMessageTopic": "support dependencies"
     },
     {
+      "matchFileNames": [
+        "tasks/iac.yaml",
+        ".github/bundles/aks/**",
+        ".github/bundles/rke2/**",
+        ".github/bundles/eks/**",
+        ".github/test-infra/azure/aks/**",
+        ".github/test-infra/aws/rke2/**",
+        ".github/test-infra/aws/eks/**",
+        ".github/workflows/test-iac.yaml",
+        ".github/workflows/test-aks.yaml",
+        ".github/workflows/test-rke2.yaml",
+        ".github/workflows/test-eks.yaml"
+      ],
+      "groupName": "iac-support-deps",
+      "commitMessageTopic": "iac support dependencies"
+    },
+    {
       "matchFileNames": ["package.json", "package-lock.json"],
       "groupName": "operator-deps",
       "commitMessageTopic": "operator-deps",


### PR DESCRIPTION
## Description

We have quite frequent "support dependency" updates that normally don't need to run the full IAC changes. Separating the IAC specific changes out will help to isolate that testing better.