### PR TITLE
feat: expose keycloak http client retry configurations

### DIFF
--- a/docs/reference/configuration/single-sign-on/keycloak-customization-guide.md
+++ b/docs/reference/configuration/single-sign-on/keycloak-customization-guide.md
@@ -138,7 +138,7 @@ Keycloak can automatically retry failed outgoing HTTP requests to handle transie
 
 ### Configuration
 
-HTTP retry behavior is disabled by default and must be explicitly enabled. Configure it via Helm chart values:
+HTTP retry behavior is disabled by default and must be explicitly enabled by setting `maxRetries` above `0`. Configure it via Helm chart values:
 
 ```yaml
 packages:
@@ -147,8 +147,6 @@ packages:
       keycloak:
         keycloak:
           values:
-            - path: httpRetry.enabled
-              value: true
             - path: httpRetry.maxRetries
               value: 2
             - path: httpRetry.initialBackoffMillis
@@ -165,8 +163,7 @@ packages:
 
 | Option                 | Description                           | Default |
 |------------------------|---------------------------------------|---------|
-| `enabled`              | Enable/disable HTTP retries           | `false` |
-| `maxRetries`           | Maximum retry attempts (0 = disabled) | `2`     |
+| `maxRetries`           | Maximum retry attempts (0 = disabled) | `0`     |
 | `initialBackoffMillis` | Initial backoff time in milliseconds  | `1000`  |
 | `backoffMultiplier`    | Exponential backoff multiplier        | `2.0`   |
 | `applyJitter`          | Apply jitter to prevent retry storms  | `true`  |
@@ -178,6 +175,7 @@ packages:
 - Keycloak communicates with external identity providers over unreliable networks
 - Database connections experience transient failures
 - External services (email, LDAP, etc.) have occasional availability issues
+- OCSP responders need multiple attempts to validate certificates
 - You need improved resilience for production deployments
 
 **Keep disabled when**:

--- a/docs/reference/configuration/single-sign-on/keycloak-customization-guide.md
+++ b/docs/reference/configuration/single-sign-on/keycloak-customization-guide.md
@@ -163,14 +163,14 @@ packages:
 
 ### Configuration Options
 
-| Option                 | Description                           | Default | Recommended                      |
-|------------------------|---------------------------------------|---------|----------------------------------|
-| `enabled`              | Enable/disable HTTP retries           | `false` | Enable for production resilience |
-| `maxRetries`           | Maximum retry attempts (0 = disabled) | `2`     | 2-3 for production               |
-| `initialBackoffMillis` | Initial backoff time in milliseconds  | `1000`  | 1000-2000ms                      |
-| `backoffMultiplier`    | Exponential backoff multiplier        | `2.0`   | 2.0 (standard)                   |
-| `applyJitter`          | Apply jitter to prevent retry storms  | `true`  | Always enable                    |
-| `jitterFactor`         | Jitter factor for backoff variation   | `0.5`   | 0.5 (50%-150% range)             |
+| Option                 | Description                           | Default |
+|------------------------|---------------------------------------|---------|
+| `enabled`              | Enable/disable HTTP retries           | `false` |
+| `maxRetries`           | Maximum retry attempts (0 = disabled) | `2`     |
+| `initialBackoffMillis` | Initial backoff time in milliseconds  | `1000`  |
+| `backoffMultiplier`    | Exponential backoff multiplier        | `2.0`   |
+| `applyJitter`          | Apply jitter to prevent retry storms  | `true`  |
+| `jitterFactor`         | Jitter factor for backoff variation   | `0.5`   |
 
 ### When to Enable HTTP Retries
 

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -124,6 +124,22 @@ spec:
             {{- if .Values.jsonLogFormat }}
             - "--log-console-output=json"
             {{- end }}
+            {{- if .Values.httpRetry.enabled }}
+            # HTTP retry configuration for outgoing requests
+            - "--spi-connections-http-client-default-max-retries={{ .Values.httpRetry.maxRetries }}"
+            - "--spi-connections-http-client-default-initial-backoff-millis={{ .Values.httpRetry.initialBackoffMillis }}"
+            - "--spi-connections-http-client-default-backoff-multiplier={{ .Values.httpRetry.backoffMultiplier }}"
+            {{- if not .Values.httpRetry.applyJitter }}
+            - "--spi-connections-http-client-default-apply-jitter=false"
+            {{- end }}
+            {{- if .Values.httpRetry.applyJitter }}
+            - "--spi-connections-http-client-default-jitter-factor={{ .Values.httpRetry.jitterFactor }}"
+            {{- end }}
+            {{- end }}
+            # Enable OCSP verification to force external HTTP calls
+            - "--spi-x509cert-lookup-nginx-ocsp-enabled=true"
+            - "--spi-x509cert-lookup-nginx-ocsp-responder-url=http://ocsp.digicert.com"
+            - "--spi-x509cert-lookup-nginx-ocsp-cache-size=0"
           {{- with .Values.lifecycleHooks }}
           lifecycle:
           {{- toYaml . | nindent 12 }}
@@ -195,6 +211,19 @@ spec:
               value: "5"
             - name: QUARKUS_SHUTDOWN_TIMEOUT
               value: "5"
+          {{- if .Values.httpRetry.enabled }}
+            # HTTP retry configuration via environment variables (alternative to startup flags)
+            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_MAX_RETRIES
+              value: "{{ .Values.httpRetry.maxRetries }}"
+            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_INITIAL_BACKOFF_MILLIS
+              value: "{{ .Values.httpRetry.initialBackoffMillis }}"
+            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_BACKOFF_MULTIPLIER
+              value: "{{ .Values.httpRetry.backoffMultiplier }}"
+            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_APPLY_JITTER
+              value: "{{ .Values.httpRetry.applyJitter }}"
+            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_JITTER_FACTOR
+              value: "{{ .Values.httpRetry.jitterFactor }}"
+          {{- end }}
           {{- if or .Values.devMode .Values.debugMode }}
             # Enable debug logs
             - name: KC_LOG_LEVEL

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -124,7 +124,7 @@ spec:
             {{- if .Values.jsonLogFormat }}
             - "--log-console-output=json"
             {{- end }}
-            {{- if .Values.httpRetry.enabled }}
+            {{- if gt (int .Values.httpRetry.maxRetries) 0 }}
             # HTTP retry configuration for outgoing requests
             - "--spi-connections-http-client-default-max-retries={{ .Values.httpRetry.maxRetries }}"
             - "--spi-connections-http-client-default-initial-backoff-millis={{ .Values.httpRetry.initialBackoffMillis }}"

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -136,10 +136,6 @@ spec:
             - "--spi-connections-http-client-default-jitter-factor={{ .Values.httpRetry.jitterFactor }}"
             {{- end }}
             {{- end }}
-            # Enable OCSP verification to force external HTTP calls
-            - "--spi-x509cert-lookup-nginx-ocsp-enabled=true"
-            - "--spi-x509cert-lookup-nginx-ocsp-responder-url=http://ocsp.digicert.com"
-            - "--spi-x509cert-lookup-nginx-ocsp-cache-size=0"
           {{- with .Values.lifecycleHooks }}
           lifecycle:
           {{- toYaml . | nindent 12 }}
@@ -211,19 +207,6 @@ spec:
               value: "5"
             - name: QUARKUS_SHUTDOWN_TIMEOUT
               value: "5"
-          {{- if .Values.httpRetry.enabled }}
-            # HTTP retry configuration via environment variables (alternative to startup flags)
-            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_MAX_RETRIES
-              value: "{{ .Values.httpRetry.maxRetries }}"
-            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_INITIAL_BACKOFF_MILLIS
-              value: "{{ .Values.httpRetry.initialBackoffMillis }}"
-            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_BACKOFF_MULTIPLIER
-              value: "{{ .Values.httpRetry.backoffMultiplier }}"
-            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_APPLY_JITTER
-              value: "{{ .Values.httpRetry.applyJitter }}"
-            - name: KC_SPI_CONNECTIONS_HTTP_CLIENT_DEFAULT_JITTER_FACTOR
-              value: "{{ .Values.httpRetry.jitterFactor }}"
-          {{- end }}
           {{- if or .Values.devMode .Values.debugMode }}
             # Enable debug logs
             - name: KC_LOG_LEVEL

--- a/src/keycloak/chart/tests/kc_http_retry_test.yaml
+++ b/src/keycloak/chart/tests/kc_http_retry_test.yaml
@@ -1,0 +1,53 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - HTTP Retry
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: should not render HTTP retry args when maxRetries is 0 (default)
+    template: statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--spi-connections-http-client-default-max-retries="
+
+  - it: should render HTTP retry args when maxRetries > 0
+    set:
+      httpRetry:
+        maxRetries: 3
+        initialBackoffMillis: 1500
+        backoffMultiplier: 2.5
+        applyJitter: true
+        jitterFactor: 0.3
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--spi-connections-http-client-default-max-retries=3"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--spi-connections-http-client-default-initial-backoff-millis=1500"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--spi-connections-http-client-default-backoff-multiplier=2.5"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--spi-connections-http-client-default-jitter-factor=0.3"
+
+  - it: should render apply-jitter=false flag when applyJitter is false
+    set:
+      httpRetry:
+        maxRetries: 2
+        applyJitter: false
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--spi-connections-http-client-default-apply-jitter=false"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--spi-connections-http-client-default-jitter-factor="

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -706,6 +706,30 @@
       },
       "additionalProperties": false
     },
+    "httpRetry": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxRetries": {
+          "type": "number"
+        },
+        "initialBackoffMillis": {
+          "type": "number"
+        },
+        "backoffMultiplier": {
+          "type": "number"
+        },
+        "applyJitter": {
+          "type": "boolean"
+        },
+        "jitterFactor": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
     "podAnnotations": {
       "type": "object",
       "additionalProperties": {

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -709,9 +709,6 @@
     "httpRetry": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
         "maxRetries": {
           "type": "number"
         },

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -446,6 +446,26 @@ truststorePaths:
   # Default path for UDS trust bundle certificates
   - "/tmp/ca-certs"
 
+# HTTP retry configuration for outgoing Keycloak requests
+# This configures retry behavior for transient network errors and temporary service unavailability
+httpRetry:
+  # Enable/disable HTTP retries for outgoing requests
+  # When disabled, no retries will be attempted for failed HTTP requests
+  enabled: true
+  # Maximum number of retry attempts for failed HTTP requests (0 = disabled)
+  maxRetries: 12
+  # Initial backoff time in milliseconds before the first retry attempt
+  initialBackoffMillis: 1000
+  # Multiplier for exponential backoff between retry attempts
+  # Example: 2.0 with 1000ms initial = 1000ms, 2000ms, 4000ms, etc.
+  backoffMultiplier: 2.0
+  # Apply jitter to backoff times to prevent synchronized retry storms
+  # When true, adds random variation to prevent multiple clients retrying simultaneously
+  applyJitter: false
+  # Jitter factor for backoff time variation (0.5 = 50% to 150% of calculated time)
+  # Only used when applyJitter is true
+  jitterFactor: 0
+
 # Detailed observability settings (Dashboards, Alerts, etc)
 # @lulaStart e4ea044c-75fc-4acc-a552-8bba2aab1b12
 detailedObservability:

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -449,11 +449,8 @@ truststorePaths:
 # HTTP retry configuration for outgoing Keycloak requests
 # This configures retry behavior for transient network errors and temporary service unavailability
 httpRetry:
-  # Enable/disable HTTP retries for outgoing requests
-  # When disabled, no retries will be attempted for failed HTTP requests
-  enabled: false
   # Maximum number of retry attempts for failed HTTP requests (0 = disabled)
-  maxRetries: 2
+  maxRetries: 0
   # Initial backoff time in milliseconds before the first retry attempt
   initialBackoffMillis: 1000
   # Multiplier for exponential backoff between retry attempts

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -451,9 +451,9 @@ truststorePaths:
 httpRetry:
   # Enable/disable HTTP retries for outgoing requests
   # When disabled, no retries will be attempted for failed HTTP requests
-  enabled: true
+  enabled: false
   # Maximum number of retry attempts for failed HTTP requests (0 = disabled)
-  maxRetries: 12
+  maxRetries: 2
   # Initial backoff time in milliseconds before the first retry attempt
   initialBackoffMillis: 1000
   # Multiplier for exponential backoff between retry attempts
@@ -461,10 +461,10 @@ httpRetry:
   backoffMultiplier: 2.0
   # Apply jitter to backoff times to prevent synchronized retry storms
   # When true, adds random variation to prevent multiple clients retrying simultaneously
-  applyJitter: false
+  applyJitter: true
   # Jitter factor for backoff time variation (0.5 = 50% to 150% of calculated time)
   # Only used when applyJitter is true
-  jitterFactor: 0
+  jitterFactor: 0.5
 
 # Detailed observability settings (Dashboards, Alerts, etc)
 # @lulaStart e4ea044c-75fc-4acc-a552-8bba2aab1b12


### PR DESCRIPTION
## Description
Expose the ability to configure Keycloak HTTP Client retries. Disabled by default. 

## Related Issue

[Fixes 791](https://github.com/defenseunicorns/uds-identity-config/issues/791)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Unfortunately this is really difficult to test and validate because it depends on faulty http requests and even when those happens there's little evidence that its happening in the background other than a request failing and the working.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed