### PR TITLE
fix: allow access and distribution requirements in classification banner

### DIFF
--- a/src/istio/common/chart/templates/classification-banner.yaml
+++ b/src/istio/common/chart/templates/classification-banner.yaml
@@ -60,6 +60,7 @@ spec:
           "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
           inlineCode: |-
             -- Setup colors, text and banner div(s)
+            -- Color reference: https://www.astrouxds.com/components/classification-markings/
             local classColorMap = {
               UNCLASSIFIED = { backgroundColor = "#007a33", textColor = "#ffffff" },
               CUI = { backgroundColor = "#502b85", textColor = "#ffffff" },
@@ -70,7 +71,48 @@ spec:
               UNKNOWN = { backgroundColor = "#000000", textColor = "#ffffff" },
             }
             local classification = "{{ .Values.classificationBanner.text }}"
-            local colors = classColorMap[classification] or classColorMap["UNKNOWN"]
+
+            local function trim(s)
+              return (s:gsub("^%s*(.-)%s*$", "%1"))
+            end
+
+            local function classificationKey(text)
+              local upper = string.upper(trim(text or ""))
+
+              -- Split on // segments to avoid substring matches
+              local segments = {}
+              for segment in upper:gmatch("[^/]+") do
+                table.insert(segments, trim(segment))
+              end
+
+              local base = segments[1] or ""
+              local hasSCI = false
+              for i = 2, #segments do
+                if segments[i] == "SCI" then
+                  hasSCI = true
+                  break
+                end
+              end
+
+              if string.find(base, "^TOP SECRET") then
+                if hasSCI then
+                  return "TOP SECRET//SCI"
+                end
+                return "TOP SECRET"
+              elseif string.find(base, "^SECRET") then
+                return "SECRET"
+              elseif string.find(base, "^CONFIDENTIAL") then
+                return "CONFIDENTIAL"
+              elseif string.find(base, "^CUI") then
+                return "CUI"
+              elseif string.find(base, "^UNCLASSIFIED") then
+                return "UNCLASSIFIED"
+              else
+                return "UNKNOWN"
+              end
+            end
+
+            local colors = classColorMap[classificationKey(classification)] or classColorMap["UNKNOWN"]
             local backgroundColor = colors.backgroundColor
             local textColor = colors.textColor
             local style = "background-color: " .. backgroundColor .. "; color: " .. textColor .. "; height: 24px; line-height: 24px; border: 1px solid transparent; border-radius: 0; position: fixed; left: 0; width: 100vw; text-align: center; margin: 0; z-index: 10000;"

--- a/src/istio/common/chart/values.schema.json
+++ b/src/istio/common/chart/values.schema.json
@@ -11,8 +11,8 @@
         },
         "text": {
           "type": ["string", "null"],
-          "pattern": "^(?i)(UNCLASSIFIED|CUI|CONFIDENTIAL|SECRET|TOP SECRET|TOP SECRET//SCI|UNKNOWN|)$",
-          "description": "The classification banner text must match one of the allowed values (case-insensitive): UNCLASSIFIED, CONTROLLED, CONFIDENTIAL, SECRET, TOP SECRET, TOP SECRET//SCI, UNKNOWN, or it can be an empty string or null."
+          "pattern": "^(?i)((UNCLASSIFIED|CUI|CONFIDENTIAL|SECRET|TOP SECRET)(//.*)?|UNKNOWN)?$",
+          "description": "Classification text must start with a known level (UNCLASSIFIED, CUI, CONFIDENTIAL, SECRET, TOP SECRET) and may include additional access or distribution requirements delimited by // (e.g., SECRET//NOFORN). UNKNOWN or empty/null are also allowed."
         }
       }
     }


### PR DESCRIPTION
## Description

Adjusts Lua to split on `//` and match the segments for color selection rather than the full text.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/2252

## Review/Testing

For review and testing I'd recommend changing the [istio chart values](https://github.com/defenseunicorns/uds-core/blob/main/src/istio/common/chart/values.yaml) to set a specific classification text that is valid + set enabledHosts to:
```yaml
  enabledHosts:
    - sso.{{ .Values.domain }}
```
Then run slim-dev: `uds run slim-dev --set flavor=unicorn`. Check that keycloak has the expected text and color.