### PR TITLE
fix: revert breaking change that required non wildcard paths in redirecturis

### DIFF
--- a/docs/reference/configuration/single-sign-on/auth-service.md
+++ b/docs/reference/configuration/single-sign-on/auth-service.md
@@ -34,7 +34,7 @@ The UDS Operator uses the first `redirectUris` to populate the `match.prefix` ho
 
 When using `enableAuthserviceSelector`, the UDS Operator validates the `redirectUris` array to ensure proper configuration:
 
-- **Root paths (`/` or `/*`) are not allowed** in `redirectUris` for authservice clients
+- **Root paths (`/`) are not allowed** in `redirectUris` for authservice clients
 - **Valid redirect URIs must be fully qualified URLs** (e.g., `https://example.com/callback`)
 - **Non-authservice clients are not affected** by this validation
 

--- a/src/pepr/operator/crd/validators/package-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/package-validator.spec.ts
@@ -841,31 +841,7 @@ describe("Test validation of Package CRs", () => {
     await validator(mockReq);
     expect(mockReq.Deny).toHaveBeenCalledTimes(1);
     expect(mockReq.Deny).toHaveBeenCalledWith(
-      'The client ID "test-client" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.',
-    );
-    expect(mockReq.Approve).not.toHaveBeenCalled();
-  });
-
-  it("denies authservice clients with redirectUris containing URLs with wildcard root paths", async () => {
-    const mockReq = makeMockReq(
-      {},
-      [],
-      [],
-      [
-        {
-          clientId: "test-client",
-          enableAuthserviceSelector: {
-            app: "test",
-          },
-          redirectUris: ["https://google.com/*"],
-        },
-      ],
-      [],
-    );
-    await validator(mockReq);
-    expect(mockReq.Deny).toHaveBeenCalledTimes(1);
-    expect(mockReq.Deny).toHaveBeenCalledWith(
-      'The client ID "test-client" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.',
+      'The client ID "test-client" has redirectUris containing root paths ("/"). Authservice clients cannot have root path redirect URIs.',
     );
     expect(mockReq.Approve).not.toHaveBeenCalled();
   });

--- a/src/pepr/operator/crd/validators/package-validator.ts
+++ b/src/pepr/operator/crd/validators/package-validator.ts
@@ -319,9 +319,9 @@ export async function validator(req: PeprValidateRequest<UDSPackage>) {
         }
 
         const path = url.pathname;
-        if (path === "/" || path === "/*") {
+        if (path === "/") {
           return req.Deny(
-            `The client ID "${client.clientId}" has redirectUris containing root paths ("/" or "/*"). Authservice clients cannot have root path redirect URIs.`,
+            `The client ID "${client.clientId}" has redirectUris containing root paths ("/"). Authservice clients cannot have root path redirect URIs.`,
           );
         }
       }


### PR DESCRIPTION
## Description
revert the changes that were technically a breaking change in 0.61.0 that required redirectUris not contain wildcard paths. While this is recommended to not use wildcards, it is a viable option and we didnt denote it as breaking change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed