### PR TITLE
fix: cleanup stale authpolicies on change of default mesh mode

### DIFF
--- a/src/pepr/operator/controllers/istio/auth-policy.ts
+++ b/src/pepr/operator/controllers/istio/auth-policy.ts
@@ -85,6 +85,7 @@ export function generateCentralAmbientEgressAuthorizationPolicy(
         "uds/package": ambientSharedEgressPkgId,
         "uds/generation": generation.toString(),
         "uds/for": "egress",
+        "uds/mesh-mode": "ambient",
       },
     },
     spec: {

--- a/src/pepr/operator/controllers/istio/egress-ambient.ts
+++ b/src/pepr/operator/controllers/istio/egress-ambient.ts
@@ -5,6 +5,7 @@
 import { GenericClass } from "kubernetes-fluent-client";
 import { K8s } from "pepr";
 import { IstioAuthorizationPolicy, IstioServiceEntry, K8sGateway, RemoteProtocol } from "../../crd";
+import { Mode } from "../../crd/generated/package-v1alpha1";
 import { purgeOrphans } from "../utils";
 import { createEgressWaypointGateway, waitForWaypointPodHealthy } from "./ambient-waypoint";
 import { generateCentralAmbientEgressAuthorizationPolicy } from "./auth-policy";
@@ -354,6 +355,8 @@ export async function purgeAmbientEgressResources(
       sharedEgressPkgId,
       IstioAuthorizationPolicy,
       log,
+      undefined,
+      Mode.Ambient,
     );
   } catch (e) {
     const errText = `Failed to purge orphaned ambient egress resources`;

--- a/src/pepr/operator/controllers/keycloak/authservice/authorization-policy.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/authorization-policy.ts
@@ -300,7 +300,7 @@ async function updatePolicy(
     monitorExemptions.push({ port: "15020", path: "/stats/prometheus" });
   }
 
-  const meshMode = isAmbient ? Mode.Ambient : Mode.Sidecar;
+  const meshMode = pkg.spec?.network?.serviceMesh?.mode ?? Mode.Ambient;
   const updateMetadata = (resource: IstioAuthorizationPolicy | IstioRequestAuthentication) => {
     resource!.metadata!.ownerReferences = ownerReferences;
     resource!.metadata!.labels = {

--- a/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
@@ -7,7 +7,6 @@ import { describe, expect, test, vi } from "vitest";
 import { Direction, Gateway, RemoteGenerated, UDSPackage } from "../../crd";
 import { Action, AuthorizationPolicy } from "../../crd/generated/istio/authorizationpolicy-v1beta1";
 import { Mode } from "../../crd/generated/package-v1alpha1";
-import { IstioState } from "../istio/namespace";
 import {
   createDenyAllExceptWaypointPolicy,
   findMatchingSsoClient,
@@ -67,7 +66,7 @@ describe("flexible gateway configuration", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "test-ns", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "test-ns", Mode.Ambient);
     expect(policies.length).toBe(1);
     const policy = policies[0];
     expect(policy.metadata?.name).toBe(
@@ -96,7 +95,7 @@ describe("flexible gateway configuration", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "test-ns", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "test-ns", Mode.Ambient);
     expect(policies.length).toBe(1);
     const policy = policies[0];
     expect(policy.spec?.rules?.[0].from?.[0].source).toEqual({
@@ -122,7 +121,7 @@ describe("flexible gateway configuration", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "test-ns", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "test-ns", Mode.Ambient);
     expect(policies.length).toBe(1);
     const policy = policies[0];
     expect(policy.spec?.rules?.[0].from?.[0].source).toEqual({
@@ -150,7 +149,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "test-ns", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "test-ns", Mode.Ambient);
     expect(policies.length).toBe(1);
     const policy = policies[0];
     expect(policy.metadata?.name).toBe(
@@ -177,7 +176,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "test-ns", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "test-ns", Mode.Ambient);
     expect(policies.length).toBe(1);
     const policy = policies[0];
     expect(policy.metadata?.name).toBe("protect-kubeapi-test-ingress-kubeapi-test-kubeapi");
@@ -202,7 +201,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "test-ns", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "test-ns", Mode.Ambient);
     expect(policies.length).toBe(1);
     const policy = policies[0];
     expect(policy.metadata?.name).toBe("protect-kubenodes-test-ingress-kubenodes-test-kubenodes");
@@ -230,7 +229,7 @@ describe("authorization policy generation", () => {
     const policies: AuthorizationPolicy[] = await generateAuthorizationPolicies(
       pkg,
       "curl-ns-remote-cidr",
-      IstioState.Ambient,
+      Mode.Ambient,
     );
     expect(policies).toHaveLength(1);
     const policy = policies[0];
@@ -300,7 +299,7 @@ describe("authorization policy generation", () => {
     const policies = await generateAuthorizationPolicies(
       pkg,
       "authservice-sidecar-test-app",
-      IstioState.Ambient,
+      Mode.Ambient,
     );
     // We expect exactly two policies: one for the expose rule and one for the allow rule.
     expect(policies.length).toBe(2);
@@ -356,11 +355,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(
-      pkg,
-      "test-tenant-app",
-      IstioState.Ambient,
-    );
+    const policies = await generateAuthorizationPolicies(pkg, "test-tenant-app", Mode.Ambient);
     expect(policies.length).toBe(2);
     const names = policies.map(p => p.metadata?.name);
     expect(new Set(names).size).toBe(2);
@@ -384,7 +379,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "loki", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "loki", Mode.Ambient);
     // With one allow rule (Ingress/IntraNamespace), expect one policy
     expect(policies.length).toBe(1);
     const policy = policies[0];
@@ -428,7 +423,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "falco", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "falco", Mode.Ambient);
     // With current design we expect three policies (Ingress IntraNamespace + two Prometheus metrics)
     expect(policies.length).toBe(3);
 
@@ -511,7 +506,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "vector", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "vector", Mode.Ambient);
     expect(policies.length).toBe(1);
     const policy = policies[0];
     expect(policy.metadata?.name).toBe("protect-vector-ingress-prometheus-metrics");
@@ -546,7 +541,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "velero", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "velero", Mode.Ambient);
     // Expect one policy
     expect(policies.length).toBe(1);
     const policy = policies[0];
@@ -584,7 +579,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "authservice", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "authservice", Mode.Ambient);
     // Expect two policies
     expect(policies.length).toBe(2);
     const nsPolicy = policies.find(
@@ -630,7 +625,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "authservice", IstioState.Sidecar);
+    const policies = await generateAuthorizationPolicies(pkg, "authservice", Mode.Sidecar);
     // Expect three policies
     expect(policies.length).toBe(3);
     const nsPolicy = policies.find(
@@ -703,7 +698,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "monitoring", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "monitoring", Mode.Ambient);
     // Expect three policies
     expect(policies.length).toBe(3);
     const nsPolicy = policies.find(
@@ -781,7 +776,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "grafana", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "grafana", Mode.Ambient);
     // Expect three policies: one from expose, one from allow, and one monitor policy
     expect(policies.length).toBe(3);
     const exposePolicy = policies.find(
@@ -947,7 +942,7 @@ describe("authorization policy generation", () => {
       },
     };
 
-    const policies = await generateAuthorizationPolicies(pkg, "keycloak", IstioState.Ambient);
+    const policies = await generateAuthorizationPolicies(pkg, "keycloak", Mode.Ambient);
     // We expect 6 policies
     expect(policies.length).toBe(6);
 
@@ -1090,7 +1085,7 @@ describe("createDenyAllExceptWaypointPolicy", () => {
     const waypointName = "test-waypoint";
     const appSelector = { app: "test-app" };
 
-    const policy = createDenyAllExceptWaypointPolicy(pkg, waypointName, appSelector);
+    const policy = createDenyAllExceptWaypointPolicy(pkg, waypointName, appSelector, Mode.Ambient);
 
     // Verify basic policy structure
     expect(policy.apiVersion).toBe("security.istio.io/v1beta1");
@@ -1103,6 +1098,7 @@ describe("createDenyAllExceptWaypointPolicy", () => {
       "uds/package": "test-app",
       "uds/generation": "1",
       "uds/for": "network",
+      "uds/mesh-mode": "ambient",
       "uds/ambient-waypoint": "test-waypoint",
     });
 

--- a/src/pepr/operator/controllers/utils.ts
+++ b/src/pepr/operator/controllers/utils.ts
@@ -149,13 +149,14 @@ export async function purgeOrphans<T extends GenericClass>(
     // Delete if generation is missing or mismatched
     const hasGenerationMismatch = resourceGenLabel == null || resourceGenLabel !== generation;
 
-    // Delete if mesh mode is provided and the resource has a different mesh mode
+    // Delete if mesh mode is provided and the resource is missing the label or has a different mode.
+    // This ensures old resources without the mesh-mode label get cleaned up during mode transitions.
     const hasMeshModeMismatch =
-      currentMeshMode != null && resourceMeshMode != null && resourceMeshMode !== currentMeshMode;
+      currentMeshMode != null && (resourceMeshMode == null || resourceMeshMode !== currentMeshMode);
 
     if (hasGenerationMismatch || hasMeshModeMismatch) {
       const reason = hasMeshModeMismatch
-        ? `mesh-mode mismatch (${resourceMeshMode} != ${currentMeshMode})`
+        ? `mesh-mode mismatch (${resourceMeshMode ?? "missing"} != ${currentMeshMode})`
         : `generation mismatch`;
       log.debug(
         { resource },


### PR DESCRIPTION
## Description

Adds in operator logic to cleanup authorization policies when the default mesh mode changes.

## Related Issue

Fixes #2364 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds deploy k3d-core-slim-dev:0.59.1 --confirm`
- Create files:
`zarf.yaml`
```yaml
kind: ZarfPackageConfig
metadata:
  name: demo-ambient-default
  version: 0.0.1
components:
  - name: demo-app
    required: true
    manifests:
      - name: demo-pkg
        namespace: authservice-ambient-test-app
        files:
          - test-app.yaml
    images:
      - docker.io/kong/httpbin:0.2.3
```
`test-app.yaml`
```yaml
apiVersion: uds.dev/v1alpha1
kind: Package
metadata:
  name: ambient-httpbin
  namespace: authservice-ambient-test-app
spec:
  sso:
    - name: "Ambient SSO"
      clientId: uds-core-ambient-httpbin
      redirectUris:
        - "https://ambient-protected.uds.dev/login"
      enableAuthserviceSelector:
        app: httpbin
  network:
    expose:
      - service: httpbin
        selector:
          app: httpbin
        gateway: tenant
        host: ambient-protected
        port: 8000
        targetPort: 80
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: httpbin
  namespace: authservice-ambient-test-app
---
apiVersion: v1
kind: Service
metadata:
  name: httpbin
  namespace: authservice-ambient-test-app
  labels:
    app: httpbin
    service: httpbin
spec:
  ports:
    - name: http
      port: 8000
      targetPort: 80
  selector:
    app: httpbin
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: httpbin
  namespace: authservice-ambient-test-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: httpbin
      version: v1
  template:
    metadata:
      labels:
        app: httpbin
        version: v1
    spec:
      serviceAccountName: httpbin
      containers:
        - image: docker.io/kong/httpbin:0.2.3
          imagePullPolicy: IfNotPresent
          name: httpbin
          resources:
            limits:
              cpu: 50m
              memory: 64Mi
            requests:
              cpu: 50m
              memory: 64Mi
          ports:
            - containerPort: 80
          securityContext:
            allowPrivilegeEscalation: false
            privileged: false
            runAsGroup: 10001
            runAsNonRoot: true
            runAsUser: 10001
            capabilities:
              drop:
                - ALL
              add:
                - NET_BIND_SERVICE

```
- `zarf package create` && `zarf package deploy build/zarf-package-demo-ambient-default-arm64-0.0.1.tar.zst`
- Check to make sure you can access `ambient-protected.uds.dev`
- `uds run create:k3d-slim-dev-bundle`
- `uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-arm64-0.61.0.tar.zst --confirm --packages core-base,core-identity-authorization`
- Verify that the app is accessible at `https://ambient-protected.uds.dev/` and that authorization policies are all current/accurate

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed