### PR TITLE
chore: set explicit securityContext for Falco

### DIFF
--- a/src/falco/chart/templates/uds-exemption.yaml
+++ b/src/falco/chart/templates/uds-exemption.yaml
@@ -10,8 +10,9 @@ spec:
   exemptions:
     - policies:
         - DisallowHostNamespaces
+        - DisallowPrivileged
         - RequireNonRootUser
-        - RestrictCapabilities
+        - DropAllCapabilities
         - RestrictHostPathWrite
         - RestrictVolumeTypes
       matcher:
@@ -19,6 +20,6 @@ spec:
         name: "falco-(?!falcosidekick-).*" # regex to match falco but not falcosidekick
       title: "falco"
       description: "Falco requires elevated privileges and host access for runtime security monitoring.
-          As a security monitoring tool, Falco needs to use host namespaces, run as root, add security
-          capabilities, access host filesystems, and use restricted volume types to effectively monitor
-          system calls and detect security threats at the kernel level."
+          As a security monitoring tool, Falco needs to run with privileged access, use host namespaces,
+          run as root, retain security capabilities, access host filesystems, and use restricted volume types
+          to effectively monitor system calls and detect security threats at the kernel level."

--- a/src/falco/chart/templates/uds-exemption.yaml
+++ b/src/falco/chart/templates/uds-exemption.yaml
@@ -10,9 +10,8 @@ spec:
   exemptions:
     - policies:
         - DisallowHostNamespaces
-        - DisallowPrivileged
         - RequireNonRootUser
-        - DropAllCapabilities
+        - RestrictCapabilities
         - RestrictHostPathWrite
         - RestrictVolumeTypes
       matcher:
@@ -20,6 +19,6 @@ spec:
         name: "falco-(?!falcosidekick-).*" # regex to match falco but not falcosidekick
       title: "falco"
       description: "Falco requires elevated privileges and host access for runtime security monitoring.
-          As a security monitoring tool, Falco needs to run with privileged access, use host namespaces,
-          run as root, retain security capabilities, access host filesystems, and use restricted volume types
-          to effectively monitor system calls and detect security threats at the kernel level."
+          As a security monitoring tool, Falco needs to use host namespaces, run as root, add security
+          capabilities, access host filesystems, and use restricted volume types to effectively monitor
+          system calls and detect security threats at the kernel level."

--- a/src/falco/values/values.yaml
+++ b/src/falco/values/values.yaml
@@ -55,19 +55,10 @@ mounts:
       subPath: disable-rules.yaml
       readOnly: true
 
-# This uses the least privileged setup for Falco: https://falco.org/docs/setup/container/#docker-least-privileged-ebpf-probe
 containerSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  privileged: false
-  capabilities:
-    drop:
-      - ALL
-    add:
-      - BPF
-      - SYS_RESOURCE
-      - PERFMON
-      - SYS_PTRACE
+  privileged: true
 
 falcosidekick:
   enabled: true

--- a/src/falco/values/values.yaml
+++ b/src/falco/values/values.yaml
@@ -55,6 +55,11 @@ mounts:
       subPath: disable-rules.yaml
       readOnly: true
 
+containerSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  privileged: true
+
 falcosidekick:
   enabled: true
 

--- a/src/falco/values/values.yaml
+++ b/src/falco/values/values.yaml
@@ -55,10 +55,19 @@ mounts:
       subPath: disable-rules.yaml
       readOnly: true
 
+# This uses the least privileged setup for Falco: https://falco.org/docs/setup/container/#docker-least-privileged-ebpf-probe
 containerSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  privileged: true
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - BPF
+      - SYS_RESOURCE
+      - PERFMON
+      - SYS_PTRACE
 
 falcosidekick:
   enabled: true


### PR DESCRIPTION
## Description

This PR explicitly sets the securityContext for Falco. By doing this we can prevent potential of race conditions where Pepr mutates the user/group for Falco and causes it to start incorrectly.

This is not an actual change to the security context, it just sets the implicit values explicitly:
- run as user/group: These are defaults in each of the images, `docker run -it --entrypoint id docker.io/falcosecurity/falco:0.42.1` is one way to check this
- privileged: This is a default in the chart that would get set if we did not provide our own security context ([upstream ref](https://github.com/falcosecurity/charts/blob/master/charts/falco/templates/pod-template.tpl#L399-L417))