### PR TITLE
fix: add logic to cleanup stale network authpolicies when default meshmode changes

### DIFF
--- a/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.spec.ts
@@ -1105,6 +1105,7 @@ describe("createDenyAllExceptWaypointPolicy", () => {
       "uds/generation": "1",
       "uds/for": "network",
       "uds/ambient-waypoint": "test-waypoint",
+      "uds/mesh-mode": "ambient",
     });
 
     // Verify spec

--- a/src/pepr/operator/controllers/network/authorizationPolicies.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.ts
@@ -188,6 +188,7 @@ function buildAuthPolicy(
         "uds/package": pkgName,
         "uds/generation": generation,
         "uds/for": "network",
+        "uds/mesh-mode": pkg.spec?.network?.serviceMesh?.mode || Mode.Ambient,
         ...additionalLabels,
       },
       ownerReferences: getOwnerRef(pkg),
@@ -198,6 +199,49 @@ function buildAuthPolicy(
       rules: [ruleEntry],
     },
   };
+}
+
+/**
+ * Cleans up authorization policies that either don't have a mesh-mode label
+ * or have a mesh-mode that doesn't match the current package configuration.
+ *
+ * @param pkg - The UDSPackage resource containing the current mesh mode configuration
+ * @param pkgNamespace - The namespace where the authorization policies are deployed
+ * @param pkgName - The name of the package for label filtering
+ * @returns A promise that resolves when cleanup is complete
+ * @throws Will rethrow any errors encountered during policy deletion
+ */
+async function cleanupMismatchedMeshModePolicies(
+  pkg: UDSPackage,
+  pkgNamespace: string,
+  pkgName: string,
+): Promise<void> {
+  const currentMeshMode = pkg.spec?.network?.serviceMesh?.mode || Mode.Ambient;
+
+  try {
+    // Get all AuthorizationPolicies for this package in the namespace
+    const policies = await K8s(AuthorizationPolicy)
+      .InNamespace(pkgNamespace)
+      .WithLabel("uds/package", pkgName)
+      .WithLabel("uds/for", "network")
+      .Get();
+
+    for (const policy of policies.items) {
+      const policyMeshMode = policy.metadata?.labels?.["uds/mesh-mode"];
+
+      // Delete if mesh-mode label is missing or doesn't match current mode
+      if (!policyMeshMode || policyMeshMode !== currentMeshMode) {
+        log.debug(
+          `Deleting AuthorizationPolicy ${policy.metadata?.name} with mismatched mesh-mode: ` +
+            `current=${currentMeshMode}, policy=${policyMeshMode || "undefined"}`,
+        );
+        await K8s(AuthorizationPolicy).Delete(policy);
+      }
+    }
+  } catch (err) {
+    log.error(err, `Error cleaning up mismatched mesh-mode policies in namespace ${pkgNamespace}`);
+    throw err;
+  }
 }
 
 /**
@@ -410,6 +454,9 @@ export async function generateAuthorizationPolicies(
   await purgeOrphans(generation, pkgNamespace, pkgName, AuthorizationPolicy, log, {
     "uds/for": "network",
   });
+
+  // Cleanup any authpolicies that don't match the current meshmode or don't have a mesh-mode label at all.
+  await cleanupMismatchedMeshModePolicies(pkg, pkgNamespace, pkgName);
 
   return policies;
 }

--- a/src/pepr/operator/controllers/network/authorizationPolicies.ts
+++ b/src/pepr/operator/controllers/network/authorizationPolicies.ts
@@ -515,6 +515,7 @@ export function createDenyAllExceptWaypointPolicy(
         "uds/generation": pkg.metadata?.generation?.toString() ?? "0",
         "uds/for": "network",
         "uds/ambient-waypoint": waypointName,
+        "uds/mesh-mode": Mode.Ambient, // This policy is specifically for ambient mode
       },
       ownerReferences: getOwnerRef(pkg),
     },


### PR DESCRIPTION
## Description

Adds in operator logic to cleanup `AuthorizationPolices` when the default mesh mode changes.

There is a bug when certain `AuthoritizationPolicies` do not cleanup on a transition to UDS Core `0.60.x`.  This is because the default mesh mode changes from `sidecar` to `ambient` in the CRD spec.  Those who don't specify `network.serviceMesh.mode` will not have a change in the `Generation` number on the Package CR and therefore there are some `AuthorizationPolicies` that are not cleaned up that specifically are affecting Authservice enabled apps.

This PR adds a catch all cleanup function that deletes any network Authorization policies that don't match the current mesh mode.

## Related Issue

Fixes #2364 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds deploy k3d-core-slim-dev:0.59.1 --confirm`
- Create files:
`zarf.yaml`
```yaml
kind: ZarfPackageConfig
metadata:
  name: demo-ambient-default
  version: 0.0.1
components:
  - name: demo-app
    required: true
    manifests:
      - name: demo-pkg
        namespace: authservice-ambient-test-app
        files:
          - test-app.yaml
    images:
      - docker.io/kong/httpbin:0.2.3
```
`test-app.yaml`
```yaml
apiVersion: uds.dev/v1alpha1
kind: Package
metadata:
  name: ambient-httpbin
  namespace: authservice-ambient-test-app
spec:
  sso:
    - name: "Ambient SSO"
      clientId: uds-core-ambient-httpbin
      redirectUris:
        - "https://ambient-protected.uds.dev/login"
      enableAuthserviceSelector:
        app: httpbin
  network:
    expose:
      - service: httpbin
        selector:
          app: httpbin
        gateway: tenant
        host: ambient-protected
        port: 8000
        targetPort: 80
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: httpbin
  namespace: authservice-ambient-test-app
---
apiVersion: v1
kind: Service
metadata:
  name: httpbin
  namespace: authservice-ambient-test-app
  labels:
    app: httpbin
    service: httpbin
spec:
  ports:
    - name: http
      port: 8000
      targetPort: 80
  selector:
    app: httpbin
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: httpbin
  namespace: authservice-ambient-test-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: httpbin
      version: v1
  template:
    metadata:
      labels:
        app: httpbin
        version: v1
    spec:
      serviceAccountName: httpbin
      containers:
        - image: docker.io/kong/httpbin:0.2.3
          imagePullPolicy: IfNotPresent
          name: httpbin
          resources:
            limits:
              cpu: 50m
              memory: 64Mi
            requests:
              cpu: 50m
              memory: 64Mi
          ports:
            - containerPort: 80
          securityContext:
            allowPrivilegeEscalation: false
            privileged: false
            runAsGroup: 10001
            runAsNonRoot: true
            runAsUser: 10001
            capabilities:
              drop:
                - ALL
              add:
                - NET_BIND_SERVICE

```
- `zarf package create` && `zarf package deploy build/zarf-package-demo-ambient-default-arm64-0.0.1.tar.zst`
- Check to make sure you can access `ambient-protected.uds.dev`
- `uds run create:k3d-slim-dev-bundle`
- `uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-arm64-0.61.0.tar.zst --confirm --packages core-base,core-identity-authorization`
- Verify that the app is accessible at `https://ambient-protected.uds.dev/` and that authorization policies are all current/accurate

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed