### PR TITLE
docs: use latest tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you want to try out UDS Core, you can use the [k3d-core-demo bundle](./bundle
 <!-- x-release-please-start-version -->
 
 ```bash
-uds deploy k3d-core-demo:0.61.0
+uds deploy k3d-core-demo:latest
 ```
 
 <!-- x-release-please-end -->
@@ -70,7 +70,7 @@ Deploy Istio, Keycloak and Pepr:
 <!-- x-release-please-start-version -->
 
 ```bash
-uds deploy k3d-core-slim-dev:0.61.0
+uds deploy k3d-core-slim-dev:latest
 ```
 
 <!-- x-release-please-end -->

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,6 @@
       "bump-minor-pre-major": true,
       "versioning": "always-bump-minor",
       "extra-files": [
-        "README.md",
         "packages/checkpoint-dev/zarf.yaml",
         "packages/base/zarf.yaml",
         "packages/identity-authorization/zarf.yaml",

--- a/release-please-config.patch.json
+++ b/release-please-config.patch.json
@@ -7,7 +7,6 @@
       "versioning": "always-bump-patch",
       "skip-changelog": true,
       "extra-files": [
-        "README.md",
         "packages/checkpoint-dev/zarf.yaml",
         "packages/base/zarf.yaml",
         "packages/identity-authorization/zarf.yaml",


### PR DESCRIPTION
## Description

Since we backport fixes on separate branches, the readme will only ever reflect the latest minor version (without patches). Since these commands are references for exploring/testing Core, it seems fine to use the `latest` tag here, and remove this from `release-please`.