### PR TITLE
chore: explicitly set runAsNonRoot false for vector/falco

### DIFF
--- a/src/falco/values/values.yaml
+++ b/src/falco/values/values.yaml
@@ -60,6 +60,9 @@ containerSecurityContext:
   runAsGroup: 0
   privileged: true
 
+podSecurityContext:
+  runAsNonRoot: false
+
 falcosidekick:
   enabled: true
 

--- a/src/vector/values/values.yaml
+++ b/src/vector/values/values.yaml
@@ -85,13 +85,13 @@ customConfig:
       encoding:
         codec: "raw_message"
       labels:
-        namespace: '{{`{{ kubernetes.pod_namespace }}`}}'
-        app: '{{`{{ app }}`}}'
-        job: '{{`{{ kubernetes.pod_namespace }}`}}/{{`{{ app }}`}}'
-        container: '{{`{{ kubernetes.container_name }}`}}'
-        component: '{{`{{ component }}`}}'
-        host: '{{`{{ kubernetes.pod_node_name }}`}}'
-        filename: '{{`{{ file }}`}}'
+        namespace: "{{`{{ kubernetes.pod_namespace }}`}}"
+        app: "{{`{{ app }}`}}"
+        job: "{{`{{ kubernetes.pod_namespace }}`}}/{{`{{ app }}`}}"
+        container: "{{`{{ kubernetes.container_name }}`}}"
+        component: "{{`{{ component }}`}}"
+        host: "{{`{{ kubernetes.pod_node_name }}`}}"
+        filename: "{{`{{ file }}`}}"
         collector: "vector"
       buffer:
         type: disk
@@ -104,9 +104,9 @@ customConfig:
       encoding:
         codec: "raw_message"
       labels:
-        job: '{{`{{ job }}`}}'
-        host: '{{`{{ node_name }}`}}'
-        filename: '{{`{{ file }}`}}'
+        job: "{{`{{ job }}`}}"
+        host: "{{`{{ node_name }}`}}"
+        filename: "{{`{{ file }}`}}"
         collector: "vector"
       buffer:
         type: disk
@@ -135,6 +135,8 @@ securityContext:
   runAsUser: 0
   seLinuxOptions:
     type: spc_t
+podSecurityContext:
+  runAsNonRoot: false
 
 env:
   - name: NODE_HOSTNAME


### PR DESCRIPTION
## Description

Similar/follow-on to https://github.com/defenseunicorns/uds-core/pull/2367

Reviewing our policy mutation logic I identified that this is another spot where being explicit will be helpful:
https://github.com/defenseunicorns/uds-core/blob/04c6c7b5927a80b8511ec45b206c75be54c90751/src/pepr/policies/security.ts#L179-L182

By explicitly defining `runAsNonRoot` we avoid any mutations, and ensure that the pod will be blocked (without being mutated) until the exemption is processed. This guarantees we don't create a poorly configured pod.