### PR TITLE
feat: falco rule overrides

### DIFF
--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 kind: UDSBundle

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -129,20 +129,21 @@ packages:
           values:
             - path: overrides
               value:
-                "Mount Launched in Privileged Container":
-                  exceptions:
-                    action: append
-                    items:
-                      - name: allow_csi_node_mounts
-                        fields:
-                          - k8s.ns.name
-                          - k8s.pod.name
-                          - proc.name
-                        comps:
-                          - =
-                          - startswith
-                          - =
-                        values:
-                          - ["kube-system"]
-                          - ["ebs-csi-node-", "efs-csi-node-"]
-                          - ["mount"]
+                rules:
+                  "Mount Launched in Privileged Container":
+                    exceptions:
+                      action: append
+                      items:
+                        - name: allow_csi_node_mounts
+                          fields:
+                            - k8s.ns.name
+                            - k8s.pod.name
+                            - proc.name
+                          comps:
+                            - =
+                            - startswith
+                            - =
+                          values:
+                            - ["kube-system"]
+                            - ["ebs-csi-node-", "efs-csi-node-"]
+                            - ["mount"]

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -134,16 +134,13 @@ packages:
                     exceptions:
                       action: append
                       items:
-                        - name: allow_csi_node_mounts
-                          fields:
-                            - k8s.ns.name
-                            - k8s.pod.name
-                            - proc.name
-                          comps:
-                            - =
-                            - startswith
-                            - =
+                        - name: allow_csi_efs_node_mounts
+                          fields: [k8s.ns.name, k8s.pod.name, proc.name]
+                          comps: [in, startswith, in]
                           values:
-                            - ["kube-system"]
-                            - ["ebs-csi-node-", "efs-csi-node-"]
-                            - ["mount"]
+                            - [kube-system, efs-csi-node-, mount]
+                        - name: allow_csi_ebs_node_mounts
+                          fields: [k8s.ns.name, k8s.pod.name, proc.name]
+                          comps: [in, startswith, in]
+                          values:
+                            - [kube-system, ebs-csi-node, mount]

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -136,11 +136,11 @@ packages:
                       items:
                         - name: allow_csi_efs_node_mounts
                           fields: [k8s.ns.name, k8s.pod.name, proc.name]
-                          comps: [in, startswith, in]
+                          comps: [=, startswith, =]
                           values:
                             - [kube-system, efs-csi-node-, mount]
                         - name: allow_csi_ebs_node_mounts
                           fields: [k8s.ns.name, k8s.pod.name, proc.name]
-                          comps: [in, startswith, in]
+                          comps: [=, startswith, =]
                           values:
                             - [kube-system, ebs-csi-node, mount]

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -126,3 +126,23 @@ packages:
               description: Enable incubating rules
               path: incubatingRulesEnabled
               default: "true"
+          values:
+            - path: overrides
+              value:
+                "Mount Launched in Privileged Container":
+                  exceptions:
+                    action: append
+                    items:
+                      - name: allow_csi_node_mounts
+                        fields:
+                          - k8s.ns.name
+                          - k8s.pod.name
+                          - proc.name
+                        comps:
+                          - =
+                          - startswith
+                          - =
+                        values:
+                          - ["kube-system"]
+                          - ["ebs-csi-node-", "efs-csi-node-"]
+                          - ["mount"]

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -254,3 +254,15 @@ packages:
             - name: FALCO_DISABLED_RULES
               description: Disable specific rules
               path: disabledRules
+          values:
+            - path: overrides
+              value:
+                "Unexpected UDP Traffic":
+                  exceptions:
+                    action: append
+                    items:
+                      - name: allow_udp_in_smoke_ns
+                        fields: ["proc.name", "fd.l4proto"]
+                        comps: ["=", "="]
+                        values:
+                          - ["iptables-restor", "udp"]

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -254,16 +254,3 @@ packages:
             - name: FALCO_DISABLED_RULES
               description: Disable specific rules
               path: disabledRules
-          values:
-            - path: overrides
-              value:
-                rules:
-                  "Unexpected UDP Traffic":
-                    exceptions:
-                      action: append
-                      items:
-                        - name: allow_udp_in_smoke_ns
-                          fields: ["proc.name", "fd.l4proto"]
-                          comps: ["=", "="]
-                          values:
-                            - ["iptables-restor", "udp"]

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -257,12 +257,13 @@ packages:
           values:
             - path: overrides
               value:
-                "Unexpected UDP Traffic":
-                  exceptions:
-                    action: append
-                    items:
-                      - name: allow_udp_in_smoke_ns
-                        fields: ["proc.name", "fd.l4proto"]
-                        comps: ["=", "="]
-                        values:
-                          - ["iptables-restor", "udp"]
+                rules:
+                  "Unexpected UDP Traffic":
+                    exceptions:
+                      action: append
+                      items:
+                        - name: allow_udp_in_smoke_ns
+                          fields: ["proc.name", "fd.l4proto"]
+                          comps: ["=", "="]
+                          values:
+                            - ["iptables-restor", "udp"]

--- a/docs/reference/configuration/runtime-security/alerting.md
+++ b/docs/reference/configuration/runtime-security/alerting.md
@@ -57,7 +57,7 @@ To use this feature, provide an array of rule names under the `disabledRules` va
 
 **Falco Official Documentation:**
 
-  - [List of Falco Rules](https://falco.org/docs/reference/rules/default-rules/)
+- [List of Falco Rules](https://falco.org/docs/reference/rules/default-rules/)
 
 **UDS Core rule files:**
 
@@ -141,25 +141,25 @@ overrides:
 
 In AWS EKS environments, it is common to see Falco alerts triggered by the CSI (Container Storage Interface) drivers, such as EFS and EBS, because these drivers launch privileged containers to perform storage operations. These alerts are expected and do not indicate malicious activity. To reduce noise and avoid unnecessary investigation of these known benign events, it is recommended to add rule exceptions for the affected CSI driver pods. The following override demonstrates how to safely suppress these alerts while maintaining visibility into other privileged container activity.
 
-```
-  values:
-    - path: overrides
-      value:
-        rules:
-          "Mount Launched in Privileged Container":
-            exceptions:
-              action: append
-              items:
-                - name: allow_csi_efs_node_mounts
-                  fields: [k8s.ns.name, k8s.pod.name, proc.name]
-                  comps: [=, startswith, =]
-                  values:
-                    - [kube-system, efs-csi-node-, mount]
-                - name: allow_csi_ebs_node_mounts
-                  fields: [k8s.ns.name, k8s.pod.name, proc.name]
-                  comps: [=, startswith, =]
-                  values:
-                    - [kube-system, ebs-csi-node, mount]
+```yaml
+values:
+  - path: overrides
+    value:
+      rules:
+        "Mount Launched in Privileged Container":
+          exceptions:
+            action: append
+            items:
+              - name: allow_csi_efs_node_mounts
+                fields: [k8s.ns.name, k8s.pod.name, proc.name]
+                comps: [=, startswith, =]
+                values:
+                  - [kube-system, efs-csi-node-, mount]
+              - name: allow_csi_ebs_node_mounts
+                fields: [k8s.ns.name, k8s.pod.name, proc.name]
+                comps: [=, startswith, =]
+                values:
+                  - [kube-system, ebs-csi-node, mount]
 ```
 
 ### Querying Events with Loki

--- a/docs/reference/configuration/runtime-security/alerting.md
+++ b/docs/reference/configuration/runtime-security/alerting.md
@@ -61,7 +61,7 @@ To use this feature, provide an array of rule names under the `disabledRules` va
 
 1. **UDS Core rule files:**
 
-- Stable rules: ['src/falco/chart/rules/stable-rules.yaml'](https://github.com/defenseunicorns/uds-core/blob/main/src/falco/chart/rules/stable-rules.yaml)
+- Stable rules: [`src/falco/chart/rules/stable-rules.yaml`](https://github.com/defenseunicorns/uds-core/blob/main/src/falco/chart/rules/stable-rules.yaml)
 - Sandbox rules: [`src/falco/chart/rules/sandbox-rules.yaml`](https://github.com/defenseunicorns/uds-core/blob/main/src/falco/chart/rules/sandbox-rules.yaml)
 - Incubating rules: [`src/falco/chart/rules/incubating-rules.yaml`](https://github.com/defenseunicorns/uds-core/blob/main/src/falco/chart/rules/incubating-rules.yaml)
 - Look for entries that start with `- rule:` to find the rule names.
@@ -134,8 +134,8 @@ overrides:
 
 **Exception Structure Rules**
 
-- `fields`, `comps`, and `values` must have the same length.
-- Each element in `values` must itself be an array.
+- `fields`, `comps` must have the same length.
+- When using multiple fields, each element in `values` must be an array (tuple) whose length matches the number of fields. When using a single field or omitting the `fields` specification, `values` can be a simple array of scalar values.
 
 ### Querying Events with Loki
 
@@ -160,7 +160,7 @@ The upstream Falco helm chart includes a Grafana dashboard out of the box for vi
 
 ### External Alert Forwarding
 
-While Loki integration provides centralized logging of Falco events, it's recommended to configure external alert forwarding using [Falco Sidekick's native output forwarding](https://github.com/falcosecurity/falcosidekick#outputs) for real-time notifications. It is generally a good idea to send these alerts to a messaging platform like Slack, Microsoft Teams where these security events can be more visbile to relevant teams.
+While Loki integration provides centralized logging of Falco events, it's recommended to configure external alert forwarding using [Falco Sidekick's native output forwarding](https://github.com/falcosecurity/falcosidekick#outputs) for real-time notifications. It is generally a good idea to send these alerts to a messaging platform like Slack, Microsoft Teams where these security events can be more visible to relevant teams.
 
 :::tip[Network Egress]
 By default, the Falco UDS Package locks down network egress for security reasons. If you need to ship alerts to external services, ensure you override the `additionalNetworkAllow` value like so:

--- a/src/falco/chart/templates/rules-configmap.yaml
+++ b/src/falco/chart/templates/rules-configmap.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 apiVersion: v1

--- a/src/falco/chart/templates/rules-configmap.yaml
+++ b/src/falco/chart/templates/rules-configmap.yaml
@@ -56,7 +56,7 @@ data:
   {{- $allDisabledRules = concat $allDisabledRules .Values.udsDefaultDisabledRulesSandbox }}
 {{- end }}
 {{- $allDisabledRules = concat $allDisabledRules .Values.disabledRules | uniq }}
-{{- if (gt (len $allDisabledRules) 0) }}
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -73,4 +73,54 @@ data:
       override:
         enabled: replace
 {{- end }}
+
+{{/*
+Renders a ConfigMap with a single key: override-rules.yaml
+Always created (but may be empty).
+*/}}
+
+{{ $lists := (.Values.overrides.lists | default dict) }}
+{{ $macros := (.Values.overrides.macros | default dict) }}
+{{ $rules := (.Values.overrides.rules | default dict) }}
+{{ $extraRules := (.Values.extraRules | default list) }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: falco-override-rules
+  namespace: falco
+  labels:
+    uds.dev/pod-reload: "true"
+data:
+  override-rules.yaml: |-
+{{- /* LIST OVERRIDES */}}
+{{- range $name, $cfg := $lists }}
+    - list: {{ $name | quote }}
+      items:
+{{ toYaml $cfg.items | nindent 8 }}
+      override:
+        items: {{ $cfg.action }}
+{{- end }}
+
+{{- /* MACRO OVERRIDES */}}
+{{- range $name, $cfg := $macros }}
+    - macro: {{ $name | quote }}
+      condition: {{ $cfg.condition | quote }}
+      override:
+        condition: {{ $cfg.action }}
+{{- end }}
+
+{{- /* RULE OVERRIDES (EXCEPTIONS ONLY) */}}
+{{- range $name, $cfg := $rules }}
+    - rule: {{ $name | quote }}
+      exceptions:
+{{ toYaml $cfg.exceptions.items | nindent 8 }}
+      override:
+        exceptions: {{ $cfg.exceptions.action }}
+{{- end }}
+
+{{- /* STRUCTURED EXTRA RULES */}}
+{{- if gt (len $extraRules) 0 }}
+{{ toYaml $extraRules | nindent 4 }}
 {{- end }}

--- a/src/falco/chart/tests/rules_configmap_test.yaml
+++ b/src/falco/chart/tests/rules_configmap_test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
@@ -28,7 +28,7 @@ tests:
           pattern: '- rule: "Contact K8S API Server From Container"'
       - matchRegex:
           path: data["disable-rules.yaml"]
-          pattern: 'enabled: false'
+          pattern: "enabled: false"
       - matchRegex:
           path: data["disable-rules.yaml"]
           pattern: 'override:\s+enabled: replace'
@@ -57,7 +57,7 @@ tests:
           pattern: '- rule: "Contact EC2 Instance Metadata Service From Container"'
       - matchRegex:
           path: data["disable-rules.yaml"]
-          pattern: 'enabled: false'
+          pattern: "enabled: false"
       - matchRegex:
           path: data["disable-rules.yaml"]
           pattern: 'override:\s+enabled: replace'
@@ -86,7 +86,7 @@ tests:
           pattern: '- rule: "Custom Rule 2"'
       - matchRegex:
           path: data["disable-rules.yaml"]
-          pattern: 'enabled: false'
+          pattern: "enabled: false"
       - matchRegex:
           path: data["disable-rules.yaml"]
           pattern: 'override:\s+enabled: replace'
@@ -198,7 +198,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["sandbox-rules.yaml"]
-          pattern: '# Sandbox rules are disabled by default'
+          pattern: "# Sandbox rules are disabled by default"
 
   - it: should include sandbox rules when sandboxRulesEnabled is true
     set:
@@ -219,7 +219,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["incubating-rules.yaml"]
-          pattern: '# Incubating rules are disabled by default'
+          pattern: "# Incubating rules are disabled by default"
 
   - it: should include incubating rules when incubatingRulesEnabled is true
     set:

--- a/src/falco/chart/tests/rules_overrides_test.yaml
+++ b/src/falco/chart/tests/rules_overrides_test.yaml
@@ -50,6 +50,28 @@ tests:
           path: data["override-rules.yaml"]
           pattern: '(?s)override:\n\s*items:\s*append'
 
+  - it: renders override ConfigMap when all overrides and extraRules are empty
+    set:
+      incubatingRulesEnabled: false
+      sandboxRulesEnabled: false
+      udsDefaultDisabledRulesStable: []
+      udsDefaultDisabledRulesIncubating: []
+      udsDefaultDisabledRulesSandbox: []
+      disabledRules: []
+      overrides: {}
+      extraRules: []
+    documentSelector:
+      path: metadata.name
+      value: falco-override-rules
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["override-rules.yaml"]
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '^\s*$'
+
   - it: renders override ConfigMap when macro overrides exist (replace)
     set:
       incubatingRulesEnabled: false

--- a/src/falco/chart/tests/rules_overrides_test.yaml
+++ b/src/falco/chart/tests/rules_overrides_test.yaml
@@ -1,6 +1,8 @@
 # Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
 suite: overrides ConfigMap (override-rules.yaml)
 templates:
   - templates/rules-configmap.yaml

--- a/src/falco/chart/tests/rules_overrides_test.yaml
+++ b/src/falco/chart/tests/rules_overrides_test.yaml
@@ -1,3 +1,6 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
 suite: overrides ConfigMap (override-rules.yaml)
 templates:
   - templates/rules-configmap.yaml

--- a/src/falco/chart/tests/rules_overrides_test.yaml
+++ b/src/falco/chart/tests/rules_overrides_test.yaml
@@ -1,0 +1,233 @@
+suite: overrides ConfigMap (override-rules.yaml)
+templates:
+  - templates/rules-configmap.yaml
+
+tests:
+  - it: renders override ConfigMap when list overrides exist (append)
+    set:
+      incubatingRulesEnabled: false
+      sandboxRulesEnabled: false
+      udsDefaultDisabledRulesStable: []
+      udsDefaultDisabledRulesIncubating: []
+      udsDefaultDisabledRulesSandbox: []
+      disabledRules: []
+      overrides:
+        lists:
+          my_programs:
+            action: append
+            items:
+              - cp
+              - mv
+      extraRules: []
+    documentSelector:
+      path: metadata.name
+      value: falco-override-rules
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+      - exists:
+          path: data["override-rules.yaml"]
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '- list: "my_programs"'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: "(?s)items:.*- cp"
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: "(?s)items:.*- mv"
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)override:\n\s*items:\s*append'
+
+  - it: renders override ConfigMap when macro overrides exist (replace)
+    set:
+      incubatingRulesEnabled: false
+      sandboxRulesEnabled: false
+      udsDefaultDisabledRulesStable: []
+      udsDefaultDisabledRulesIncubating: []
+      udsDefaultDisabledRulesSandbox: []
+      disabledRules: []
+      overrides:
+        macros:
+          open_write:
+            action: replace
+            condition: "evt.type=open"
+      extraRules: []
+    documentSelector:
+      path: metadata.name
+      value: falco-override-rules
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+      - exists:
+          path: data["override-rules.yaml"]
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '- macro: "open_write"'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)condition:\s*"evt\.type=open"'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)override:\n\s*condition:\s*replace'
+
+  - it: renders override ConfigMap when rule exception overrides exist (append) and does NOT emit rule condition override
+    set:
+      incubatingRulesEnabled: false
+      sandboxRulesEnabled: false
+      udsDefaultDisabledRulesStable: []
+      udsDefaultDisabledRulesIncubating: []
+      udsDefaultDisabledRulesSandbox: []
+      disabledRules: []
+      overrides:
+        rules:
+          "Terminal shell in container":
+            exceptions:
+              action: append
+              items:
+                - name: allow_ci_shell
+                  fields:
+                    - container.image.repository
+                  comps:
+                    - in
+                  values:
+                    - ghcr.io/my-org/ci-runner
+      extraRules: []
+    documentSelector:
+      path: metadata.name
+      value: falco-override-rules
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+      - exists:
+          path: data["override-rules.yaml"]
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '- rule: "Terminal shell in container"'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: "exceptions:"
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: 'name:\s*allow_ci_shell'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)override:\n\s*exceptions:\s*append'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: 'values:\s*\n\s*-\s*ghcr\.io/my-org/ci-runner'
+
+      # exceptions-only UX: do not render condition for rule overrides
+      - notMatchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)- rule: "Terminal shell in container".*\n\s*condition:'
+
+  - it: renders override ConfigMap when extraRules is non-empty
+    set:
+      incubatingRulesEnabled: false
+      sandboxRulesEnabled: false
+      udsDefaultDisabledRulesStable: []
+      udsDefaultDisabledRulesIncubating: []
+      udsDefaultDisabledRulesSandbox: []
+      disabledRules: []
+      overrides: {}
+      extraRules:
+        - rule: "My Local Rule"
+          desc: "Example additional rule"
+          condition: evt.type=open
+          output: "opened file"
+          priority: NOTICE
+          tags: ["local"]
+    documentSelector:
+      path: metadata.name
+      value: falco-override-rules
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+      - exists:
+          path: data["override-rules.yaml"]
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)-.*rule:\s*My Local Rule'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)condition:\s*evt\.type=open'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)condition:\s*evt\.type=open'
+
+  - it: renders override ConfigMap with lists + macros + rule exceptions + extraRules together (order sanity)
+    set:
+      incubatingRulesEnabled: false
+      sandboxRulesEnabled: false
+      udsDefaultDisabledRulesStable: []
+      udsDefaultDisabledRulesIncubating: []
+      udsDefaultDisabledRulesSandbox: []
+      disabledRules: []
+      overrides:
+        lists:
+          trusted_images:
+            action: replace
+            items:
+              - registry.corp/*
+        macros:
+          open_write:
+            action: append
+            condition: "or evt.type=openat"
+        rules:
+          "Terminal shell in container":
+            exceptions:
+              action: replace
+              items:
+                - name: allow_shell
+                  values:
+                    - bash
+                    - sh
+      extraRules:
+        - list: "extra_list"
+          items: ["x"]
+    documentSelector:
+      path: metadata.name
+      value: falco-override-rules
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+      - exists:
+          path: data["override-rules.yaml"]
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)- list: "trusted_images".*override:\n\s*items:\s*replace'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)- macro: "open_write".*override:\n\s*condition:\s*append'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)- rule: "Terminal shell in container".*override:\n\s*exceptions:\s*replace'
+
+      - matchRegex:
+          path: data["override-rules.yaml"]
+          pattern: '(?s)- list: "trusted_images".*- macro: "open_write".*- rule: "Terminal shell in container".*- items:\s*\n\s*-\s*x.*\n\s*list:\s*extra_list'

--- a/src/falco/chart/tests/rules_overrides_test.yaml
+++ b/src/falco/chart/tests/rules_overrides_test.yaml
@@ -177,10 +177,6 @@ tests:
           path: data["override-rules.yaml"]
           pattern: '(?s)condition:\s*evt\.type=open'
 
-      - matchRegex:
-          path: data["override-rules.yaml"]
-          pattern: '(?s)condition:\s*evt\.type=open'
-
   - it: renders override ConfigMap with lists + macros + rule exceptions + extraRules together (order sanity)
     set:
       incubatingRulesEnabled: false

--- a/src/falco/chart/values.schema.json
+++ b/src/falco/chart/values.schema.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "UDS Falco Values Schema (overrides + exception-only rule overrides)",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "overrides": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lists": {
+          "type": "object",
+          "description": "Falco list overrides rendered into override-rules.yaml.",
+          "additionalProperties": {
+            "$ref": "#/definitions/listOverride"
+          },
+          "default": {}
+        },
+        "macros": {
+          "type": "object",
+          "description": "Falco macro overrides rendered into override-rules.yaml.",
+          "additionalProperties": {
+            "$ref": "#/definitions/macroOverride"
+          },
+          "default": {}
+        },
+        "rules": {
+          "type": "object",
+          "description": "Rule overrides limited to exceptions only (no condition replacement).",
+          "additionalProperties": {
+            "$ref": "#/definitions/ruleExceptionOverride"
+          },
+          "default": {}
+        }
+      },
+      "default": {}
+    },
+    "extraRules": {
+      "type": "array",
+      "description": "Raw Falco rules list appended as-is.",
+      "default": []
+    }
+  },
+  "definitions": {
+    "action": {
+      "type": "string",
+      "enum": [
+        "append",
+        "replace"
+      ]
+    },
+    "listOverride": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "items"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/action"
+        },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "macroOverride": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "condition"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/action"
+        },
+        "condition": {
+          "type": "string",
+          "minLength": 1,
+          "description": "For append, provide a valid condition fragment (e.g., 'or ...', 'and ...')."
+        }
+      }
+    },
+    "ruleExceptionOverride": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exceptions"
+      ],
+      "properties": {
+        "exceptions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "action",
+            "items"
+          ],
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/action"
+            },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/exceptionItem"
+              }
+            }
+          }
+        }
+      }
+    },
+    "exceptionItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "values"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "comps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "values": {
+          "description": "Either a list of scalars or a list of tuples (list-of-lists), depending on fields/comps usage.",
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/falco/chart/values.schema.json
+++ b/src/falco/chart/values.schema.json
@@ -108,48 +108,7 @@
       ]
     },
     "networkAllowEntry": {
-      "type": "object",
-      "description": "A UDS Package network.allow entry (per https://uds.defenseunicorns.com/ reference). This schema is intentionally permissive to avoid blocking valid CR shapes.",
-      "additionalProperties": true,
-      "properties": {
-        "direction": {
-          "type": "string",
-          "enum": [
-            "Ingress",
-            "Egress"
-          ]
-        },
-        "selector": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "remoteGenerated": {
-          "type": "string",
-          "description": "UDS-generated remote target identifier (e.g., Anywhere, IntraNamespace)."
-        },
-        "remoteNamespace": {
-          "type": "string"
-        },
-        "remoteSelector": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "remoteServiceAccount": {
-          "type": "string"
-        },
-        "port": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 65535
-        },
-        "description": {
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "listOverride": {
       "type": "object",

--- a/src/falco/chart/values.schema.json
+++ b/src/falco/chart/values.schema.json
@@ -1,3 +1,6 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "UDS Falco Values Schema (overrides + exception-only rule overrides)",

--- a/src/falco/chart/values.schema.json
+++ b/src/falco/chart/values.schema.json
@@ -1,6 +1,3 @@
-# Copyright 2026 Defense Unicorns
-# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
-
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "UDS Falco Values Schema (overrides + exception-only rule overrides)",

--- a/src/falco/chart/values.schema.json
+++ b/src/falco/chart/values.schema.json
@@ -4,9 +4,64 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "additionalNetworkAllow": {
+      "type": "array",
+      "default": [],
+      "description": "Additional entries merged into the UDS Package spec.network.allow list (escape hatch for custom network policy rules).",
+      "items": {
+        "$ref": "#/definitions/networkAllowEntry"
+      }
+    },
+    "incubatingRulesEnabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Toggle inclusion of Falco's incubating ruleset."
+    },
+    "sandboxRulesEnabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Toggle inclusion of Falco's sandbox (experimental) ruleset."
+    },
+    "disabledRules": {
+      "type": "array",
+      "default": [],
+      "description": "List of Falco rule names to explicitly disable by name.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "udsDefaultDisabledRulesStable": {
+      "type": "array",
+      "default": [],
+      "description": "Falco stable rules that are disabled by default in UDS.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "udsDefaultDisabledRulesIncubating": {
+      "type": "array",
+      "default": [],
+      "description": "Falco incubating rules that are disabled by default in UDS (only used when incubatingRulesEnabled=true).",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "udsDefaultDisabledRulesSandbox": {
+      "type": "array",
+      "default": [],
+      "description": "Falco sandbox rules that are disabled by default in UDS (only used when sandboxRulesEnabled=true).",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "overrides": {
       "type": "object",
       "additionalProperties": false,
+      "default": {},
       "properties": {
         "lists": {
           "type": "object",
@@ -32,13 +87,16 @@
           },
           "default": {}
         }
-      },
-      "default": {}
+      }
     },
     "extraRules": {
       "type": "array",
-      "description": "Raw Falco rules list appended as-is.",
-      "default": []
+      "description": "Additional Falco rules/list/macro YAML objects appended as-is after override blocks.",
+      "default": [],
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
     }
   },
   "definitions": {
@@ -48,6 +106,50 @@
         "append",
         "replace"
       ]
+    },
+    "networkAllowEntry": {
+      "type": "object",
+      "description": "A UDS Package network.allow entry (per https://uds.defenseunicorns.com/ reference). This schema is intentionally permissive to avoid blocking valid CR shapes.",
+      "additionalProperties": true,
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": [
+            "Ingress",
+            "Egress"
+          ]
+        },
+        "selector": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "remoteGenerated": {
+          "type": "string",
+          "description": "UDS-generated remote target identifier (e.g., Anywhere, IntraNamespace)."
+        },
+        "remoteNamespace": {
+          "type": "string"
+        },
+        "remoteSelector": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "remoteServiceAccount": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "description": {
+          "type": "string"
+        }
+      }
     },
     "listOverride": {
       "type": "object",
@@ -136,7 +238,8 @@
       "properties": {
         "name": {
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Exception name. If this matches an existing exception in the base rules, fields/comps may be omitted and Falco will apply values to that exception definition."
         },
         "fields": {
           "type": "array",
@@ -155,7 +258,7 @@
           }
         },
         "values": {
-          "description": "Either a list of scalars or a list of tuples (list-of-lists), depending on fields/comps usage.",
+          "description": "Falco exception values. For single-field exceptions, Falco accepts either a flat list (values: [a,b]) OR tuple rows (values: [[a],[b]]). For multi-field exceptions, use tuple rows (values: [[a,b],[c,d]]).",
           "oneOf": [
             {
               "type": "array",

--- a/src/falco/chart/values.yaml
+++ b/src/falco/chart/values.yaml
@@ -36,7 +36,7 @@ udsDefaultDisabledRulesIncubating:
 # Sandbox ruleset disabled rules
 udsDefaultDisabledRulesSandbox: []
 
-# Overrides for built-in Falco rules, macros, and lists. Each entry supports an "action" field (replace, append, or remove) and an "items" field with the relevant YAML snippet for the override.
+# Overrides for built-in Falco rules, macros, and lists. Each entry supports an "action" field (replace, append) and an "items" field with the relevant YAML snippet for the override.
 overrides:
   lists: {}
   macros: {}

--- a/src/falco/chart/values.yaml
+++ b/src/falco/chart/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # Support for custom `network.allow` entries on the Package CR, useful for sending Falco Sidekick alerts to external destinations

--- a/src/falco/chart/values.yaml
+++ b/src/falco/chart/values.yaml
@@ -35,3 +35,41 @@ udsDefaultDisabledRulesIncubating:
 
 # Sandbox ruleset disabled rules
 udsDefaultDisabledRulesSandbox: []
+
+# Overrides for built-in Falco rules, macros, and lists. Each entry supports an "action" field (replace, append, or remove) and an "items" field with the relevant YAML snippet for the override.
+overrides:
+  lists: {}
+  macros: {}
+  rules: {}
+# Raw Falco rules YAML appended as-is (optional)
+extraRules: []
+# Example usage:
+#
+# overrides:
+#   lists:
+#     trusted_images:
+#       action: replace
+#       items:
+#         - "registry.corp/*"
+#         - "gcr.io/distroless/*"
+#   macros:
+#     open_write:
+#       action: append
+#       condition: "or evt.type=openat"
+#   rules:
+#     "Terminal shell in container":
+#       exceptions:
+#         action: append
+#         items:
+#           - name: allow_ci_shell
+#             fields: ["container.image.repository"]
+#             comps: ["in"]
+#             values: ["ghcr.io/my-org/ci-runner"]
+#
+# extraRules:
+#   - rule: "My Local Rule"
+#     desc: "Example additional rule"
+#     condition: evt.type=open
+#     output: "opened file"
+#     priority: NOTICE
+#     tags: ["local"]

--- a/src/falco/values/values.yaml
+++ b/src/falco/values/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # Disable automatic update/loading of Falco default rules for airgapped environments

--- a/src/falco/values/values.yaml
+++ b/src/falco/values/values.yaml
@@ -22,6 +22,7 @@ falco:
     - /etc/falco/rules.d/incubating-rules.yaml
     - /etc/falco/rules.d/sandbox-rules.yaml
     - /etc/falco/rules.d/disable-rules.yaml
+    - /etc/falco/rules.d/override-rules.yaml
 
 mounts:
   volumes:
@@ -37,6 +38,9 @@ mounts:
     - name: disable-rules
       configMap:
         name: falco-disable-rules
+    - name: override-rules
+      configMap:
+        name: falco-override-rules
   volumeMounts:
     - name: stable-rules
       mountPath: /etc/falco/rules.d/stable-rules.yaml
@@ -53,6 +57,10 @@ mounts:
     - name: disable-rules
       mountPath: /etc/falco/rules.d/disable-rules.yaml
       subPath: disable-rules.yaml
+      readOnly: true
+    - name: override-rules
+      mountPath: /etc/falco/rules.d/override-rules.yaml
+      subPath: override-rules.yaml
       readOnly: true
 
 containerSecurityContext:


### PR DESCRIPTION
## Description

- Adds a new set of values for falco helm chart that allow for [rule overrides](https://falco.org/docs/concepts/rules/overriding/) including [rule exceptions](https://falco.org/docs/concepts/rules/exceptions/)
- Adds exception for privileged mount for csi pods for eks IaC bundle

Note Falco documentation:
> The keys that can be overridden vary by rules component and action being taken:
> - Lists (append or replace): items
> - Macros (append or replace): condition
> - Rules (append): condition, output, desc, tags, exceptions
> - Rules (replace): condition, output desc, priority, tags, exceptions, enabled, warn_evttypes, skip-if-unknown-filter

## Related Issue

Fixes #2254

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

<details>
<summary>Testing Details</summary>

Added the following to falco bundle overrides for k3d-standard bundle to test:

```
      values:
                macros:
                  user_expected_terminal_shell_in_container_conditions:
                    action: replace
                    condition: '(k8s.ns.name="monitoring")'
                rules:
                  "Terminal shell in container":
                    exceptions:
                      action: append
                      items:
                        - name: allow_shell_in_ns
                          fields: ["k8s.ns.name"]
                          comps: ["="]
                          values:
                            - ["monitoring"]
                  "Unexpected UDP Traffic":
                    exceptions:
                      action: append
                      items:
                        - name: allow_udp_in_smoke_ns
                          fields: ["proc.name", "fd.l4proto"]
                          comps: ["=", "="]
                          values:
                            - ["iptables-restor", "udp"]
            - path: extraRules
              value:
                - rule: UDS Smoke Test - Open marker file
                  desc: Smoke test rule to verify extraRules is loaded (opens a known file)
                  condition: evt.type in (open,openat,openat2) and fd.name="/tmp/uds-falco-smoke.marker" and evt.is_open_read=true
                  output: "UDS SMOKE: opened marker file (proc=%proc.name user=%user.name container=%container.id)"
                  priority: NOTICE
                  tags: [local, uds_smoke]
```

Test extraRules:

```
kubectl run falco-smoke-marker \
  -n monitoring \
  --image=127.0.0.1:31999/library/busybox:1.37.0-zarf-2140033595 \
  --restart=Never \
  --command -- sh -c 'echo hello > /tmp/uds-falco-smoke.marker && cat /tmp/uds-falco-smoke.marker >/dev/null' \
  --overrides='
{
  "spec": {
    "securityContext": {
      "runAsNonRoot": true,
      "runAsUser": 1000
    },
    "containers": [{
      "name": "falco-smoke-marker",
      "securityContext": {
        "allowPrivilegeEscalation": false,
        "capabilities": { "drop": ["ALL"] }
      }
    }]
  }
}'
```
Observed "UDS SMOKE: opened marker file..." in logs

Test exception:

```
kubectl run falco-smoke-shell \
  -n monitoring \
  --image=127.0.0.1:31999/library/busybox:1.37.0-zarf-2140033595 \
  --restart=Never \
  --command -- sh -c 'while true; do sleep 3600; done' \
  --overrides='
{
  "spec": {
    "securityContext": {
      "runAsNonRoot": true,
      "runAsUser": 1000
    },
    "containers": [{
      "name": "falco-smoke-shell",
      "securityContext": {
        "allowPrivilegeEscalation": false,
        "capabilities": { "drop": ["ALL"] }
      }
    }]
  }
}
```

Opened shell in pod. Did not see "Terminal shell in container" in logs.  (Confirmed prior to rule exception I did see in logs)


Confirmed the following removed Unexpected UDP traffic in k3d demo deployments

```
"Unexpected UDP Traffic":
exceptions:
  action: append
  items:
	- name: allow_udp_in_smoke_ns
	  fields: ["proc.name", "fd.l4proto"]
	  comps: ["=", "="]
	  values:
		- ["iptables-restor", "udp"]
```

</details>

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed