### PR TITLE
chore: set IAC bundles k8s-sidecar logs to debug

### DIFF
--- a/.github/bundles/aks/uds-bundle.yaml
+++ b/.github/bundles/aks/uds-bundle.yaml
@@ -76,6 +76,8 @@ packages:
           values:
             - path: loki.storage.type
               value: "azure"
+            - path: sidecar.rules.logLevel
+              value: DEBUG
 
       kube-prometheus-stack:
         kube-prometheus-stack:
@@ -87,6 +89,11 @@ packages:
                     memory: 512Mi
       grafana:
         grafana:
+          values:
+            - path: sidecar.dashboards.logLevel
+              value: DEBUG
+            - path: sidecar.datasources.logLevel
+              value: DEBUG
           variables:
             - name: GRAFANA_HA
               description: Enable HA Grafana

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -54,6 +54,8 @@ packages:
               value: ""
             - path: loki.storage.s3.accessKeyId
               value: ""
+            - path: sidecar.rules.logLevel
+              value: DEBUG
           variables:
             - name: LOKI_CHUNKS_BUCKET
               description: "The object storage bucket for Loki chunks"
@@ -72,6 +74,11 @@ packages:
               path: serviceAccount.annotations.eks\.amazonaws\.com/role-arn
       grafana:
         grafana:
+          values:
+            - path: sidecar.dashboards.logLevel
+              value: DEBUG
+            - path: sidecar.datasources.logLevel
+              value: DEBUG
           variables:
             - name: GRAFANA_HA
               description: Enable HA Grafana

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -60,9 +60,6 @@ packages:
             - name: LOKI_CHUNKS_BUCKET
               description: "The object storage bucket for Loki chunks"
               path: loki.storage.bucketNames.chunks
-            - name: LOKI_RULER_BUCKET
-              description: "The object storage bucket for Loki ruler"
-              path: loki.storage.bucketNames.ruler
             - name: LOKI_ADMIN_BUCKET
               description: "The object storage bucket for Loki admin"
               path: loki.storage.bucketNames.admin

--- a/.github/bundles/rke2/uds-bundle.yaml
+++ b/.github/bundles/rke2/uds-bundle.yaml
@@ -91,9 +91,6 @@ packages:
             - name: LOKI_CHUNKS_BUCKET
               description: "The object storage bucket for Loki chunks"
               path: loki.storage.bucketNames.chunks
-            - name: LOKI_RULER_BUCKET
-              description: "The object storage bucket for Loki ruler"
-              path: loki.storage.bucketNames.ruler
             - name: LOKI_ADMIN_BUCKET
               description: "The object storage bucket for Loki admin"
               path: loki.storage.bucketNames.admin

--- a/.github/bundles/rke2/uds-bundle.yaml
+++ b/.github/bundles/rke2/uds-bundle.yaml
@@ -85,6 +85,8 @@ packages:
               value: ""
             - path: global.dnsService
               value: rke2-coredns-rke2-coredns
+            - path: sidecar.rules.logLevel
+              value: DEBUG
           variables:
             - name: LOKI_CHUNKS_BUCKET
               description: "The object storage bucket for Loki chunks"
@@ -103,6 +105,11 @@ packages:
               path: serviceAccount.annotations.irsa/role-arn
       grafana:
         grafana:
+          values:
+            - path: sidecar.dashboards.logLevel
+              value: DEBUG
+            - path: sidecar.datasources.logLevel
+              value: DEBUG
           variables:
             - name: GRAFANA_HA
               description: Enable HA Grafana

--- a/.github/test-infra/aws/eks/uds-config.tf
+++ b/.github/test-infra/aws/eks/uds-config.tf
@@ -10,7 +10,6 @@ resource "local_sensitive_file" "uds_config" {
     "variables" : {
       "core" : {
         "loki_chunks_bucket" : module.S3["loki"].bucket_name
-        "loki_ruler_bucket" : module.S3["loki"].bucket_name,
         "loki_admin_bucket" : module.S3["loki"].bucket_name,
         "loki_s3_region" : data.aws_region.current.region,
         "loki_irsa_role_arn" : module.irsa["loki"].role_arn,

--- a/.github/test-infra/aws/rke2/uds-config.tf
+++ b/.github/test-infra/aws/rke2/uds-config.tf
@@ -10,7 +10,6 @@ resource "local_sensitive_file" "uds_config" {
     "variables" : {
       "core" : {
         "loki_chunks_bucket" : module.storage.s3_buckets["loki"].bucket_name
-        "loki_ruler_bucket" : module.storage.s3_buckets["loki"].bucket_name,
         "loki_admin_bucket" : module.storage.s3_buckets["loki"].bucket_name,
         "loki_s3_region" : data.aws_region.current.name,
         "loki_irsa_role_arn" : module.storage.irsa["loki"].bucket_role.arn


### PR DESCRIPTION
## Description

Sets k8s-sidecar to DEBUG logs in our IAC bundles.  We have had some flakiness with the sidecars (specifically loki ruler) not picking up configmaps and failing e2e tests.  Setting logs to DEBUG might give us some more clarity as to what is happening.

Related to #2351

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed