### PR TITLE
chore: swap example.com for bing.com in our network tests

### DIFF
--- a/src/test/app-egress-ambient-package.yaml
+++ b/src/test/app-egress-ambient-package.yaml
@@ -23,7 +23,7 @@ spec:
           app: curl
         ports:
           - 443
-        remoteHost: www.example.com
+        remoteHost: www.bing.com
         remoteProtocol: TLS
         description: "Example Curl"
 ---

--- a/src/test/app-egress-ambient.yaml
+++ b/src/test/app-egress-ambient.yaml
@@ -1,7 +1,7 @@
 # Copyright 2025 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-# egress-ambient-1 tests curl to example.com via 443
+# egress-ambient-1 tests curl to bing.com via 443
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/test/app-egress-sidecar-package.yaml
+++ b/src/test/app-egress-sidecar-package.yaml
@@ -23,7 +23,7 @@ spec:
           app: curl
         ports:
           - 443
-        remoteHost: example.com
+        remoteHost: bing.com
         remoteProtocol: TLS
         description: "Example Curl"
 ---
@@ -49,6 +49,6 @@ spec:
           app: curl
         ports:
           - 80
-        remoteHost: example.com
+        remoteHost: bing.com
         remoteProtocol: HTTP
         description: "Example Curl"

--- a/test/vitest/network.spec.ts
+++ b/test/vitest/network.spec.ts
@@ -284,13 +284,13 @@ describe("Network Policy Validation", { retry: 2 }, () => {
     const egress_ambient_http_curl = [
       "sh",
       "-c",
-      `curl -s -w " HTTP_CODE:%{http_code}" http://www.example.com`,
+      `curl -s -w " HTTP_CODE:%{http_code}" http://www.bing.com`,
     ];
 
     const egress_ambient_tls_curl = [
       "sh",
       "-c",
-      `curl -s -w " HTTP_CODE:%{http_code}" https://www.example.com`,
+      `curl -s -w " HTTP_CODE:%{http_code}" https://www.bing.com`,
     ];
 
     // Validate successful tls request when using Egress for egress-ambient-1
@@ -301,7 +301,7 @@ describe("Network Policy Validation", { retry: 2 }, () => {
       egress_ambient_tls_curl,
     );
 
-    const tlsDebugMessage = `TLS example.com curl failed: stdout=${success_response_tls.stdout}, stderr=${success_response_tls.stderr}`;
+    const tlsDebugMessage = `TLS bing.com curl failed: stdout=${success_response_tls.stdout}, stderr=${success_response_tls.stderr}`;
 
     expect(isResponseError(success_response_tls), tlsDebugMessage).toBe(false);
 
@@ -353,14 +353,10 @@ describe("Network Policy Validation", { retry: 2 }, () => {
   test.concurrent(
     "Admin (Anywhere, ambient) can reach remoteHost defined in another namespace",
     async () => {
-      const EXAMPLE_TLS = [
-        "sh",
-        "-c",
-        `curl -s -w " HTTP_CODE:%{http_code}" https://www.example.com`,
-      ];
+      const EXAMPLE_TLS = ["sh", "-c", `curl -s -w " HTTP_CODE:%{http_code}" https://www.bing.com`];
 
       // Source: test-admin-app (Anywhere via app-admin-package, now ambient)
-      // Target: www.example.com defined as remoteHost in egress-ambient-1
+      // Target: www.bing.com defined as remoteHost in egress-ambient-1
       const resp = await execInPod("test-admin-app", testAdminApp, "curl", EXAMPLE_TLS);
       const msg = `Admin Anywhere->remoteHost cross-ns: stdout=${resp.stdout}, stderr=${resp.stderr}`;
       expect(isResponseError(resp), msg).toBe(false);
@@ -372,7 +368,7 @@ describe("Network Policy Validation", { retry: 2 }, () => {
     const EXAMPLE_TLS_DENIED = [
       "sh",
       "-c",
-      `curl -s -w " HTTP_CODE:%{http_code}" https://www.example.com`,
+      `curl -s -w " HTTP_CODE:%{http_code}" https://www.bing.com`,
     ];
 
     const resp = await execInPod(
@@ -381,7 +377,7 @@ describe("Network Policy Validation", { retry: 2 }, () => {
       "curl",
       EXAMPLE_TLS_DENIED,
     );
-    const msg = `Egress Ambient per-host isolation (example.com denied for egress-ambient-2 SA): stdout=${resp.stdout}, stderr=${resp.stderr}`;
+    const msg = `Egress Ambient per-host isolation (bing.com denied for egress-ambient-2 SA): stdout=${resp.stdout}, stderr=${resp.stderr}`;
     expect(isResponseError(resp), msg).toBe(true);
   });
 
@@ -391,7 +387,7 @@ describe("Network Policy Validation", { retry: 2 }, () => {
       const EXAMPLE_HTTP_DENIED = [
         "sh",
         "-c",
-        `curl -s -w " HTTP_CODE:%{http_code}" http://www.example.com`,
+        `curl -s -w " HTTP_CODE:%{http_code}" http://www.bing.com`,
       ];
 
       const resp = await execInPod(
@@ -400,7 +396,7 @@ describe("Network Policy Validation", { retry: 2 }, () => {
         "curl",
         EXAMPLE_HTTP_DENIED,
       );
-      const msg = `Egress Ambient HTTP example.com denied for egress-ambient-2 SA: stdout=${resp.stdout}, stderr=${resp.stderr}`;
+      const msg = `Egress Ambient HTTP bing.com denied for egress-ambient-2 SA: stdout=${resp.stdout}, stderr=${resp.stderr}`;
       expect(isResponseError(resp), msg).toBe(true);
     },
   );
@@ -409,13 +405,13 @@ describe("Network Policy Validation", { retry: 2 }, () => {
     const egress_gateway_http_curl = [
       "sh",
       "-c",
-      `curl -s -w " HTTP_CODE:%{http_code}" http://example.com`,
+      `curl -s -w " HTTP_CODE:%{http_code}" http://bing.com`,
     ];
 
     const egress_gateway_tls_curl = [
       "sh",
       "-c",
-      `curl -s -w " HTTP_CODE:%{http_code}" https://example.com`,
+      `curl -s -w " HTTP_CODE:%{http_code}" https://bing.com`,
     ];
 
     // Validate successful tls request when using Egress Gateway for egress-gw-1


### PR DESCRIPTION
## Description

`example.com` in our e2e tests started showing cert invalid issues for the new cert issued on Feb 13.  It appears the curl image does not trust this cert.  Swapping to `bing.com`.
## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- `uds run test:uds-core-e2e`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed