### PR TITLE
fix(ci): update hook timeout on keycloak notification test

### DIFF
--- a/test/vitest/keycloak-notifications.spec.ts
+++ b/test/vitest/keycloak-notifications.spec.ts
@@ -2,16 +2,16 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
-import * as net from "net";
 import * as crypto from "crypto";
+import * as net from "net";
 import { afterAll, beforeAll, describe, test } from "vitest";
-import { closeForward, getForward } from "./helpers/forward";
 import { expectAlertFires } from "./helpers/alertmanager";
+import { closeForward, getForward } from "./helpers/forward";
 import {
-  getAdminToken,
   createRandomClient,
   createRandomUserAndJoinGroup,
   createUser,
+  getAdminToken,
 } from "./helpers/keycloak";
 
 let alertmanagerProxy: { server: net.Server; url: string };
@@ -46,7 +46,7 @@ describe("integration - Keycloak Notifications", () => {
 
     const randomMasterRealmUsername = `keycloak-notifications-test-${crypto.randomBytes(6).toString("base64url")}`;
     await createUser(keycloakProxy.url, accessToken, randomMasterRealmUsername, "master");
-  });
+  }, testTimeoutMs);
 
   afterAll(async () => {
     await closeForward(alertmanagerProxy.server);

--- a/test/vitest/keycloak-notifications.spec.ts
+++ b/test/vitest/keycloak-notifications.spec.ts
@@ -19,6 +19,7 @@ let prometheusProxy: { server: net.Server; url: string };
 let keycloakProxy: { server: net.Server; url: string };
 
 const testTimeoutMs = 5 * 60 * 1000; // 5 minutes timeout for the test
+const hookTimeoutMs = 60 * 1000; // 1 minute for hook timeout (realm/user changes)
 
 describe("integration - Keycloak Notifications", () => {
   beforeAll(async () => {
@@ -46,7 +47,7 @@ describe("integration - Keycloak Notifications", () => {
 
     const randomMasterRealmUsername = `keycloak-notifications-test-${crypto.randomBytes(6).toString("base64url")}`;
     await createUser(keycloakProxy.url, accessToken, randomMasterRealmUsername, "master");
-  }, testTimeoutMs);
+  }, hookTimeoutMs);
 
   afterAll(async () => {
     await closeForward(alertmanagerProxy.server);


### PR DESCRIPTION
## Description

While chasing test issues I identified that the hook timeout is 10s on the `Keycloak Notifications` test and can sometimes timeout (see [here](https://github.com/defenseunicorns/uds-core/actions/runs/22005084594/job/63586874395?pr=2376)), but the overall test allows 5 minutes.

Increasing the hook timeout to 1 minute gives more flexibility to account for slower setup, while not exceeding the overall test time.