### PR TITLE
fix: set k8s-sidecar watch method to SLEEP

### DIFF
--- a/src/grafana/values/values.yaml
+++ b/src/grafana/values/values.yaml
@@ -8,6 +8,7 @@ sidecar:
     searchNamespace: ALL
     initDashboards: true
     restartPolicy: Always
+    watchMethod: SLEEP # use sleep method to avoid watch issues (will relist every 60 secs)
     startupProbe:
       httpGet:
         path: /healthz
@@ -20,6 +21,7 @@ sidecar:
     label: grafana_datasource
     initDatasources: true
     restartPolicy: Always
+    watchMethod: SLEEP # use sleep method to avoid watch issues (will relist every 60 secs)
     startupProbe:
       httpGet:
         path: /healthz

--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -187,6 +187,7 @@ sidecar:
     folder: /rules/fake # Note: when auth is not enabled on Loki the tenant is 'fake'
     # -- Look for configmaps/secrets in all namespaces
     searchNamespace: ALL
+    watchMethod: SLEEP # use sleep method to avoid watch issues (will relist every 60 secs)
 
 memcachedExporter:
   # -- Whether memcached metrics should be exported


### PR DESCRIPTION
## Description

This PR sets k8s-sidecars (in both Grafana and Loki) to watch method to SLEEP.  We have been having flakey issues with the WATCH method in our IAC e2e tests. Setting to SLEEP to improve stability.

## Related Issue

Fixes #2351 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- IAC e2e tests in CI

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed