### PR TITLE
chore: update rke2 get-kubeconfig

### DIFF
--- a/.github/bundles/.gitignore
+++ b/.github/bundles/.gitignore
@@ -1,1 +1,0 @@
-**/uds-config.yaml

--- a/.github/test-infra/aws/rke2/scripts/get-kubeconfig.sh
+++ b/.github/test-infra/aws/rke2/scripts/get-kubeconfig.sh
@@ -1,55 +1,75 @@
 #!/bin/bash
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-
-
 # Utility script that can be called from a uds task after tofu has deployed the e2e test module
-
+#
+set -euo pipefail
 echo "tofu version: $(tofu --version)"
 
 # Get required outputs from tofu
-tofu output -raw private_key > key.pem
+tofu output -raw private_key >key.pem
 chmod 600 key.pem
+trap 'rm -f key.pem' EXIT
 
 bootstrap_ip=$(tofu output -raw bootstrap_ip)
 node_user=$(tofu output -raw node_user)
 cluster_hostname=$(tofu output -raw cluster_hostname)
 
+ssh_opts=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i key.pem)
+
 # Try ssh up to 20 times waiting 15 seconds between tries
+ok=false
 for i in $(seq 1 20); do
-    echo "Waiting on cloud-init to finish running on cluster node"
-    ssh -o StrictHostKeyChecking=no -i key.pem ${node_user}@${bootstrap_ip} "cloud-init status --wait" > /dev/null && break
-    sleep 15
+  echo "Waiting on cloud-init to finish running on cluster node (attempt $i/20)"
+  if ssh "${ssh_opts[@]}" "${node_user}@${bootstrap_ip}" "cloud-init status --wait" >/dev/null; then
+    ok=true
+    break
+  fi
+  sleep 15
 done
+
+if [[ "$ok" != true ]]; then
+  echo "ERROR: cloud-init did not finish after 20 attempts" >&2
+  exit 1
+fi
 
 # Make sure .kube directory exists
 mkdir -p ~/.kube
 
-# Copy kubectl from cluster node
-ssh -o StrictHostKeyChecking=no -i key.pem ${node_user}@${bootstrap_ip} "mkdir -p /home/${node_user}/.kube && sudo cp /etc/rancher/rke2/rke2.yaml /home/${node_user}/.kube/config && sudo chown ${node_user} /home/${node_user}/.kube/config" > /dev/null
-scp -o StrictHostKeyChecking=no -i key.pem ${node_user}@${bootstrap_ip}:/home/${node_user}/.kube/config ./rke2-config > /dev/null
+# Copy kubeconfig from cluster node
+ssh "${ssh_opts[@]}" "${node_user}@${bootstrap_ip}" \
+  "mkdir -p /home/${node_user}/.kube && sudo cp /etc/rancher/rke2/rke2.yaml /home/${node_user}/.kube/config && sudo chown ${node_user} /home/${node_user}/.kube/config" >/dev/null
+scp "${ssh_opts[@]}" "${node_user}@${bootstrap_ip}:/home/${node_user}/.kube/config" ./rke2-config >/dev/null
 
-# Replace the loopback address with the cluster hostname
-sed -i "s/127.0.0.1/${bootstrap_ip}/g" ./rke2-config > /dev/null
-mkdir -p /home/runner/.kube
-mv ./rke2-config /home/runner/.kube/config
+# Replace the loopback address with the bootstrap IP address
+# GNU sed supports --version flag, BSD/macOS sed does not
+# On macOS (BSD sed), -i requires a backup-extension argument (often '')
+if sed --version >/dev/null 2>&1; then
+  sed -i "s/127.0.0.1/${bootstrap_ip}/g" ./rke2-config >/dev/null
+else
+  sed -i '' "s/127.0.0.1/${bootstrap_ip}/g" ./rke2-config >/dev/null
+fi
+
+mkdir -p ~/.kube
+mv ./rke2-config ~/.kube/config
 #export KUBECONFIG=$(pwd)/rke2-config
 
-# find existing host record in the host file and save the line numbers
-matches_in_hosts="$(grep -n $cluster_hostname /etc/hosts | cut -f1 -d:)"
+# Add or update /etc/hosts file record
+matches_in_hosts="$(grep -nF -- "$cluster_hostname" /etc/hosts | cut -f1 -d: || true)"
 host_entry="${bootstrap_ip} ${cluster_hostname}"
 
-# Add or update /etc/hosts file record
-if [ ! -z "$matches_in_hosts" ]
-then
-    echo "Updating existing hosts entry."
-    # iterate over the line numbers on which matches were found
-    while read -r line_number; do
-        # replace the text of each line with the desired host entry
-        sudo sed -i "${line_number}s/.*/${host_entry} /" /etc/hosts  > /dev/null
-    done <<< "$matches_in_hosts"
+if [[ -n "$matches_in_hosts" ]]; then
+  echo "Updating existing hosts entry."
+  while read -r line_number; do
+    [[ -z "$line_number" ]] && continue
+    if sed --version >/dev/null 2>&1; then
+      sudo sed -i "${line_number}s|.*|${host_entry}|" /etc/hosts >/dev/null
+    else
+      sudo sed -i '' "${line_number}s|.*|${host_entry}|" /etc/hosts >/dev/null
+    fi
+  done <<<"$matches_in_hosts"
 else
-    echo "Adding new hosts entry."
-    echo "$host_entry" | sudo tee -a /etc/hosts  > /dev/null
+  echo "Adding new hosts entry."
+  echo "$host_entry" | sudo tee -a /etc/hosts >/dev/null
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ cluster-config.yaml
 
 uds-docs/
 uds-docs/**
+**/uds-config.yaml
 
 *.tar
 


### PR DESCRIPTION
## Description
- Some enhancements to make the this rke2 script more flexible with different version of sed and local troubleshooting
- Moved `**/uds-config.yaml` in nested gitignore to gitignore at root.  Pre-commit check for license will fail on it if file exists.  As it does when testing RKE2 from local machine
...

## Related Issue

Relates to #2341

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed