### PR TITLE
chore(docs): document airgapped certificate revocation check process

### DIFF
--- a/docs/dev/keycloak-crl-airgap.md
+++ b/docs/dev/keycloak-crl-airgap.md
@@ -137,7 +137,7 @@ variables:
 
 Reference that in the deployment of slim-dev bundle:
 ```bash
-
+UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-amd64-*.tar.zst --confirm --no-progress
 ```
 
 ### 1.3) Add keycloak-crls package to bundle
@@ -178,7 +178,7 @@ UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/
 # Configure tenant gateway to trust our demo CA and advertise to browsers
 kubectl -n istio-tenant-gateway patch secret gateway-tls \
   --type merge \
-  -p '{"data": {"cacert": "'"$(base64 -w 0 pki-crl-test/ca.crt)"'"}}'
+  -p '{"data": {"cacert": "'"$(base64 < pki-crl-test/ca.crt | tr -d '\n')"'"}}'
 
 # Restart tenant gateway to apply CA trust changes
 kubectl -n istio-tenant-gateway rollout restart deployment tenant-ingressgateway
@@ -234,7 +234,7 @@ zip -j demo-crls.zip demoCA/demo-ca.crl
 ```bash
 cd <path-to-uds-core-repo>
 
-bash scripts/keycloak-crl-airgap/update-keycloak-crl-oci-volume-package.sh \
+bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh \
   --crl-zip "$WORKDIR/demo-crls.zip"
 
 uds zarf package deploy keycloak-crls/zarf-package-keycloak-crls-*.tar.zst --confirm

--- a/docs/dev/keycloak-crl-airgap.md
+++ b/docs/dev/keycloak-crl-airgap.md
@@ -1,0 +1,266 @@
+# Local Testing (Fake CA + CRL) using the CRL OCI Volume Scripts
+
+This guide is for **local/dev testing only**.
+
+---
+
+## 1) Create Fake CA and CRL
+
+> **Note:** Copy and paste the following snippet into a bash shell
+
+```bash
+# Setup working directory for PKI materials
+WORKDIR="${WORKDIR:-$(pwd)/pki-crl-test}"
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+# Initialize OpenSSL CA database structure
+mkdir -p demoCA/newcerts
+: > demoCA/index.txt
+echo 1000 > demoCA/serial
+echo 1000 > demoCA/crlnumber
+
+# Create OpenSSL configuration for CA and certificate generation
+cat > ca.conf <<'EOF'
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+dir = .
+database = $dir/demoCA/index.txt
+new_certs_dir = $dir/demoCA/newcerts
+certificate = $dir/ca.crt
+serial = $dir/demoCA/serial
+private_key = $dir/ca.key
+crlnumber = $dir/demoCA/crlnumber
+crl = $dir/demoCA/demo-ca.crl
+default_md = sha256
+default_days = 365
+default_crl_days = 30
+unique_subject = no
+policy = policy_any
+copy_extensions = copy
+
+[ policy_any ]
+commonName = supplied
+
+[ v3_client ]
+subjectAltName = @alt_names
+keyUsage = digitalSignature
+extendedKeyUsage = clientAuth, 2.16.840.1.101.3.6.8
+certificatePolicies = @policy_anything
+
+[ alt_names ]
+# UPN (otherName) used by the UDS X.509 flow
+otherName.0 = 2.16.840.1.101.3.6.6;UTF8:test@mil
+email = unicorn.test@uds.dev
+
+# Include a policy OID that UDS accepts (must match Common.REQUIRED_CERT_POLICIES)
+[ policy_anything ]
+policyIdentifier = 2.16.840.1.101.3.2.1.3.12
+EOF
+
+# Generate Certificate Authority (CA) key and certificate
+openssl genrsa -out ca.key 2048
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.crt \
+  -subj "/CN=UDS Scripted CRL Demo CA" \
+  -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "keyUsage=critical,keyCertSign,cRLSign"
+
+# Generate client certificate key and signing request
+openssl genrsa -out client.key 2048
+openssl req -new -key client.key -out client.csr -subj "/CN=UNICORN.TEST.USER.1234567890"
+openssl ca -batch -config ca.conf -in client.csr -out client.crt -extensions v3_client
+
+# Create PKCS12 bundle for browser import (empty password)
+openssl pkcs12 -export -out client.pfx -inkey client.key -in client.crt -certfile ca.crt -passout pass:
+
+# Generate Certificate Revocation List (CRL) in PEM (keep as .crl)
+openssl ca -batch -config ca.conf -gencrl -out demoCA/demo-ca.crl
+
+# Verify locally before packaging (this is critical)
+openssl crl -in demoCA/demo-ca.crl -noout -text >/dev/null
+
+# Package CRL into ZIP for OCI volume creation
+zip -j demo-crls.zip demoCA/demo-ca.crl
+
+# Create Zarf OCI volume package containing the CRL
+cd ../
+bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh \
+  --crl-zip "pki-crl-test/demo-crls.zip"
+```
+
+### 1.1) Configure Slim Dev Bundle
+
+Copy the Keycloak CRL Path from the generated crl paths text file into the uds-bundle.yaml:
+```yaml
+      keycloak:
+        keycloak:
+          values:
+            - path: realmInitEnv
+              value:
+                X509_OCSP_FAIL_OPEN: "false"
+                X509_OCSP_CHECKING_ENABLED: "false"
+                X509_CRL_CHECKING_ENABLED: "true"
+                X509_CRL_ABORT_IF_NON_UPDATED: "false"
+                X509_CRL_RELATIVE_PATH: "../../../tmp/keycloak-crls/demo-ca.crl" # add CRL Path here with '##' delimiter
+            - path: extraVolumes
+              value:
+                - name: ca-certs
+                  configMap:
+                    name: uds-trust-bundle
+                    optional: true
+                - name: keycloak-crls
+                  image:
+                    reference: 127.0.0.1:31999/library/keycloak-crls:local
+                    pullPolicy: Always
+            - path: extraVolumeMounts
+              value:
+                - name: ca-certs
+                  mountPath: /tmp/ca-certs
+                  readOnly: true
+                - mountPath: /tmp/keycloak-crls
+                  name: keycloak-crls
+                  readOnly: true
+```
+
+### 1.2) Create UDS Slim Dev Bundle Config
+
+Create uds-config.yaml:
+```yaml
+variables:
+  uds-k3d-dev:
+    k3d_extra_args: >-
+      --k3s-arg --kube-apiserver-arg=feature-gates=ImageVolume=true@server:0
+      --k3s-arg --kubelet-arg=feature-gates=ImageVolume=true@server:0
+```
+
+Reference that in the deployment of slim-dev bundle:
+```bash
+
+```
+
+### 1.3) Add keycloak-crls package to bundle
+```yaml
+  - name: keycloak-crls
+    path: ../../keycloak-crls/zarf-package-keycloak-crls-amd64-20260221.tar.zst
+    ref: 0.61.0
+```
+
+### 1.4) Add Exemption for ImageVolume
+```yaml
+      uds-exemptions:
+        uds-exemptions:
+          values:
+            - path: exemptions.custom
+              value:
+                - name: keycloak-imagevolume-exemption
+                  exemptions:
+                    - policies:
+                        - RestrictVolumeTypes
+                      matcher:
+                        namespace: keycloak
+                        name: "^keycloak-.*"
+                        kind: pod
+                      title: "Allow Keycloak ImageVolume for CRLs"
+                      description: "Allow Keycloak pods to mount CRLs via Kubernetes ImageVolume (OCI-backed) in slim-dev."
+```
+
+## 2) Deploy UDS Core with CRL Configuration
+
+> **Note:** Copy and paste the following snippet into a bash shell
+
+```bash
+# Deploy UDS Core with the configured CRL overrides
+uds run create:k3d-slim-dev-bundle
+UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-amd64-*.tar.zst --confirm --no-progress
+
+# Configure tenant gateway to trust our demo CA and advertise to browsers
+kubectl -n istio-tenant-gateway patch secret gateway-tls \
+  --type merge \
+  -p '{"data": {"cacert": "'"$(base64 -w 0 pki-crl-test/ca.crt)"'"}}'
+
+# Restart tenant gateway to apply CA trust changes
+kubectl -n istio-tenant-gateway rollout restart deployment tenant-ingressgateway
+kubectl -n istio-tenant-gateway rollout status deployment tenant-ingressgateway
+
+# Configure Keycloak to trust our demo CA for client cert validation
+kubectl -n keycloak create configmap uds-trust-bundle \
+  --from-file=ca-bundle.pem=pki-crl-test/ca.crt \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Restart Keycloak to apply trust bundle changes
+kubectl -n keycloak rollout restart statefulset keycloak
+kubectl -n keycloak rollout status statefulset keycloak
+
+# Connect Keycloakd Admin Portal
+zarf connect keycloak
+```
+
+---
+
+## 8) Manual steps: Import `client.pfx` into Browser and test login
+
+- Import `$WORKDIR/client.pfx`
+- Export password: empty
+
+Then browse:
+
+- `https://sso.uds.dev`
+
+You should be prompted to choose the certificate.
+
+Get logs from attempt:
+
+```bash
+kubectl logs -n keycloak keycloak-0 -c keycloak | grep -i "x509\|crl\|revoc" | tail -n 200 >> keycloak.json
+```
+
+---
+
+## Negative test: revoked certificate
+
+1. Revoke and regenerate the CRL:
+
+```bash
+cd "$WORKDIR"
+openssl ca -batch -config ca.conf -revoke client.crt
+openssl ca -batch -config ca.conf -gencrl -out demoCA/demo-ca.crl
+zip -j demo-crls.zip demoCA/demo-ca.crl
+```
+
+2. Rebuild and redeploy the CRL package:
+
+```bash
+cd <path-to-uds-core-repo>
+
+bash scripts/keycloak-crl-airgap/update-keycloak-crl-oci-volume-package.sh \
+  --crl-zip "$WORKDIR/demo-crls.zip"
+
+uds zarf package deploy keycloak-crls/zarf-package-keycloak-crls-*.tar.zst --confirm
+kubectl -n keycloak rollout restart statefulset keycloak
+kubectl -n keycloak rollout status statefulset keycloak
+```
+
+3. Attempt login again. Expect failure and log messages similar to:
+
+- `Certificate validation's failed. Certificate revoked or incorrect.`
+- `Certificate has been revoked,`
+
+4. Renew the Certificate (same as upgrade path)
+```bash
+cd pki-crl-test
+# Clear the revocation database
+cp demoCA/index.txt.attr demoCA/index.txt.attr.bak
+cp demoCA/index.txt demoCA/index.txt.bak > demoCA/index.txt
+echo "unique_subject = no" > demoCA/index.txt.attr
+
+# Generate fresh CRL (empty)
+openssl ca -batch -config ca.conf -gencrl -out demoCA/demo-ca.crl
+zip -j demo-crls.zip demoCA/demo-ca.crl
+
+cd /home/chance/Unicorn/uds-core
+bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh --crl-zip pki-crl-test/demo-crls.zip
+uds zarf package deploy keycloak-crls/zarf-package-keycloak-crls-*.tar.zst --confirm
+kubectl -n keycloak rollout restart statefulset keycloak
+```

--- a/docs/dev/keycloak-crl-airgap.md
+++ b/docs/dev/keycloak-crl-airgap.md
@@ -112,7 +112,7 @@ Copy the Keycloak CRL Path from the generated crl paths text file into the uds-b
                     optional: true
                 - name: keycloak-crls
                   image:
-                    reference: 127.0.0.1:31999/library/keycloak-crls:local
+                    reference: keycloak-crls:local
                     pullPolicy: Always
             - path: extraVolumeMounts
               value:
@@ -124,31 +124,19 @@ Copy the Keycloak CRL Path from the generated crl paths text file into the uds-b
                   readOnly: true
 ```
 
-### 1.2) Create UDS Slim Dev Bundle Config
-
-Create uds-config.yaml:
-```yaml
-variables:
-  uds-k3d-dev:
-    k3d_extra_args: >-
-      --k3s-arg --kube-apiserver-arg=feature-gates=ImageVolume=true@server:0
-      --k3s-arg --kubelet-arg=feature-gates=ImageVolume=true@server:0
-```
-
-Reference that in the deployment of slim-dev bundle:
-```bash
-UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-amd64-*.tar.zst --confirm --no-progress
-```
-
-### 1.3) Add keycloak-crls package to bundle
+### 1.2) Add keycloak-crls package to bundle
 ```yaml
   - name: keycloak-crls
-    path: ../../keycloak-crls/zarf-package-keycloak-crls-amd64-20260221.tar.zst
-    ref: 0.61.0
+    path: ../../keycloak-crls/zarf-package-keycloak-crls-amd64-local.tar.zst
+    ref: local
 ```
 
-### 1.4) Add Exemption for ImageVolume
+### 1.3) Add Exemption for ImageVolume
 ```yaml
+  - name: core-base
+    path: ../../build/
+    ref: x.x.x
+    overrides:
       uds-exemptions:
         uds-exemptions:
           values:
@@ -166,40 +154,51 @@ UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/
                       description: "Allow Keycloak pods to mount CRLs via Kubernetes ImageVolume (OCI-backed) in slim-dev."
 ```
 
-## 2) Deploy UDS Core with CRL Configuration
+### 1.4) Configure CA trust via bundle and bundle config
 
-> **Note:** Copy and paste the following snippet into a bash shell
+**Add CA cert to bundle**
 
 ```bash
-# Deploy UDS Core with the configured CRL overrides
+      istio-tenant-gateway:
+        uds-istio-config:
+          variables:
+            - name: TENANT_TLS_CACERT
+              description: "CA cert for mTLS client auth (must be base64 encoded)"
+              path: tls.cacert
+```
+
+**Create `uds-config.yaml`** (run from the repo root — this encodes the CA cert and writes the full config):
+
+```bash
+CA_CERT_B64=$(base64 -w0 < pki-crl-test/ca.crt)
+cat > bundles/k3d-slim-dev/uds-config.yaml << EOF
+variables:
+  uds-k3d-dev:
+    k3d_extra_args: >-
+      --k3s-arg --kube-apiserver-arg=feature-gates=ImageVolume=true@server:0
+      --k3s-arg --kubelet-arg=feature-gates=ImageVolume=true@server:0
+  core-base:
+    CA_BUNDLE_CERTS: "${CA_CERT_B64}"
+    TENANT_TLS_CACERT: "${CA_CERT_B64}"
+EOF
+```
+
+- `CA_BUNDLE_CERTS` is picked up by the UDS Operator, which automatically creates/updates the `uds-trust-bundle` ConfigMap in the `keycloak` namespace.
+- `TENANT_TLS_CACERT` sets the `cacert` field on the `gateway-tls` Secret during deploy.
+
+## 2) Deploy UDS Core with CRL Configuration
+
+```bash
 uds run create:k3d-slim-dev-bundle
 UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-amd64-*.tar.zst --confirm --no-progress
 
-# Configure tenant gateway to trust our demo CA and advertise to browsers
-kubectl -n istio-tenant-gateway patch secret gateway-tls \
-  --type merge \
-  -p '{"data": {"cacert": "'"$(base64 < pki-crl-test/ca.crt | tr -d '\n')"'"}}'
-
-# Restart tenant gateway to apply CA trust changes
-kubectl -n istio-tenant-gateway rollout restart deployment tenant-ingressgateway
-kubectl -n istio-tenant-gateway rollout status deployment tenant-ingressgateway
-
-# Configure Keycloak to trust our demo CA for client cert validation
-kubectl -n keycloak create configmap uds-trust-bundle \
-  --from-file=ca-bundle.pem=pki-crl-test/ca.crt \
-  --dry-run=client -o yaml | kubectl apply -f -
-
-# Restart Keycloak to apply trust bundle changes
-kubectl -n keycloak rollout restart statefulset keycloak
-kubectl -n keycloak rollout status statefulset keycloak
-
-# Connect Keycloakd Admin Portal
+# Connect Keycloak Admin Portal
 zarf connect keycloak
 ```
 
 ---
 
-## 8) Manual steps: Import `client.pfx` into Browser and test login
+## 3) Manual steps: Import `client.pfx` into Browser and test login
 
 - Import `$WORKDIR/client.pfx`
 - Export password: empty
@@ -259,7 +258,7 @@ echo "unique_subject = no" > demoCA/index.txt.attr
 openssl ca -batch -config ca.conf -gencrl -out demoCA/demo-ca.crl
 zip -j demo-crls.zip demoCA/demo-ca.crl
 
-cd /home/chance/Unicorn/uds-core
+cd <path-to-uds-core-repo>
 bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh --crl-zip pki-crl-test/demo-crls.zip
 uds zarf package deploy keycloak-crls/zarf-package-keycloak-crls-*.tar.zst --confirm
 kubectl -n keycloak rollout restart statefulset keycloak

--- a/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
+++ b/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
@@ -1,0 +1,282 @@
+---
+title: Keycloak Airgap CRLs
+---
+
+## Overview
+
+In connected environments, Keycloak can use **OCSP (Online Certificate Status Protocol)** to check whether a client certificate has been revoked. In a true air-gap, OCSP responders are unreachable, so you must either:
+
+* disable revocation checks (not recommended), or
+* rely on **CRLs (Certificate Revocation Lists)** that you download *before* entering the air-gap and load locally into Keycloak.
+
+This guide documents a repeatable workflow to:
+
+1. Collect one or more CRL files (`*.crl`).
+2. Package them as a small OCI **data image** and wrap that into a **Zarf package**.
+3. Deploy that Zarf package **before** Keycloak.
+4. Mount the OCI data image into the Keycloak pod via **Kubernetes ImageVolume**.
+5. Configure Keycloak’s X.509 authenticator to read CRLs from the generated CRL path list.
+
+You do **not** need to build a custom Keycloak image.
+
+---
+
+## Use the script (recommended path)
+
+The intent of this workflow is that **users run one script** to fetch (or accept) a CRL bundle, filter it, build an OCI “data image”, and emit everything you need to wire Keycloak up.
+
+### What the script does
+
+When you run `create-keycloak-crl-oci-volume-package.sh`, it will:
+
+1. **Acquire CRLs as a ZIP**
+   * If you provide `--crl-zip <path>`, it uses that ZIP.
+   * Otherwise it **downloads the DoD “ALL CRL ZIP”** from DISA.
+
+2. **Extract and filter CRL files**
+   * Unzips and finds all `*.crl`.
+   * By default it **excludes** CRLs whose filenames start with:
+     * `DODEMAIL*` (email) and
+     * `DODSW*` (software)
+   * You can include them with flags (below).
+
+3. **Stage the CRLs into an OCI data image**
+   * Copies the selected CRLs into a staging directory.
+   * Builds a tiny OCI image (FROM `scratch`) that contains only the CRL files.
+
+4. **Generate the Keycloak “CRL Path” string**
+   * Sorts the CRL filenames.
+   * Builds a single string of relative paths using `##` as the delimiter.
+   * Writes it to `./keycloak-crls/keycloak-crl-paths.txt`.
+
+5. **Create a Zarf package that delivers the image**
+   * Creates a `keycloak-crls` Zarf package that contains the OCI image.
+   * Writes the package to `./keycloak-crls/zarf-package-keycloak-crls-*.tar.zst`.
+
+### Prerequisites
+
+Run the script on a machine that has:
+
+* `bash`, `curl`, `unzip`, `zip`, `find`, `sort`
+* `docker` (to build the OCI data image)
+* `uds` (so the script can run `uds zarf package create`)
+
+### Run it
+
+From the repo root (or wherever the script lives):
+
+```bash
+bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh
+```
+
+That will:
+
+* download the DISA CRL ZIP
+* filter out `DODEMAIL*` and `DODSW*`
+* output:
+
+  * `./keycloak-crls/keycloak-crl-paths.txt`
+  * `./keycloak-crls/zarf-package-keycloak-crls-*.tar.zst`
+
+### Common options
+
+#### Use a pre-downloaded ZIP (recommended when preparing an air-gap transfer)
+
+```bash
+bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh \
+  --crl-zip /path/to/crls.zip
+```
+
+This is the usual flow when you:
+1. download the ZIP on a connected machine,
+2. move it into the air-gap (or a build system inside the enclave), then
+3. run the script locally to produce the package.
+
+#### Include DoD Email CRLs
+
+```bash
+bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh --include-email
+```
+
+#### Include DoD Software CRLs
+
+```bash
+bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh --include-sw
+```
+
+### Outputs
+
+After the script finishes, you should have:
+
+* **CRL path list (paste into Bundle Keycloak config):**
+  * `./keycloak-crls/keycloak-crl-paths.txt`
+
+* **Zarf package to add to your bundle/deploy:**
+  * `./keycloak-crls/zarf-package-keycloak-crls-*.tar.zst`
+
+## Step 4: Configure your UDS bundle
+
+Before deploying, configure your bundle to:
+1. deploy the CRL package before Keycloak
+2. mount the CRL data image via ImageVolume
+3. configure Keycloak X.509 settings to use the generated CRL Path
+4. add policy exemptions if needed
+
+### 4.1 Add Keycloak CRL configuration to bundle
+
+Add the following to your bundle’s Keycloak values:
+
+```yaml
+keycloak:
+  keycloak:
+    values:
+      - path: realmInitEnv
+        value:
+          X509_OCSP_FAIL_OPEN: "false"
+          X509_OCSP_CHECKING_ENABLED: "false"
+          X509_CRL_CHECKING_ENABLED: "true"
+          X509_CRL_ABORT_IF_NON_UPDATED: "false"
+          X509_CRL_RELATIVE_PATH: "ca.pem" # Replace with keycloak-crl-paths.txt content
+      - path: extraVolumes
+        value:
+          - name: ca-certs
+            configMap:
+              name: uds-trust-bundle
+              optional: true
+          - name: keycloak-crls
+            image:
+              reference: 127.0.0.1:31999/library/keycloak-crls:local
+              pullPolicy: Always
+      - path: extraVolumeMounts
+        value:
+          - name: ca-certs
+            mountPath: /tmp/ca-certs
+            readOnly: true
+          - mountPath: /tmp/keycloak-crls
+            name: keycloak-crls
+            readOnly: true
+```
+
+:::caution
+Using the `X509_CRL_ABORT_IF_NON_UPDATED` to false means that if the CRL cannot be updated, the connection will be allowed. This is useful for air-gapped environments where the CRL may not be available. If it's set to true, the connection will be denied if the CRL cannot be updated on time.
+:::
+
+### 4.2 Add CRL package to bundle (deployment order)
+
+Make sure the CRL package deploys **before** Keycloak.
+
+```yaml
+packages:
+  - name: core-base
+    ref: x.x.x
+  - name: keycloak-crls
+    path: ./keycloak-crls/zarf-package-keycloak-crls-<arch>-<tag>.tar.zst
+    ref: x.x.x
+  - name: core-identity-authorization
+    ref: x.x.x
+```
+
+### 4.3 Configure UDS policy exemptions (if required)
+
+If ImageVolume is denied by policy, add an exemption targeting Keycloak pods:
+
+```yaml
+uds-exemptions:
+  uds-exemptions:
+    values:
+      - path: exemptions.custom
+        value:
+          - name: keycloak-imagevolume-exemption
+            exemptions:
+              - policies:
+                  - RestrictVolumeTypes
+                matcher:
+                  namespace: keycloak
+                  name: "^keycloak-.*"
+                  kind: pod
+                title: "Allow Keycloak ImageVolume for CRLs"
+                description: "Allow Keycloak pods to mount CRLs via Kubernetes ImageVolume (OCI-backed)."
+```
+
+### 4.4 Configure ImageVolume feature gates (k3s/k3d only)
+
+If using k3s/k3d on a Kubernetes version that requires explicit enablement, create a `uds-config.yaml`:
+
+```yaml
+variables:
+  uds-k3d-dev:
+    k3d_extra_args: >-
+      --k3s-arg --kube-apiserver-arg=feature-gates=ImageVolume=true@server:0
+      --k3s-arg --kubelet-arg=feature-gates=ImageVolume=true@server:0
+```
+
+---
+
+## Step 5: Deploy UDS Core with CRL support
+
+Deploy the fully configured bundle.
+
+```bash
+# For Slim Dev Bundle
+UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-amd64-*.tar.zst --confirm --no-progress
+```
+---
+
+## Step 6: Verify
+
+### 6.1 Verify CRL package deployment
+
+```bash
+uds zarf package list | grep keycloak-crls
+```
+
+### 6.2 Verify CRLs are mounted in Keycloak
+
+```bash
+kubectl exec -n keycloak keycloak-0 -c keycloak -- ls -la /tmp/keycloak-crls
+```
+
+### 6.3 Verify Keycloak CRL configuration
+
+Confirm the realm’s X.509 configuration uses the CRL Path value you generated (the contents of `keycloak-crl-paths.txt`).
+
+### 6.4 Test X.509 authentication
+
+Use your normal mTLS/browser client cert flow and confirm Keycloak validates certificates without CRL-related errors.
+
+---
+
+## CRL renewal and maintenance
+
+CRLs have an expiry window (driven by `nextUpdate`). Treat refresh as an operational requirement:
+
+1. Re-download all CRLs on a connected machine.
+2. Validate `nextUpdate` is in the future.
+3. Rebuild and redeploy the CRL Zarf package.
+4. Restart Keycloak if needed to ensure caches are refreshed.
+
+---
+
+## Troubleshooting
+
+### "Volume has a disallowed volume type of 'image'"
+
+Your UDS exemption was not applied (or did not match). Verify:
+
+* The exemption is included in your bundle and deployed
+* It targets the right namespace (`keycloak`) and pod matcher (`^keycloak-.*`)
+
+### "Failed to pull image … not found"
+
+The CRL image is missing or the reference is wrong. Verify:
+
+* CRL package is deployed before Keycloak
+* `extraVolumes.image.reference` matches the image reference available in the cluster registry
+
+### Keycloak logs: "Unable to load CRL from …"
+
+Verify:
+
+* CRL files exist in the container at `/tmp/keycloak-crls`
+* `X509_CRL_RELATIVE_PATH` exactly matches `keycloak-crl-paths.txt`
+* CRLs are not expired (`nextUpdate` still in the future)

--- a/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
+++ b/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
@@ -213,9 +213,9 @@ uds-exemptions:
                 description: "Allow Keycloak pods to mount CRLs via Kubernetes ImageVolume (OCI-backed)."
 ```
 
-### Enable ImageVolume on k3s/k3d clusters
+### Enable ImageVolume on uds-k3d
 
-If running on k3s/k3d with Kubernetes < 1.35, enable the feature gate via `uds-config.yaml`:
+If running on the dev/demo bundles (uds-k3d) with Kubernetes < 1.35, enable the feature gate via `uds-config.yaml`:
 
 ```yaml
 variables:

--- a/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
+++ b/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
@@ -28,7 +28,7 @@ Mounting CRL files via **Kubernetes ImageVolume** requires:
 * **Kubernetes 1.31–1.34** — supported, but the `ImageVolume` feature gate must be **explicitly enabled** on both the API server and kubelet.
 * **Kubernetes 1.35+** — `ImageVolume` is **enabled by default**; no feature gate configuration needed.
 
-This requirement applies to all Kubernetes distributions (EKS, GKE, RKE2, k3s, etc.). For k3s/k3d-specific configuration see [Enable ImageVolume on k3s/k3d clusters](#enable-imagevolume-on-k3sk3d-clusters) in the bundle configuration section below.
+This requirement applies to all Kubernetes distributions (EKS, GKE, RKE2, k3s, etc.). For k3s/k3d-specific configuration see [Enable ImageVolume on uds-k3d](#enable-imagevolume-on-uds-k3d) in the bundle configuration section below.
 
 ---
 

--- a/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
+++ b/docs/reference/configuration/single-sign-on/keycloak-crl-airgap.md
@@ -4,10 +4,10 @@ title: Keycloak Airgap CRLs
 
 ## Overview
 
-In connected environments, Keycloak can use **OCSP (Online Certificate Status Protocol)** to check whether a client certificate has been revoked. In a true air-gap, OCSP responders are unreachable, so you must either:
+In connected environments, Keycloak can use **OCSP (Online Certificate Status Protocol)** to check whether a client certificate has been revoked. In a true airgap, OCSP responders are unreachable, so you must either:
 
 * disable revocation checks (not recommended), or
-* rely on **CRLs (Certificate Revocation Lists)** that you download *before* entering the air-gap and load locally into Keycloak.
+* rely on **CRLs (Certificate Revocation Lists)** that you download *before* entering the airgap and load locally into Keycloak.
 
 This guide documents a repeatable workflow to:
 
@@ -18,6 +18,17 @@ This guide documents a repeatable workflow to:
 5. Configure Keycloak’s X.509 authenticator to read CRLs from the generated CRL path list.
 
 You do **not** need to build a custom Keycloak image.
+
+---
+
+## Kubernetes Version Requirements
+
+Mounting CRL files via **Kubernetes ImageVolume** requires:
+
+* **Kubernetes 1.31–1.34** — supported, but the `ImageVolume` feature gate must be **explicitly enabled** on both the API server and kubelet.
+* **Kubernetes 1.35+** — `ImageVolume` is **enabled by default**; no feature gate configuration needed.
+
+This requirement applies to all Kubernetes distributions (EKS, GKE, RKE2, k3s, etc.). For k3s/k3d-specific configuration see [Enable ImageVolume on k3s/k3d clusters](#enable-imagevolume-on-k3sk3d-clusters) in the bundle configuration section below.
 
 ---
 
@@ -80,7 +91,7 @@ That will:
 
 ### Common options
 
-#### Use a pre-downloaded ZIP (recommended when preparing an air-gap transfer)
+#### Use a pre-downloaded ZIP (recommended when preparing an airgap transfer)
 
 ```bash
 bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh \
@@ -89,7 +100,7 @@ bash scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh \
 
 This is the usual flow when you:
 1. download the ZIP on a connected machine,
-2. move it into the air-gap (or a build system inside the enclave), then
+2. move it into the airgap (or a build system inside the enclave), then
 3. run the script locally to produce the package.
 
 #### Include DoD Email CRLs
@@ -145,7 +156,7 @@ keycloak:
               optional: true
           - name: keycloak-crls
             image:
-              reference: 127.0.0.1:31999/library/keycloak-crls:local # Common Zarf registry address; adjust for your environment
+              reference: keycloak-crls:local # Common Zarf registry address; adjust for your environment
               pullPolicy: Always
       - path: extraVolumeMounts
         value:
@@ -162,7 +173,7 @@ keycloak:
 :::
 
 :::caution
-Using the `X509_CRL_ABORT_IF_NON_UPDATED` to false means that if the CRL cannot be updated, the connection will be allowed. This is useful for air-gapped environments where the CRL may not be available. If it's set to true, the connection will be denied if the CRL cannot be updated on time.
+Using the `X509_CRL_ABORT_IF_NON_UPDATED` to false means that if the CRL cannot be updated, the connection will be allowed. This is useful for airgapped environments where the CRL may not be available. If it's set to true, the connection will be denied if the CRL cannot be updated on time.
 :::
 
 ### Add CRL package to bundle (deployment order)
@@ -180,9 +191,9 @@ packages:
     ref: x.x.x
 ```
 
-### Configure UDS policy exemptions (if required)
+### Configure UDS policy exemptions
 
-If ImageVolume is denied by policy, add an exemption targeting Keycloak pods:
+ImageVolumes are currently blocked by UDS Policies (future support will be added), so add an exemption targeting Keycloak pods:
 
 ```yaml
 uds-exemptions:
@@ -202,9 +213,9 @@ uds-exemptions:
                 description: "Allow Keycloak pods to mount CRLs via Kubernetes ImageVolume (OCI-backed)."
 ```
 
-### Configure ImageVolume feature gates (k3s/k3d only)
+### Enable ImageVolume on k3s/k3d clusters
 
-If using k3s/k3d on a Kubernetes version that requires explicit enablement, create a `uds-config.yaml`:
+If running on k3s/k3d with Kubernetes < 1.35, enable the feature gate via `uds-config.yaml`:
 
 ```yaml
 variables:

--- a/scripts/keycloak-crl-airgap/Dockerfile
+++ b/scripts/keycloak-crl-airgap/Dockerfile
@@ -1,0 +1,5 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+FROM scratch
+COPY stage/ /

--- a/scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh
+++ b/scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+set -euo pipefail
+
+OUTPUT_DIR="./keycloak-crls"
+PACKAGE_VERSION="local"
+IMAGE_REF="keycloak-crls:local"
+CRL_ZIP_URL="https://crl.gds.disa.mil/getcrlzip?ALL+CRL+ZIP"
+
+CRL_ZIP_PATH=""
+INCLUDE_EMAIL="false"
+INCLUDE_SW="false"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --crl-zip) CRL_ZIP_PATH="$2"; shift 2 ;;
+    --include-email) INCLUDE_EMAIL="true"; shift ;;
+    --include-sw) INCLUDE_SW="true"; shift ;;
+    -h|--help) echo "Usage: $0 [--crl-zip PATH] [--include-email] [--include-sw]"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; echo "Usage: $0 [--crl-zip PATH] [--include-email] [--include-sw]" >&2; exit 2 ;;
+  esac
+done
+
+ZARF=(uds zarf)
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+zip="$tmp/crls.zip"
+unz="$tmp/unzipped"
+stage="$tmp/stage"
+mkdir -p "$unz" "$stage" "$OUTPUT_DIR"
+
+# Get ZIP
+if [ -n "$CRL_ZIP_PATH" ]; then
+  cp -f "$CRL_ZIP_PATH" "$zip"
+else
+  curl -fL -o "$zip" "$CRL_ZIP_URL"
+fi
+
+# Unzip
+unzip -q "$zip" -d "$unz"
+
+# Filter + stage
+while IFS= read -r -d '' crl; do
+  base="$(basename "$crl")"
+  upper="$(printf '%s' "$base" | tr '[:lower:]' '[:upper:]')"
+
+  if [ "$INCLUDE_EMAIL" = "false" ] && [[ "$upper" == DODEMAIL* ]]; then
+    continue
+  fi
+  if [ "$INCLUDE_SW" = "false" ] && [[ "$upper" == DODSW* ]]; then
+    continue
+  fi
+
+  cp -f "$crl" "$stage/$base"
+done < <(find "$unz" -type f -iname '*.crl' -print0)
+
+# Generate Keycloak CRL Path list (sorted, ## delimited)
+paths_file="$OUTPUT_DIR/keycloak-crl-paths.txt"
+crl_list="$(ls -1 "$stage" 2>/dev/null | sort || true)"
+if [ -z "$crl_list" ]; then
+  echo "no CRLs after filtering (try --include-email and/or --include-sw)" >&2
+  exit 1
+fi
+
+CRL_PATH_LIST=""
+while IFS= read -r filename; do
+  entry="../../../tmp/keycloak-crls/${filename}"
+  if [ -z "$CRL_PATH_LIST" ]; then
+    CRL_PATH_LIST="$entry"
+  else
+    CRL_PATH_LIST="${CRL_PATH_LIST}##${entry}"
+  fi
+done <<< "$crl_list"
+printf '%s\n' "$CRL_PATH_LIST" > "$paths_file"
+
+# Build data image
+cat > "$tmp/Dockerfile" <<'EOF'
+FROM scratch
+COPY stage/ /
+EOF
+docker build -q -t "$IMAGE_REF" -f "$tmp/Dockerfile" "$tmp"
+
+# Create package from a TEMP package directory so we don't leave zarf.yaml in OUTPUT_DIR
+pkgdir="$tmp/pkg"
+mkdir -p "$pkgdir"
+
+cat > "$pkgdir/zarf.yaml" <<EOF
+kind: ZarfPackageConfig
+metadata:
+  name: keycloak-crls
+  description: "DoD CRLs for Keycloak X.509 (OCI volume)"
+  version: "${PACKAGE_VERSION}"
+components:
+  - name: keycloak-crls
+    required: true
+    images:
+      - ${IMAGE_REF}
+EOF
+
+"${ZARF[@]}" package create "$pkgdir" --confirm --output "$OUTPUT_DIR"
+
+echo "Done. Outputs:"
+echo "  - Keycloak CRL Path value: $paths_file"
+echo "  - Zarf package:            $(ls -1 "$OUTPUT_DIR"/zarf-package-keycloak-crls-*.tar.zst 2>/dev/null || true)"

--- a/scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh
+++ b/scripts/keycloak-crl-airgap/create-keycloak-crl-oci-volume-package.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 OUTPUT_DIR="./keycloak-crls"
 PACKAGE_VERSION="local"
 IMAGE_REF="keycloak-crls:local"
@@ -78,28 +80,16 @@ done <<< "$crl_list"
 printf '%s\n' "$CRL_PATH_LIST" > "$paths_file"
 
 # Build data image
-cat > "$tmp/Dockerfile" <<'EOF'
-FROM scratch
-COPY stage/ /
-EOF
-docker build -q -t "$IMAGE_REF" -f "$tmp/Dockerfile" "$tmp"
+docker build -q -t "$IMAGE_REF" -f "$SCRIPT_DIR/Dockerfile" "$tmp"
 
 # Create package from a TEMP package directory so we don't leave zarf.yaml in OUTPUT_DIR
 pkgdir="$tmp/pkg"
 mkdir -p "$pkgdir"
 
-cat > "$pkgdir/zarf.yaml" <<EOF
-kind: ZarfPackageConfig
-metadata:
-  name: keycloak-crls
-  description: "DoD CRLs for Keycloak X.509 (OCI volume)"
-  version: "${PACKAGE_VERSION}"
-components:
-  - name: keycloak-crls
-    required: true
-    images:
-      - ${IMAGE_REF}
-EOF
+sed \
+  -e "s|\${PACKAGE_VERSION}|${PACKAGE_VERSION}|g" \
+  -e "s|\${IMAGE_REF}|${IMAGE_REF}|g" \
+  "$SCRIPT_DIR/zarf.yaml" > "$pkgdir/zarf.yaml"
 
 "${ZARF[@]}" package create "$pkgdir" --confirm --output "$OUTPUT_DIR"
 

--- a/scripts/keycloak-crl-airgap/zarf.yaml
+++ b/scripts/keycloak-crl-airgap/zarf.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+kind: ZarfPackageConfig
+metadata:
+  name: keycloak-crls
+  description: "DoD CRLs for Keycloak X.509 (OCI volume)"
+  version: "${PACKAGE_VERSION}"
+components:
+  - name: keycloak-crls
+    required: true
+    images:
+      - ${IMAGE_REF}

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 image:
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.23.0
+configImage: uds-core-config:keycloak
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"
@@ -44,6 +44,10 @@ realmInitEnv:
   # EMAIL_AS_USERNAME: false
   # TERMS_AND_CONDITIONS_ENABLED: true
   # X509_OCSP_FAIL_OPEN: true
+  # X509_CRL_ABORT_IF_NON_UPDATED: false
+  # X509_CRL_CHECKING_ENABLED: true
+  # X509_CRL_RELATIVE_PATH: "crl.pem"
+  # X509_OCSP_CHECKING_ENABLED: true
   # Number of temporary lockouts allowed before permanent lockout
   # MAX_TEMPORARY_LOCKOUTS: "0"
   # @lulaStart ef276ec4-7921-4287-a18c-80dec5f8e742

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: uds-core-config:keycloak
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.23.0
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # @lulaStart 4147b6a6-3339-4d5d-b10a-f16502b52206
@@ -32,7 +32,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.5.3
-      - ghcr.io/defenseunicorns/uds/identity-config:0.23.0
+      - uds-core-config:keycloak
 
   - name: keycloak
     required: true
@@ -46,7 +46,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:26.5.3
-      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.23.0
+      - uds-core-config:keycloak
 
   - name: keycloak
     required: true
@@ -60,4 +60,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - quay.io/rfcurated/keycloak:26.5.3-jammy-fips-rfcurated
-      - ghcr.io/defenseunicorns/uds/identity-config:0.23.0
+      - uds-core-config:keycloak

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024-2026 Defense Unicorns
+# Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # @lulaStart 4147b6a6-3339-4d5d-b10a-f16502b52206
@@ -32,7 +32,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.5.3
-      - uds-core-config:keycloak
+      - ghcr.io/defenseunicorns/uds/identity-config:0.23.0
 
   - name: keycloak
     required: true
@@ -46,7 +46,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak:26.5.3
-      - uds-core-config:keycloak
+      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.23.0
 
   - name: keycloak
     required: true
@@ -60,4 +60,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - quay.io/rfcurated/keycloak:26.5.3-jammy-fips-rfcurated
-      - uds-core-config:keycloak
+      - ghcr.io/defenseunicorns/uds/identity-config:0.23.0


### PR DESCRIPTION
## Description

Document and script the path for end users to use CRL checking and revocation in airgapped environments.

- Dev doc is meant for internal use mostly due to the complexity of testing these things.
- Main doc for end users
- script for generating an OCI with the CRLs
- small updates to the keycloak values.yaml for documenting the new CRL values

[Corresponding Identity Config PR](https://github.com/defenseunicorns/uds-identity-config/pull/802)

## Related Issue

Fixes #2235 

[Related PR ](https://github.com/defenseunicorns/uds-core/pull/2393)that I closed due to change in scope and large amounts of comments.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- utilize the dev doc to test this. it covers the happy path and also upgrade path.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed