### PR TITLE
chore(ci): split lightweight setup-tools action from setup action

### DIFF
--- a/.github/actions/setup-tools/action.yaml
+++ b/.github/actions/setup-tools/action.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # action.yml

--- a/.github/actions/setup-tools/action.yaml
+++ b/.github/actions/setup-tools/action.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# action.yml
+name: "Setup Tools"
+description: "Installs UDS CLI and basic tooling (Node.js, uv) without registry authentication"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js latest
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        node-version: 24
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      with:
+        # renovate: datasource=github-tags depName=astral-sh/uv versioning=semver
+        version: 0.10.7
+
+    - name: Install UDS CLI
+      uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
+      with:
+        # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+        version: v0.28.3

--- a/.github/actions/setup-tools/action.yaml
+++ b/.github/actions/setup-tools/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js latest
-      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: 24
 
@@ -17,10 +17,10 @@ runs:
       uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
         # renovate: datasource=github-tags depName=astral-sh/uv versioning=semver
-        version: 0.10.7
+        version: 0.10.8
 
     - name: Install UDS CLI
       uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
       with:
         # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-        version: v0.28.3
+        version: v0.28.4

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -24,27 +24,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Use Node.js latest
-      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-      with:
-        node-version: 24
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
-      with:
-        # renovate: datasource=github-tags depName=astral-sh/uv versioning=semver
-        version: 0.10.7
+    - name: Setup Tools
+      uses: ./.github/actions/setup-tools
 
     - name: Install k3d
       shell: bash
       # renovate: datasource=github-tags depName=k3d-io/k3d versioning=semver
       run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
-
-    - name: Install UDS CLI
-      uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
-      with:
-        # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-        version: v0.28.3
 
     - name: Install helm unittest plugin
       shell: bash

--- a/.github/workflows/check-ca-certs.yaml
+++ b/.github/workflows/check-ca-certs.yaml
@@ -34,13 +34,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Environment setup
-        uses: ./.github/actions/setup
-        with:
-          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
-          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
-          ghToken: ${{ secrets.GITHUB_TOKEN }}
-          rapidfortUsername: ${{ secrets.RAPIDFORT_USERNAME }}
-          rapidfortPassword: ${{ secrets.RAPIDFORT_PASSWORD }}
+        uses: ./.github/actions/setup-tools
 
       - name: Install script dependencies
         run: npm ci

--- a/.github/workflows/docs-shim.yaml
+++ b/.github/workflows/docs-shim.yaml
@@ -60,13 +60,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Environment setup
-        uses: ./.github/actions/setup
-        with:
-          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
-          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
-          ghToken: ${{ secrets.GITHUB_TOKEN }}
-          rapidfortUsername: ${{ secrets.RAPIDFORT_USERNAME }}
-          rapidfortPassword: ${{ secrets.RAPIDFORT_PASSWORD }}
+        uses: ./.github/actions/setup-tools
       - name: Check UDS Docs links
         run: uds run uds-docs-validate
 
@@ -76,13 +70,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Environment setup
-        uses: ./.github/actions/setup
-        with:
-          registry1Username: ${{ secrets.IRON_BANK_ROBOT_USERNAME }}
-          registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
-          ghToken: ${{ secrets.GITHUB_TOKEN }}
-          rapidfortUsername: ${{ secrets.RAPIDFORT_USERNAME }}
-          rapidfortPassword: ${{ secrets.RAPIDFORT_PASSWORD }}
+        uses: ./.github/actions/setup-tools
       - name: Verify documented k8s version matches CI config
         run: uds run lint:k8s-version-check
 


### PR DESCRIPTION
## Description

Split UDS CLI + basic tooling (Node.js, uv) into a new .github/actions/setup-tools action that performs no registry authentication.

  - New setup-tools action installs only Node.js, uv, and UDS CLI
  - Existing setup action composes on setup-tools, avoiding duplicate version pins
  - docs-shim.yaml and check-ca-certs.yaml switched to setup-tools since they don't need registry credentials
  - No changes to workflows that require registry auth (test, publish, cve-scan, etc.)

This reduces credential exposure by ensuring workflows that only need UDS CLI don't receive unnecessary registry credentials.

## Related Issue

Closes CORE-394

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- CI runs succesfully

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed