### PR TITLE
docs: add documentation on resizing prometheus volumes

### DIFF
--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -20,7 +20,7 @@ This procedure follows upstream guidance from Prometheus Operator:
 
 ## Prerequisites
 
-- `kubectl` access with permissions to patch Prometheus CRs and PVCs and delete StatefulSets.
+- `kubectl` access with permissions to patch Prometheus CRs and PVCs, delete StatefulSets and Prometheus pods, and list/describe PVCs and StorageClasses.
 - Correct kube context selected.
 - Target Prometheus instance identified.
 - StorageClass for target PVCs supports expansion (`allowVolumeExpansion=true`).

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -32,22 +32,6 @@ This runbook assumes UDS Core defaults:
 
 If your deployment uses non-default names, update the commands accordingly.
 
-## Target Size
-
-Set the target size before running commands:
-
-```bash
-export TARGET_SIZE=60Gi
-```
-
-Confirm the defaults exist in your cluster:
-
-This confirms the expected Prometheus CR exists before continuing.
-
-```bash
-kubectl get prometheus -n monitoring kube-prometheus-stack-prometheus
-```
-
 ## Update Bundle Configuration
 
 Set the target size in your UDS bundle so desired Prometheus storage is captured in code before running manual resize steps.
@@ -87,7 +71,15 @@ variables:
 
 ## Prechecks
 
-1. Confirm matching PVCs:
+1. Confirm the target Prometheus CR exists:
+
+This confirms the expected Prometheus CR exists before continuing.
+
+```bash
+kubectl get prometheus -n monitoring kube-prometheus-stack-prometheus
+```
+
+2. Confirm matching PVCs:
 
 This lists the PVCs that will be resized and verifies label selection is correct.
 
@@ -95,7 +87,7 @@ This lists the PVCs that will be resized and verifies label selection is correct
 kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
 ```
 
-2. Confirm StorageClass and expansion support:
+3. Confirm StorageClass and expansion support:
 
 Use this output to verify each target PVC has a StorageClass and that class supports expansion.
 
@@ -110,24 +102,30 @@ kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-st
 kubectl get storageclass -o custom-columns=NAME:.metadata.name,ALLOWVOLUMEEXPANSION:.allowVolumeExpansion
 ```
 
-3. Confirm this is a size increase (never shrink):
+4. Confirm this is a size increase (never shrink):
 
-Compare current PVC request sizes to `TARGET_SIZE`; continue only for a size increase.
+Compare current PVC request sizes to your desired volume size; continue only if size will increase.
 
 ```bash
 kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.resources.requests.storage}{"\n"}{end}'
 ```
 
 > [!CAUTION]
-> If any target PVC is already larger than `TARGET_SIZE`, **stop and reassess**. PVC shrinking is not supported.
+> If any target PVC is already larger than your desired volume size, **stop and reassess**. PVC shrinking is not supported.
 
-4. Confirm the size configured in your `uds-bundle.yaml` and/or `uds-config.yaml` matches `TARGET_SIZE`.
+5. Confirm the size configured in your `uds-bundle.yaml` and/or `uds-config.yaml` matches your desired volume size.
 
 ## Procedure
 
-1. Update bundle configuration to the target size (see examples above).
+1. Set the `TARGET_SIZE` variable to your desired volume size. The `TARGET_SIZE` variable is used throughout this procedure:
 
-2. Pause Prometheus reconciliation:
+```bash
+export TARGET_SIZE=60Gi
+```
+
+2. Update bundle configuration to the target size (see examples above).
+
+3. Pause Prometheus reconciliation:
 
 Pausing prevents operator reconciliation churn while you patch PVCs and rotate the StatefulSet.
 
@@ -135,11 +133,11 @@ Pausing prevents operator reconciliation churn while you patch PVCs and rotate t
 kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":true}}'
 ```
 
-3. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflows.
+4. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflows.
 
 This applies the desired Prometheus storage size from code before patching existing PVCs.
 
-4. Patch each existing PVC to the new request size:
+5. Patch each existing PVC to the new request size:
 
 This updates the requested storage on all existing Prometheus PVCs to match bundle desired state.
 
@@ -168,7 +166,7 @@ If any target PVC shows `FileSystemResizePending`, restart the affected Promethe
 kubectl delete pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
 ```
 
-5. Delete backing StatefulSet with orphan strategy:
+6. Delete backing StatefulSet with orphan strategy:
 
 Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Prometheus Operator can recreate the StatefulSet against resized PVCs.
 
@@ -176,7 +174,7 @@ Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Promet
 kubectl delete statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" --cascade=orphan
 ```
 
-6. Unpause Prometheus reconciliation:
+7. Unpause Prometheus reconciliation:
 
 Unpausing allows Prometheus Operator to reconcile resources back to normal managed state.
 

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -148,25 +148,28 @@ kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-st
   --patch "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"$TARGET_SIZE\"}}}}"
 ```
 
-During and after patching, monitor PVC events for resize progress or errors:
+6. Monitor PVC resize progress:
+
+After patching, monitor PVC events for resize progress or errors:
 
 ```bash
 kubectl describe pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
 ```
 
-If controller-side expansion completes but the filesystem resize does not, PVCs may show `FileSystemResizePending` and `CAP` may remain below `REQ`. Check for that condition before proceeding:
+Check whether filesystem resize is pending before proceeding:
 
 ```bash
 kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,CONDITION:.status.conditions[*].type
 ```
 
-If any target PVC shows `FileSystemResizePending`, restart the affected Prometheus pod(s), then confirm `CAP` converges to `REQ` before continuing:
+> [!NOTE]
+> If any target PVC shows `FileSystemResizePending`, restart the affected Prometheus pod(s), then confirm `CAP` converges to `REQ` before continuing:
 
 ```bash
 kubectl delete pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
 ```
 
-6. Delete backing StatefulSet with orphan strategy:
+7. Delete backing StatefulSet with orphan strategy:
 
 Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Prometheus Operator can recreate the StatefulSet against resized PVCs.
 
@@ -174,7 +177,7 @@ Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Promet
 kubectl delete statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" --cascade=orphan
 ```
 
-7. Unpause Prometheus reconciliation:
+8. Unpause Prometheus reconciliation:
 
 Unpausing allows Prometheus Operator to reconcile resources back to normal managed state.
 

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -1,0 +1,209 @@
+---
+title: Resize Prometheus PVCs
+sidebar:
+  order: 3
+---
+
+## Purpose
+
+Use this runbook to manually resize Prometheus PVCs managed by Prometheus Operator when storage requirements increase.
+
+This procedure follows upstream guidance from Prometheus Operator:
+
+- https://prometheus-operator.dev/docs/platform/storage/#resizing-volumes
+
+## Scope
+
+- Resize only (no retention tuning).
+- Intended for UDS Core deployments using `kube-prometheus-stack`.
+- Safe for mixed environments as long as prechecks pass.
+
+## Prerequisites
+
+- `kubectl` access with permissions to patch Prometheus CRs and PVCs and delete StatefulSets.
+- Correct kube context selected.
+- Target Prometheus instance identified.
+- StorageClass for target PVCs supports expansion (`allowVolumeExpansion=true`).
+
+This runbook assumes UDS Core defaults:
+
+- Namespace: `monitoring`
+- Prometheus CR name: `kube-prometheus-stack-prometheus`
+
+If your deployment uses non-default names, update the commands accordingly.
+
+## Variables
+
+Set the target size before running commands:
+
+```bash
+export TARGET_SIZE=60Gi
+```
+
+Confirm the defaults exist in your cluster:
+
+This confirms the expected Prometheus CR exists before continuing.
+
+```bash
+kubectl get prometheus -n monitoring kube-prometheus-stack-prometheus
+```
+
+## Update Bundle Configuration
+
+Set the target size in your UDS bundle so desired Prometheus storage is captured in code before running manual resize steps.
+
+### Option A: Direct override value in `uds-bundle.yaml`
+
+```yaml title="uds-bundle.yaml"
+packages:
+  - name: core
+    overrides:
+      kube-prometheus-stack:
+        kube-prometheus-stack:
+          values:
+            - path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
+              value: "60Gi"
+```
+
+### Option B: Bundle variable with value in `uds-config.yaml`
+
+```yaml title="uds-bundle.yaml"
+packages:
+  - name: core
+    overrides:
+      kube-prometheus-stack:
+        kube-prometheus-stack:
+          variables:
+            - name: PROMETHEUS_STORAGE_SIZE
+              description: Prometheus PVC requested storage size
+              path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
+```
+
+```yaml title="uds-config.yaml"
+variables:
+  core:
+    prometheus_storage_size: "60Gi"
+```
+
+## Prechecks
+
+1. Confirm matching PVCs:
+
+This lists the PVCs that will be resized and verifies label selection is correct.
+
+```bash
+kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+```
+
+2. Confirm StorageClass and expansion support:
+
+Use this output to verify each target PVC has a StorageClass and that class supports expansion. If expansion is not supported, stop and reassess.
+
+```bash
+# Determine the storage class in use
+kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,REQ:.spec.resources.requests.storage
+
+# Show whether volume expansion is enabled in each storage class
+kubectl get storageclass -o custom-columns=NAME:.metadata.name,ALLOWVOLUMEEXPANSION:.allowVolumeExpansion
+```
+
+3. Confirm this is a size increase (never shrink):
+
+Compare current PVC request sizes to `TARGET_SIZE`; continue only for a size increase.
+
+```bash
+kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.resources.requests.storage}{"\n"}{end}'
+```
+
+If any target PVC is already larger than `TARGET_SIZE`, stop and reassess.
+
+4. Confirm the size you configured in your uds-bundle and/or uds-config match `TARGET_SIZE`.
+
+## Procedure
+
+1. Update bundle configuration to the target size (see examples above).
+
+2. Pause Prometheus reconciliation:
+
+Pausing prevents operator reconciliation churn while you patch PVCs and rotate the StatefulSet.
+
+```bash
+kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":true}}'
+```
+
+3. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflows so Prometheus desired storage is updated from code.
+
+4. Patch each existing PVC to the new request size:
+
+This updates the requested storage on all existing Prometheus PVCs to match bundle desired state.
+
+```bash
+kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+| xargs -I{} kubectl patch pvc "{}" -n monitoring --type merge \
+  --patch "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"$TARGET_SIZE\"}}}}"
+```
+
+5. Delete backing StatefulSet with orphan strategy:
+
+Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Prometheus Operator can recreate the StatefulSet against resized PVCs.
+
+```bash
+kubectl delete statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" --cascade=orphan
+```
+
+6. Unpause Prometheus reconciliation:
+
+Unpausing allows Prometheus Operator to reconcile resources back to normal managed state.
+
+```bash
+kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":false}}'
+```
+
+## Verification
+
+1. Prometheus CR is unpaused:
+
+This confirms operator reconciliation is re-enabled.
+
+```bash
+kubectl get prometheus kube-prometheus-stack-prometheus -n monitoring -o jsonpath='{.spec.paused}{"\n"}'
+```
+
+Expected: `false`
+
+2. PVC requests show the new size:
+
+All listed PVC `REQ` values should match `TARGET_SIZE`.
+
+```bash
+kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage
+```
+
+3. StatefulSet is recreated by operator:
+
+You should see a recreated StatefulSet present for the Prometheus instance.
+
+```bash
+kubectl get statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+```
+
+4. Confirm Prometheus pods are Running/Ready:
+
+Pods should be `Running`/`Ready` before closing the operation.
+
+```bash
+kubectl get pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+```
+
+## Failure Handling
+
+- If any step fails after pause, ensure unpause is restored:
+
+```bash
+kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":false}}'
+```
+
+- If StorageClass is not expandable, do not continue this runbook.
+
+- If one PVC patch fails, resolve that PVC issue first, then continue from Procedure step 4.

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -10,18 +10,18 @@ Use this runbook to manually resize Prometheus PVCs managed by Prometheus Operat
 
 This procedure follows upstream guidance from Prometheus Operator:
 
-- https://prometheus-operator.dev/docs/platform/storage/#resizing-volumes
+- <https://prometheus-operator.dev/docs/platform/storage/#resizing-volumes>
 
 ## Scope
 
-- Resize only (no retention tuning).
+- Increase in size only (volume shrinking is not supported).
 - Intended for UDS Core deployments using `kube-prometheus-stack`.
 - Safe for mixed environments as long as prechecks pass.
 
 ## Prerequisites
 
-- `kubectl` access with permissions to patch Prometheus CRs and PVCs, delete StatefulSets and Prometheus pods, and list/describe PVCs and StorageClasses.
-- Correct kube context selected.
+- `kubectl`
+- Correct kube context selected with permissions to patch Prometheus CRs and PVCs, delete StatefulSets and Prometheus pods, and list/describe PVCs and StorageClasses.
 - Target Prometheus instance identified.
 - StorageClass for target PVCs supports expansion (`allowVolumeExpansion=true`).
 
@@ -34,47 +34,43 @@ If your deployment uses non-default names, update the commands accordingly.
 
 ## Prechecks
 
-1. Confirm the target Prometheus CR exists:
+1. Confirm the target Prometheus CR exists before continuing:
 
-This confirms the expected Prometheus CR exists before continuing.
+    ```bash
+    kubectl get prometheus -n monitoring kube-prometheus-stack-prometheus
+    ```
 
-```bash
-kubectl get prometheus -n monitoring kube-prometheus-stack-prometheus
-```
+2. Confirm matching PVCs by listing the PVCs that will be resized and verifying that the label selector is correct.
 
-2. Confirm matching PVCs:
-
-This lists the PVCs that will be resized and verifies label selection is correct.
-
-```bash
-kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
-```
+    ```bash
+    kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+    ```
 
 3. Confirm StorageClass and expansion support:
 
-Use this output to verify each target PVC has a StorageClass and that class supports expansion.
+    Use this output to verify each target PVC has a StorageClass and that class supports expansion.
 
-> [!CAUTION]
-> If expansion is not supported, stop and reassess.
+    > [!CAUTION]
+    > If expansion is not supported, stop and reassess.
 
-```bash
-# Determine the storage class in use
-kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,REQ:.spec.resources.requests.storage
+    ```bash
+    # Determine the storage class in use
+    kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,SC:.spec.storageClassName,REQ:.spec.resources.requests.storage
 
-# Show whether volume expansion is enabled in each storage class
-kubectl get storageclass -o custom-columns=NAME:.metadata.name,ALLOWVOLUMEEXPANSION:.allowVolumeExpansion
-```
+    # Show whether volume expansion is enabled in each storage class
+    kubectl get storageclass -o custom-columns=NAME:.metadata.name,ALLOWVOLUMEEXPANSION:.allowVolumeExpansion
+    ```
 
 4. Confirm this is a size increase (never shrink):
 
-Compare current PVC request sizes to your desired volume size; continue only if size will increase.
+    Compare current PVC request sizes to your desired volume size; continue only if size will increase.
 
-```bash
-kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.resources.requests.storage}{"\n"}{end}'
-```
+    ```bash
+    kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.resources.requests.storage}{"\n"}{end}'
+    ```
 
-> [!CAUTION]
-> If any target PVC is already larger than your desired volume size, **stop and reassess**. PVC shrinking is not supported.
+    > [!CAUTION]
+    > If any target PVC is already larger than your desired volume size, **stop and reassess**. PVC shrinking is not supported.
 
 5. Confirm the size configured in your `uds-bundle.yaml` and/or `uds-config.yaml` matches your desired volume size.
 
@@ -82,158 +78,144 @@ kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-st
 
 1. Set the `TARGET_SIZE` variable to your desired volume size. The `TARGET_SIZE` variable is used throughout this procedure:
 
-```bash
-export TARGET_SIZE=60Gi
-```
+    ```bash
+    export TARGET_SIZE=60Gi
+    ```
 
 2. Update your bundle configuration by setting the desired volume size using one of the methods below.
 
-Option A: Directly override the value in `uds-bundle.yaml`:
+    Option A: Directly override the value in `uds-bundle.yaml`:
 
-```yaml title="uds-bundle.yaml"
-packages:
-  - name: core
-    overrides:
-      kube-prometheus-stack:
-        kube-prometheus-stack:
-          values:
-            - path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
-              value: "60Gi"
-```
+    ```yaml title="uds-bundle.yaml"
+    packages:
+      - name: core
+        overrides:
+          kube-prometheus-stack:
+            kube-prometheus-stack:
+              values:
+                - path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
+                  value: "60Gi"
+    ```
 
-Option B: Create a variable in `uds-bundle.yaml` and set the desired value in `uds-config.yaml`:
+    Option B: Create a variable in `uds-bundle.yaml` and set the desired value in `uds-config.yaml`:
 
-```yaml title="uds-bundle.yaml"
-packages:
-  - name: core
-    overrides:
-      kube-prometheus-stack:
-        kube-prometheus-stack:
-          variables:
-            - name: PROMETHEUS_STORAGE_SIZE
-              description: Prometheus PVC requested storage size
-              path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
-```
+    ```yaml title="uds-bundle.yaml"
+    packages:
+      - name: core
+        overrides:
+          kube-prometheus-stack:
+            kube-prometheus-stack:
+              variables:
+                - name: PROMETHEUS_STORAGE_SIZE
+                  description: Prometheus PVC requested storage size
+                  path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
+    ```
 
-```yaml title="uds-config.yaml"
-variables:
-  core:
-    PROMETHEUS_STORAGE_SIZE: "60Gi"
-```
+    ```yaml title="uds-config.yaml"
+    variables:
+      core:
+        PROMETHEUS_STORAGE_SIZE: "60Gi"
+    ```
 
-3. Pause Prometheus reconciliation:
+3. Pause Prometheus reconciliation to prevent churn while you patch PVCs and rotate the StatefulSet.
 
-Pausing prevents operator reconciliation churn while you patch PVCs and rotate the StatefulSet.
-
-```bash
-kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":true}}'
-```
+    ```bash
+    kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":true}}'
+    ```
 
 4. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflow(s).
 
-This applies the desired Prometheus storage size from code before patching existing PVCs.
+5. Patch each existing PVC to match the new request size declared in the bundle:
 
-5. Patch each existing PVC to the new request size:
+    ```bash
+    kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+    | xargs -I{} kubectl patch pvc "{}" -n monitoring --type merge \
+      --patch "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"$TARGET_SIZE\"}}}}"
+    ```
 
-This updates the requested storage on all existing Prometheus PVCs to match bundle desired state.
+6. Monitor PVC resize events for progress or errors:
 
-```bash
-kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" \
-  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
-| xargs -I{} kubectl patch pvc "{}" -n monitoring --type merge \
-  --patch "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"$TARGET_SIZE\"}}}}"
-```
+    ```bash
+    kubectl describe pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+    ```
 
-6. Monitor PVC resize progress:
+    Check whether filesystem resize is pending before proceeding:
 
-After patching, monitor PVC events for resize progress or errors:
+    ```bash
+    kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,CONDITION:.status.conditions[*].type
+    ```
 
-```bash
-kubectl describe pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
-```
+    > [!NOTE]
+    > If any target PVC shows `FileSystemResizePending`, restart the affected Prometheus pod(s), then confirm `CAP` converges to `REQ` before continuing:
 
-Check whether filesystem resize is pending before proceeding:
-
-```bash
-kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,CONDITION:.status.conditions[*].type
-```
-
-> [!NOTE]
-> If any target PVC shows `FileSystemResizePending`, restart the affected Prometheus pod(s), then confirm `CAP` converges to `REQ` before continuing:
-
-```bash
-kubectl delete pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
-```
+    ```bash
+    kubectl delete pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+    ```
 
 7. Delete backing StatefulSet with orphan strategy:
 
-Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Prometheus Operator can recreate the StatefulSet against resized PVCs.
+    Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Prometheus Operator can recreate the StatefulSet against resized PVCs.
 
-```bash
-kubectl delete statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" --cascade=orphan
-```
+    ```bash
+    kubectl delete statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" --cascade=orphan
+    ```
 
-8. Unpause Prometheus reconciliation:
+8. Unpause Prometheus reconciliation to allow Prometheus Operator to reconcile resources back to their normal managed state:
 
-Unpausing allows Prometheus Operator to reconcile resources back to normal managed state.
-
-```bash
-kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":false}}'
-```
+    ```bash
+    kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":false}}'
+    ```
 
 ## Verification
 
-1. Confirm Prometheus CR is unpaused:
+1. Confirm Prometheus CR is unpaused and operator reconciliation is re-enabled:
 
-This confirms operator reconciliation is re-enabled.
+    Expected: `false`
 
-```bash
-kubectl get prometheus kube-prometheus-stack-prometheus -n monitoring -o jsonpath='{.spec.paused}{"\n"}'
-```
-
-Expected: `false`
+    ```bash
+    kubectl get prometheus kube-prometheus-stack-prometheus -n monitoring -o jsonpath='{.spec.paused}{"\n"}'
+    ```
 
 2. Confirm PVC requests show the new size:
 
-All listed PVC `REQ` values should match `TARGET_SIZE`.
+    Expected: All listed PVC `REQ` values should match `TARGET_SIZE`.
 
-```bash
-kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage
-```
+    ```bash
+    kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage
+    ```
 
 3. Confirm the StatefulSet is recreated by the operator:
 
-You should see a recreated StatefulSet present for the Prometheus instance.
+    Expected: Recreated StatefulSet is present for the Prometheus instance.
 
-```bash
-kubectl get statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
-```
+    ```bash
+    kubectl get statefulset -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+    ```
 
 4. Confirm Prometheus pods are Running/Ready:
 
-Pods should be `Running`/`Ready` before closing the operation.
+    Expected: All pods should be `Running`/`Ready`.
 
-```bash
-kubectl get pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
-```
+    ```bash
+    kubectl get pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+    ```
 
 5. Confirm PVC capacity has reconciled to the new size:
 
-This validates actual resize progress, not only requested size.
+    Expected: `CAP` matches `REQ` (or converges shortly after).
 
-```bash
-kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage
-```
-
-Expected: `CAP` matches `REQ` (or converges shortly after).
+    ```bash
+    kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage
+    ```
 
 ## Failure Handling
 
-- If any step fails after pause, ensure unpause is restored:
+- If any step fails after pause, ensure Prometheus CR is unpaused to restore operator reconciliation:
 
-```bash
-kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":false}}'
-```
+    ```bash
+    kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":false}}'
+    ```
 
 - If StorageClass is not expandable, do not continue this runbook.
 - If one PVC patch fails, resolve that PVC issue first, then continue from Procedure step 4.

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -50,8 +50,8 @@ If your deployment uses non-default names, update the commands accordingly.
 
     Use this output to verify each target PVC has a StorageClass and that class supports expansion.
 
-    > [!CAUTION]
-    > If expansion is not supported, stop and reassess.
+> [!CAUTION]
+> If expansion is not supported, stop and reassess.
 
     ```bash
     # Determine the storage class in use
@@ -69,8 +69,8 @@ If your deployment uses non-default names, update the commands accordingly.
     kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.resources.requests.storage}{"\n"}{end}'
     ```
 
-    > [!CAUTION]
-    > If any target PVC is already larger than your desired volume size, **stop and reassess**. PVC shrinking is not supported.
+> [!CAUTION]
+> If any target PVC is already larger than your desired volume size, **stop and reassess**. PVC shrinking is not supported.
 
 5. Confirm the size configured in your `uds-bundle.yaml` and/or `uds-config.yaml` matches your desired volume size.
 
@@ -146,8 +146,8 @@ If your deployment uses non-default names, update the commands accordingly.
     kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,CONDITION:.status.conditions[*].type
     ```
 
-    > [!NOTE]
-    > If any target PVC shows `FileSystemResizePending`, restart the affected Prometheus pod(s), then confirm `CAP` converges to `REQ` before continuing:
+> [!NOTE]
+> If any target PVC shows `FileSystemResizePending`, restart the affected Prometheus pod(s), then confirm `CAP` converges to `REQ` before continuing:
 
     ```bash
     kubectl delete pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -97,7 +97,10 @@ kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-st
 
 2. Confirm StorageClass and expansion support:
 
-Use this output to verify each target PVC has a StorageClass and that class supports expansion. If expansion is not supported, stop and reassess.
+Use this output to verify each target PVC has a StorageClass and that class supports expansion.
+
+> [!CAUTION]
+> If expansion is not supported, stop and reassess.
 
 ```bash
 # Determine the storage class in use
@@ -115,7 +118,8 @@ Compare current PVC request sizes to `TARGET_SIZE`; continue only for a size inc
 kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.resources.requests.storage}{"\n"}{end}'
 ```
 
-If any target PVC is already larger than `TARGET_SIZE`, stop and reassess.
+> [!CAUTION]
+> If any target PVC is already larger than `TARGET_SIZE`, **stop and reassess**. PVC shrinking is not supported.
 
 4. Confirm the size configured in your `uds-bundle.yaml` and/or `uds-config.yaml` matches `TARGET_SIZE`.
 

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -152,6 +152,18 @@ During and after patching, monitor PVC events for resize progress or errors:
 kubectl describe pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
 ```
 
+If controller-side expansion completes but the filesystem resize does not, PVCs may show `FileSystemResizePending` and `CAP` may remain below `REQ`. Check for that condition before proceeding:
+
+```bash
+kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,CONDITION:.status.conditions[*].type
+```
+
+If any target PVC shows `FileSystemResizePending`, restart the affected Prometheus pod(s), then confirm `CAP` converges to `REQ` before continuing:
+
+```bash
+kubectl delete pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
+```
+
 5. Delete backing StatefulSet with orphan strategy:
 
 Orphan deletion removes the StatefulSet object but preserves pods/PVCs so Prometheus Operator can recreate the StatefulSet against resized PVCs.
@@ -225,3 +237,4 @@ kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type m
 - If StorageClass is not expandable, do not continue this runbook.
 - If one PVC patch fails, resolve that PVC issue first, then continue from Procedure step 4.
 - If PVCs remain in `ExternalExpanding` without capacity change for an extended period, stop and reassess.
+- If a PVC shows `FileSystemResizePending` or `CAP` does not converge to `REQ` after controller-side expansion, restart the affected Prometheus pod(s), then re-check PVC conditions and capacity.

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -32,7 +32,7 @@ This runbook assumes UDS Core defaults:
 
 If your deployment uses non-default names, update the commands accordingly.
 
-## Variables
+## Target Size
 
 Set the target size before running commands:
 
@@ -117,7 +117,7 @@ kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-st
 
 If any target PVC is already larger than `TARGET_SIZE`, stop and reassess.
 
-4. Confirm the size you configured in your uds-bundle and/or uds-config match `TARGET_SIZE`.
+4. Confirm the size configured in your `uds-bundle.yaml` and/or `uds-config.yaml` matches `TARGET_SIZE`.
 
 ## Procedure
 
@@ -131,7 +131,9 @@ Pausing prevents operator reconciliation churn while you patch PVCs and rotate t
 kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":true}}'
 ```
 
-3. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflows so Prometheus desired storage is updated from code.
+3. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflows.
+
+This applies the desired Prometheus storage size from code before patching existing PVCs.
 
 4. Patch each existing PVC to the new request size:
 
@@ -142,6 +144,12 @@ kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-st
   -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
 | xargs -I{} kubectl patch pvc "{}" -n monitoring --type merge \
   --patch "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"$TARGET_SIZE\"}}}}"
+```
+
+During and after patching, monitor PVC events for resize progress or errors:
+
+```bash
+kubectl describe pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
 ```
 
 5. Delete backing StatefulSet with orphan strategy:
@@ -162,7 +170,7 @@ kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type m
 
 ## Verification
 
-1. Prometheus CR is unpaused:
+1. Confirm Prometheus CR is unpaused:
 
 This confirms operator reconciliation is re-enabled.
 
@@ -172,7 +180,7 @@ kubectl get prometheus kube-prometheus-stack-prometheus -n monitoring -o jsonpat
 
 Expected: `false`
 
-2. PVC requests show the new size:
+2. Confirm PVC requests show the new size:
 
 All listed PVC `REQ` values should match `TARGET_SIZE`.
 
@@ -180,7 +188,7 @@ All listed PVC `REQ` values should match `TARGET_SIZE`.
 kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage
 ```
 
-3. StatefulSet is recreated by operator:
+3. Confirm the StatefulSet is recreated by the operator:
 
 You should see a recreated StatefulSet present for the Prometheus instance.
 
@@ -196,6 +204,16 @@ Pods should be `Running`/`Ready` before closing the operation.
 kubectl get pod -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus"
 ```
 
+5. Confirm PVC capacity has reconciled to the new size:
+
+This validates actual resize progress, not only requested size.
+
+```bash
+kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-stack-prometheus" -o custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage
+```
+
+Expected: `CAP` matches `REQ` (or converges shortly after).
+
 ## Failure Handling
 
 - If any step fails after pause, ensure unpause is restored:
@@ -205,5 +223,5 @@ kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type m
 ```
 
 - If StorageClass is not expandable, do not continue this runbook.
-
 - If one PVC patch fails, resolve that PVC issue first, then continue from Procedure step 4.
+- If PVCs remain in `ExternalExpanding` without capacity change for an extended period, stop and reassess.

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -82,7 +82,7 @@ packages:
 ```yaml title="uds-config.yaml"
 variables:
   core:
-    prometheus_storage_size: "60Gi"
+    PROMETHEUS_STORAGE_SIZE: "60Gi"
 ```
 
 ## Prechecks

--- a/docs/operations/resize-prometheus-pvc.md
+++ b/docs/operations/resize-prometheus-pvc.md
@@ -32,43 +32,6 @@ This runbook assumes UDS Core defaults:
 
 If your deployment uses non-default names, update the commands accordingly.
 
-## Update Bundle Configuration
-
-Set the target size in your UDS bundle so desired Prometheus storage is captured in code before running manual resize steps.
-
-### Option A: Direct override value in `uds-bundle.yaml`
-
-```yaml title="uds-bundle.yaml"
-packages:
-  - name: core
-    overrides:
-      kube-prometheus-stack:
-        kube-prometheus-stack:
-          values:
-            - path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
-              value: "60Gi"
-```
-
-### Option B: Bundle variable with value in `uds-config.yaml`
-
-```yaml title="uds-bundle.yaml"
-packages:
-  - name: core
-    overrides:
-      kube-prometheus-stack:
-        kube-prometheus-stack:
-          variables:
-            - name: PROMETHEUS_STORAGE_SIZE
-              description: Prometheus PVC requested storage size
-              path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
-```
-
-```yaml title="uds-config.yaml"
-variables:
-  core:
-    PROMETHEUS_STORAGE_SIZE: "60Gi"
-```
-
 ## Prechecks
 
 1. Confirm the target Prometheus CR exists:
@@ -123,7 +86,40 @@ kubectl get pvc -n monitoring -l "operator.prometheus.io/name=kube-prometheus-st
 export TARGET_SIZE=60Gi
 ```
 
-2. Update bundle configuration to the target size (see examples above).
+2. Update your bundle configuration by setting the desired volume size using one of the methods below.
+
+Option A: Directly override the value in `uds-bundle.yaml`:
+
+```yaml title="uds-bundle.yaml"
+packages:
+  - name: core
+    overrides:
+      kube-prometheus-stack:
+        kube-prometheus-stack:
+          values:
+            - path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
+              value: "60Gi"
+```
+
+Option B: Create a variable in `uds-bundle.yaml` and set the desired value in `uds-config.yaml`:
+
+```yaml title="uds-bundle.yaml"
+packages:
+  - name: core
+    overrides:
+      kube-prometheus-stack:
+        kube-prometheus-stack:
+          variables:
+            - name: PROMETHEUS_STORAGE_SIZE
+              description: Prometheus PVC requested storage size
+              path: prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage
+```
+
+```yaml title="uds-config.yaml"
+variables:
+  core:
+    PROMETHEUS_STORAGE_SIZE: "60Gi"
+```
 
 3. Pause Prometheus reconciliation:
 
@@ -133,7 +129,7 @@ Pausing prevents operator reconciliation churn while you patch PVCs and rotate t
 kubectl patch prometheus kube-prometheus-stack-prometheus -n monitoring --type merge --patch '{"spec":{"paused":true}}'
 ```
 
-4. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflows.
+4. Create and deploy the updated bundle using your established UDS Core bundle creation and deployment workflow(s).
 
 This applies the desired Prometheus storage size from code before patching existing PVCs.
 


### PR DESCRIPTION
## Description

Adds operations doc on resizing prometheus PVCs

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Steps to Validate
Can be mostly validated by running against k3d after running `uds run test-single-layer --set LAYER=monitoring` and then stepping through each step. Note: k3d does not actually care about resizing the volume, and it won't actually do a resize...but it will show all of the expected results with the exception of the storage capacity actually changing See: https://github.com/rancher/local-path-provisioner?tab=readme-ov-file#cons

Was also validated by running against an AWS EKS reference deployment

##  Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed