### PR TITLE
chore: update to grafana 11.3.0 chart, community repo

### DIFF
--- a/src/grafana/common/zarf.yaml
+++ b/src/grafana/common/zarf.yaml
@@ -18,8 +18,8 @@ components:
         valuesFiles:
           - ../chart/values.yaml
       - name: grafana
-        url: https://grafana.github.io/helm-charts/
-        version: 10.5.15
+        url: https://grafana-community.github.io/helm-charts
+        version: 11.3.0
         namespace: grafana
         valuesFiles:
           - ../values/values.yaml


### PR DESCRIPTION
## Description

Per repo readme, the Grafana chart was moved to a community repo: https://github.com/grafana/helm-charts/tree/main/charts/grafana

I also bumped to the latest version of this chart. The major version bump is for a k8s minimum version requirement (1.8 -> 1.25).