### PR TITLE
chore: add polling/increase timeout to prometheus target e2e test

### DIFF
--- a/test/vitest/prometheus.spec.ts
+++ b/test/vitest/prometheus.spec.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { closeForward, getForward } from "./helpers/forward";
 import { pollUntilSuccess } from "./helpers/polling";
 
-describe("Prometheus and Alertmanager", { retry: 1, timeout: 210000 }, () => {
+describe("Prometheus and Alertmanager", { timeout: 210000 }, () => {
   let prometheusProxy: { server: net.Server; url: string };
   let alertmanagerProxy: { server: net.Server; url: string };
 
@@ -49,7 +49,9 @@ describe("Prometheus and Alertmanager", { retry: 1, timeout: 210000 }, () => {
     await pollUntilSuccess(
       async () => {
         const response = await fetch(`${prometheusProxy.url}/api/v1/targets`);
-        expect(response.status).toBe(200);
+        if (!response.ok) {
+          throw new Error(`Prometheus targets API returned ${response.status}`);
+        }
 
         const body = (await response.json()) as {
           data: {
@@ -59,29 +61,19 @@ describe("Prometheus and Alertmanager", { retry: 1, timeout: 210000 }, () => {
             }>;
           };
         };
-        expect(body.data).toBeDefined();
-        expect(body.data.activeTargets.length).toBeGreaterThan(0);
+
+        if (!body.data?.activeTargets?.length) {
+          throw new Error("No active targets returned from Prometheus");
+        }
 
         return body.data.activeTargets;
       },
       targets => {
-        const failedTargets = targets.filter(target => target.health === "down");
-        const unknownTargets = targets.filter(target => target.health === "unknown");
-
-        if (unknownTargets.length > 0) {
-          for (const target of unknownTargets) {
-            console.warn(`Target health is currently unknown: ${target.scrapePool}`);
-          }
+        const unhealthy = targets.filter(target => target.health !== "up");
+        for (const target of unhealthy) {
+          console.warn(`Target ${target.health}: ${target.scrapePool}`);
         }
-
-        if (failedTargets.length > 0) {
-          for (const target of failedTargets) {
-            console.warn(`Target health is down: ${target.scrapePool}`);
-          }
-          return false;
-        }
-
-        return true;
+        return unhealthy.length === 0;
       },
       "all prometheus targets to be up",
       200000,

--- a/test/vitest/prometheus.spec.ts
+++ b/test/vitest/prometheus.spec.ts
@@ -46,7 +46,7 @@ describe("Prometheus and Alertmanager", { retry: 1 }, () => {
   });
 
   test("all prometheus targets should be up", { timeout: 220000 }, async () => {
-    await pollUntilSuccess(
+    const targets = await pollUntilSuccess(
       async () => {
         const response = await fetch(`${prometheusProxy.url}/api/v1/targets`);
         if (!response.ok) {
@@ -71,7 +71,7 @@ describe("Prometheus and Alertmanager", { retry: 1 }, () => {
       targets => {
         const unhealthy = targets.filter(target => target.health !== "up");
         for (const target of unhealthy) {
-          console.warn(`Target ${target.health}: ${target.scrapePool}`);
+          console.warn(`Target ${target.scrapePool} is ${target.health}`);
         }
         return unhealthy.length === 0;
       },
@@ -79,5 +79,7 @@ describe("Prometheus and Alertmanager", { retry: 1 }, () => {
       200000,
       10000,
     );
+
+    expect(targets.every(target => target.health === "up")).toBe(true);
   });
 });

--- a/test/vitest/prometheus.spec.ts
+++ b/test/vitest/prometheus.spec.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { closeForward, getForward } from "./helpers/forward";
 import { pollUntilSuccess } from "./helpers/polling";
 
-describe("Prometheus and Alertmanager", { timeout: 210000 }, () => {
+describe("Prometheus and Alertmanager", { retry: 1 }, () => {
   let prometheusProxy: { server: net.Server; url: string };
   let alertmanagerProxy: { server: net.Server; url: string };
 
@@ -45,7 +45,7 @@ describe("Prometheus and Alertmanager", { timeout: 210000 }, () => {
     expect(response.status).toBe(200);
   });
 
-  test("all prometheus targets should be up", async () => {
+  test("all prometheus targets should be up", { timeout: 220000 }, async () => {
     await pollUntilSuccess(
       async () => {
         const response = await fetch(`${prometheusProxy.url}/api/v1/targets`);

--- a/test/vitest/prometheus.spec.ts
+++ b/test/vitest/prometheus.spec.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { closeForward, getForward } from "./helpers/forward";
 import { pollUntilSuccess } from "./helpers/polling";
 
-describe("Prometheus and Alertmanager", { retry: 1 }, () => {
+describe("Prometheus and Alertmanager", { retry: 1, timeout: 210000 }, () => {
   let prometheusProxy: { server: net.Server; url: string };
   let alertmanagerProxy: { server: net.Server; url: string };
 

--- a/test/vitest/prometheus.spec.ts
+++ b/test/vitest/prometheus.spec.ts
@@ -5,6 +5,7 @@
 import * as net from "net";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { closeForward, getForward } from "./helpers/forward";
+import { pollUntilSuccess } from "./helpers/polling";
 
 describe("Prometheus and Alertmanager", { retry: 1 }, () => {
   let prometheusProxy: { server: net.Server; url: string };
@@ -45,29 +46,46 @@ describe("Prometheus and Alertmanager", { retry: 1 }, () => {
   });
 
   test("all prometheus targets should be up", async () => {
-    const response = await fetch(`${prometheusProxy.url}/api/v1/targets`);
-    expect(response.status).toBe(200);
+    await pollUntilSuccess(
+      async () => {
+        const response = await fetch(`${prometheusProxy.url}/api/v1/targets`);
+        expect(response.status).toBe(200);
 
-    const body = (await response.json()) as {
-      data: {
-        activeTargets: Array<{
-          scrapePool: string;
-          health: string;
-        }>;
-      };
-    };
-    expect(body.data).toBeDefined();
-    expect(body.data.activeTargets.length).toBeGreaterThan(0);
+        const body = (await response.json()) as {
+          data: {
+            activeTargets: Array<{
+              scrapePool: string;
+              health: string;
+            }>;
+          };
+        };
+        expect(body.data).toBeDefined();
+        expect(body.data.activeTargets.length).toBeGreaterThan(0);
 
-    const failedTargets = body.data.activeTargets.filter(target => target.health === "down");
-    const unknownTargets = body.data.activeTargets.filter(target => target.health === "unknown");
+        return body.data.activeTargets;
+      },
+      targets => {
+        const failedTargets = targets.filter(target => target.health === "down");
+        const unknownTargets = targets.filter(target => target.health === "unknown");
 
-    if (unknownTargets.length > 0) {
-      for (const target of unknownTargets) {
-        console.warn(`Target health is currently unknown: ${target.scrapePool}`);
-      }
-    }
+        if (unknownTargets.length > 0) {
+          for (const target of unknownTargets) {
+            console.warn(`Target health is currently unknown: ${target.scrapePool}`);
+          }
+        }
 
-    expect(failedTargets).toEqual([]);
+        if (failedTargets.length > 0) {
+          for (const target of failedTargets) {
+            console.warn(`Target health is down: ${target.scrapePool}`);
+          }
+          return false;
+        }
+
+        return true;
+      },
+      "all prometheus targets to be up",
+      200000,
+      10000,
+    );
   });
 });


### PR DESCRIPTION
## Description

Fixes a flake on an e2e CI test: https://github.com/defenseunicorns/uds-core/actions/runs/22917963254/job/66511607227?pr=2414

Increase the timeout of this test to match the uptime tests (probes can take some time before getting loaded and showing metrics).

## Related Issue

Fixes CORE-405

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- e2e tests pass in CI

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed