### PR TITLE
docs: propose reorganized runbook titles/changes

### DIFF
--- a/.ai/docs/troubleshooting-runbook-template.md
+++ b/.ai/docs/troubleshooting-runbook-template.md
@@ -12,7 +12,6 @@ Runbooks live under `docs/operations/troubleshooting-and-runbooks/` and are `.md
 - Diagnostic commands to identify root cause (kubectl, istioctl, log queries)
 - Step-by-step solutions for each common cause
 - Verification that the fix worked
-- Prevention guidance to avoid recurrence
 
 ### What does NOT belong
 
@@ -34,8 +33,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## When to use this runbook
 
-<!-- For troubleshooting docs: describe observable symptoms and example errors -->
-<!-- For procedural runbooks: describe the scenario that triggers this procedure -->
+<!-- Trigger conditions and observable symptoms only. No context or background here. -->
 
 Use this runbook when:
 
@@ -49,10 +47,11 @@ Use this runbook when:
 Exact error message or log line the user would see
 \`\`\`
 
-## Background
+## Overview
 
-<!-- For troubleshooting docs: list the common root causes -->
-<!-- For procedural runbooks: explain why this procedure is needed -->
+<!-- For troubleshooting docs: root cause summary and relevant architecture context -->
+<!-- For procedural runbooks: why this procedure is needed and how the remediation works -->
+<!-- Keep short and operationally relevant — avoid deep theory -->
 
 This is typically caused by one of the following:
 
@@ -60,7 +59,11 @@ This is typically caused by one of the following:
 2. **Cause B** — brief explanation
 3. **Cause C** — brief explanation
 
-## Before you begin
+## Pre-checks
+
+<!-- Things to verify before executing the procedure -->
+<!-- For troubleshooting: log checks, metrics queries, confirming the problem exists -->
+<!-- For procedural: permissions, cluster access, preconditions -->
 
 <Steps>
 
@@ -86,7 +89,7 @@ This is typically caused by one of the following:
 
 </Steps>
 
-## Steps
+## Procedure
 
 ### Cause A: description
 
@@ -128,15 +131,6 @@ uds zarf tools kubectl get pods -n namespace
 - Indicator 1
 - Indicator 2
 
-## Prevention
-
-<!-- OPTIONAL: Only include this section if there is a specific, non-obvious configuration
-     or practice that prevents this issue. If the solution itself is the prevention, skip this section. -->
-
-To avoid this issue in the future:
-
-- Specific, actionable preventive measure
-
 ## Additional help
 
 If this runbook doesn't resolve your issue:
@@ -155,12 +149,12 @@ If this runbook doesn't resolve your issue:
 ## Conventions
 
 ### Structure
-- Every runbook follows the same section order: When to use this runbook → Background → Before you begin → Steps → Verification → Prevention (optional) → Additional help → Related documentation
-- **Prevention is optional** — only include it when there is a specific, non-obvious configuration or practice that prevents the issue. If the solution itself is the prevention, skip the section entirely.
-- "Before you begin" and "Steps" use the `<Steps>` component
-- For troubleshooting runbooks, the Steps section is organized per-cause with subsections matching the "Background" list
-- For procedural runbooks, Background explains why the procedure is needed, "Before you begin" covers prechecks/preconditions, and Steps is a single set of steps
+- Every runbook follows the same section order: When to use this runbook → Overview → Pre-checks → Procedure → Verification → Additional help → Related documentation
+- "Pre-checks" and "Procedure" use the `<Steps>` component
+- For troubleshooting runbooks, the Procedure section is organized per-cause with subsections matching the "Overview" list
+- For procedural runbooks, Overview explains why the procedure is needed, "Pre-checks" covers preconditions, and Procedure is a single set of steps
 - Keep sections focused — if a section requires extensive configuration, link to the relevant how-to guide instead of duplicating it
+- Prevention tips should be `> [!TIP]` callouts inline within Procedure or Verification — do not create a separate Prevention section
 
 ### Formatting
 - Files use `.mdx` extension
@@ -172,11 +166,13 @@ If this runbook doesn't resolve your issue:
 
 ### Content guidance
 - Write for operators running a live platform, not first-time installers
-- Lead with **when** the operator needs this runbook — for troubleshooting docs, describe observable symptoms and example errors; for procedural runbooks, describe the scenario that triggers the procedure
+- **When to use this runbook**: trigger conditions and observable symptoms only — no context, background, or notes about defaults
+- **Overview**: root cause summary, relevant architecture context, why the remediation works — keep short and operationally relevant, avoid deep theory
+- **Pre-checks**: things to verify before executing — permissions, cluster access, diagnostics, confirming the symptom. For troubleshooting runbooks this includes log checks, metrics queries, and confirming the problem exists
+- **Procedure**: the actual actions — numbered steps, copy-paste friendly, avoid explanation unless necessary
 - Diagnostic steps should be copy-pasteable commands that produce useful output
 - Explain what to look for in command output — don't just say "check the logs"
 - Solutions should be specific and actionable, not "contact support"
-- Prevention section should include concrete configuration or monitoring recommendations
 - Link to Reference for exact settings, Concepts only when understanding is needed
 
 ### Sidebar ordering

--- a/docs/operations/troubleshooting-and-runbooks/exemptions-and-packages.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/exemptions-and-packages.mdx
@@ -16,15 +16,15 @@ Use this runbook when:
 
 **What you'll notice:** After applying or updating a specific `Exemption` or `Package` CR, no corresponding `Processing exemption` or `Processing Package` log entry appears in the `pepr-system` controller logs for that CR.
 
-## Background
+## Overview
 
 This is typically caused by one of the following:
 
-1. **Kubernetes Watch missed event** — the Watch connection between the Pepr controller and the API server dropped or timed out, causing CR change events to be lost
+1. **Controller pods not running** — the `pepr-system` pods are in a crash loop or have been evicted, so no controller is processing events
 2. **Incorrect CR definition** — the `Exemption` or `Package` manifest doesn't match the expected schema, so the controller silently ignores it
-3. **Controller pods not running** — the `pepr-system` pods are in a crash loop or have been evicted, so no controller is processing events
+3. **Kubernetes Watch missed event** — the Watch connection between the Pepr controller and the API server dropped or timed out, causing CR change events to be lost
 
-## Before you begin
+## Pre-checks
 
 <Steps>
 
@@ -34,7 +34,7 @@ This is typically caused by one of the following:
    uds zarf tools kubectl get pods -n pepr-system
    ```
 
-   **What to look for:** all pods should be in `Running` state with all containers ready. Any `CrashLoopBackOff`, `Error`, or `Pending` states indicate a problem with the controller itself.
+   **What to look for:** all pods should be in `Running` state with all containers ready. Any `CrashLoopBackOff`, `Error`, or `Pending` states indicate a problem with the controller itself — skip to [Cause 1: Controller pods not running](#cause-1-controller-pods-not-running).
 
 2. **Verify the CR exists and check its status**
 
@@ -44,7 +44,7 @@ This is typically caused by one of the following:
    uds zarf tools kubectl get packages -n <namespace> <package-name> -o jsonpath='{.status.phase}'
    ```
 
-   **What to look for:** the `status.phase` should be `Ready`. If it's stuck on `Pending` or shows an error, the operator is not successfully reconciling it.
+   **What to look for:** the `status.phase` should be `Ready`. If it's stuck on `Pending` or shows an error, the operator is not successfully reconciling it — see [Cause 2: Incorrect CR definition](#cause-2-incorrect-cr-definition).
 
    For an Exemption CR, confirm it exists in the correct namespace:
 
@@ -67,7 +67,7 @@ This is typically caused by one of the following:
    {"...":"...", "msg":"Processing exemption nvidia-gpu-operator, watch phase: MODIFIED"}
    ```
 
-   If no entries appear after applying your `Exemption` CR, the Watch likely missed the event.
+   If no entries appear after applying your `Exemption` CR, the Watch likely missed the event — see [Cause 3: Kubernetes Watch missed event](#cause-3-kubernetes-watch-missed-event).
 
 4. **Check Package processing logs**
 
@@ -82,56 +82,13 @@ This is typically caused by one of the following:
    {"...":"...","msg":"Processing Package authservice-test-app/mouse, status.phase: Ready, observedGeneration: 1, retryAttempt: 0"}
    ```
 
-   If no entries appear, the watcher is not picking up Package changes.
+   If no entries appear, the watcher is not picking up Package changes — see [Cause 3: Kubernetes Watch missed event](#cause-3-kubernetes-watch-missed-event).
 
 </Steps>
 
-## Steps
+## Procedure
 
-### Cause 1: Kubernetes Watch missed event
-
-If diagnostics show the controller pods are running but no processing log entries appear for your CR:
-
-<Steps>
-
-1. **Restart the watcher deployment**
-
-   ```bash
-   uds zarf tools kubectl rollout restart deploy/pepr-uds-core-watcher -n pepr-system
-   ```
-
-2. **Wait for the rollout to complete**
-
-   ```bash
-   uds zarf tools kubectl rollout status deploy/pepr-uds-core-watcher -n pepr-system
-   ```
-
-   The watcher reprocesses all Exemptions and Packages on startup, so no need to re-apply your CRs.
-
-</Steps>
-
-If the Watch failure persists, see the [Additional help](#additional-help) section to file an issue with the UDS Core team.
-
-### Cause 2: Incorrect CR definition
-
-If the CR exists in the cluster but the controller is not processing it:
-
-<Steps>
-
-1. **Validate against the spec**
-
-   Compare your CR against the specification to ensure all required fields are present and correctly formatted:
-
-   - [Packages specification](/reference/operator-and-crds/package/)
-   - [Exemptions specification](/reference/operator-and-crds/exemption/)
-
-2. **Fix and re-apply the CR**
-
-   Correct any schema issues in your manifest and re-apply it.
-
-</Steps>
-
-### Cause 3: Controller pods not running
+### Cause 1: Controller pods not running
 
 If the `pepr-system` pods are not healthy:
 
@@ -163,6 +120,49 @@ If the `pepr-system` pods are not healthy:
    ```
 
 </Steps>
+
+### Cause 2: Incorrect CR definition
+
+If the CR exists in the cluster but the controller is not processing it:
+
+<Steps>
+
+1. **Validate against the spec**
+
+   Compare your CR against the specification to ensure all required fields are present and correctly formatted:
+
+   - [Packages specification](/reference/operator-and-crds/package/)
+   - [Exemptions specification](/reference/operator-and-crds/exemption/)
+
+2. **Fix and re-apply the CR**
+
+   Correct any schema issues in your manifest and re-apply it.
+
+</Steps>
+
+### Cause 3: Kubernetes Watch missed event
+
+If diagnostics show the controller pods are running but no processing log entries appear for your CR:
+
+<Steps>
+
+1. **Restart the watcher deployment**
+
+   ```bash
+   uds zarf tools kubectl rollout restart deploy/pepr-uds-core-watcher -n pepr-system
+   ```
+
+2. **Wait for the rollout to complete**
+
+   ```bash
+   uds zarf tools kubectl rollout status deploy/pepr-uds-core-watcher -n pepr-system
+   ```
+
+   The watcher reprocesses all Exemptions and Packages on startup, so no need to re-apply your CRs.
+
+</Steps>
+
+If the Watch failure persists, see the [Additional help](#additional-help) section to file an issue with the UDS Core team.
 
 ## Verification
 

--- a/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
@@ -14,7 +14,7 @@ Use this runbook when:
 - Admin credentials are unknown, lost, or were changed without updating records
 - Your account is locked out after a FIPS migration or upgrade
 
-## Background
+## Overview
 
 This is typically caused by one of the following:
 
@@ -22,7 +22,9 @@ This is typically caused by one of the following:
 2. **Credentials rotated without updating records** — a scheduled or manual rotation changed the password but the new value was not stored
 3. **Account locked after FIPS migration or upgrade** — FIPS mode can invalidate existing credential hashes, locking out the admin account
 
-## Before you begin
+This runbook uses the Keycloak [Admin bootstrap and recovery](https://www.keycloak.org/server/bootstrap-admin-recovery) feature to create a temporary admin user, then reset the original admin credentials.
+
+## Pre-checks
 
 <Steps>
 
@@ -38,14 +40,14 @@ This is typically caused by one of the following:
 
    **What to look for:** All Keycloak pods should be in `Running` state with all containers ready. If pods are in `CrashLoopBackOff` or `OOMKilled`, address pod health before attempting credential recovery.
 
+3. **Confirm the Keycloak container has at least 1.5G of memory allocated**
+
+   > [!CAUTION]
+   > The bootstrap-admin recovery command requires at least 1.5G of memory. You may need to temporarily increase the memory limit before starting. If the `JAVA_OPTS_KC_HEAP` environment variable is used, ensure the `-XX:MaxRAM` setting corresponds to the container memory limits.
+
 </Steps>
 
-## Steps
-
-This procedure uses the Keycloak [Admin bootstrap and recovery](https://www.keycloak.org/server/bootstrap-admin-recovery) feature.
-
-> [!CAUTION]
-> This procedure requires at least 1.5G of memory allocated to the Keycloak container. You may need to temporarily increase the memory limit before starting the recovery process. If the `JAVA_OPTS_KC_HEAP` environment variable is used, ensure the `-XX:MaxRAM` setting corresponds to the container memory limits.
+## Procedure
 
 <Steps>
 

--- a/docs/operations/troubleshooting-and-runbooks/resize-prometheus-pvc.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/resize-prometheus-pvc.mdx
@@ -14,12 +14,7 @@ Use this runbook when you need to increase the size of Prometheus PVCs managed b
 - You need to proactively increase capacity before running out of space
 - Volume size increase only — PVC shrinking is not supported
 
-> [!NOTE]
-> This runbook assumes UDS Core defaults: namespace `monitoring` and Prometheus CR name `kube-prometheus-stack-prometheus`. If your deployment uses non-default names, update the commands accordingly.
-
-This procedure follows upstream guidance from [Prometheus Operator — Resizing Volumes](https://prometheus-operator.dev/docs/platform/storage/#resizing-volumes).
-
-## Background
+## Overview
 
 Prometheus storage may need to grow for one or more of the following reasons:
 
@@ -27,7 +22,12 @@ Prometheus storage may need to grow for one or more of the following reasons:
 2. **Higher metrics cardinality** — new workloads, labels, or scrape targets increased the volume of stored time series
 3. **Additional scrape targets** — more services were added to the cluster, increasing the total metrics ingestion rate
 
-## Before you begin
+This procedure follows upstream guidance from [Prometheus Operator — Resizing Volumes](https://prometheus-operator.dev/docs/platform/storage/#resizing-volumes).
+
+> [!NOTE]
+> This runbook assumes UDS Core defaults: namespace `monitoring` and Prometheus CR name `kube-prometheus-stack-prometheus`. If your deployment uses non-default names, update the commands accordingly.
+
+## Pre-checks
 
 <Steps>
 
@@ -69,7 +69,7 @@ Prometheus storage may need to grow for one or more of the following reasons:
 
 </Steps>
 
-## Steps
+## Procedure
 
 <Steps>
 


### PR DESCRIPTION
## Description

Reorganizes runbooks a bit under different headings to be more "operations" focused/styled while keeping a unified template for both procedural and troubleshooting.