### PR TITLE
docs: update network docs, add trust management

### DIFF
--- a/.ai/docs/how-to-guide-template.md
+++ b/.ai/docs/how-to-guide-template.md
@@ -127,7 +127,7 @@ uds zarf tools kubectl get pods -n namespace
 
 ## Troubleshooting
 
-### Problem description
+### Problem: Short description of the issue
 
 **Symptom:** What the user sees.
 
@@ -194,5 +194,7 @@ These guides and concepts may be useful to explore next:
   ```
 - Related Documentation comes before Next Steps
 - Next Steps uses `<CardGrid>` with `<LinkCard>` components
+- Related Documentation and Next Steps should not overlap: Related Documentation links to reference pages, external docs, and concepts; Next Steps links to actionable how-to guides or concepts as a natural follow-up
 - For optional steps, put `(Optional)` at the beginning of the step heading: `**(Optional) Step name**` (per [Google](https://developers.google.com/style/procedures#optional-steps) and [Microsoft](https://learn.microsoft.com/en-us/style-guide/procedures-instructions/writing-step-by-step-instructions) style guides)
+- Troubleshooting headings use the `### Problem: Description` format, with `**Symptom:**` (singular) or `**Symptoms:**` (plural) and `**Solution:**` sub-headings
 - Verify all helm paths against source `values.yaml` and all upstream URLs before publishing

--- a/docs/concepts/core-features/networking.mdx
+++ b/docs/concepts/core-features/networking.mdx
@@ -109,9 +109,7 @@ This means:
 
 ## Trust and certificate management
 
-When using private PKI or self-signed certificates, UDS Core provides a trust bundle mechanism that propagates CA certificates to platform components (including Keycloak). This ensures that TLS-dependent flows — such as SSO and inter-service mTLS — do not break when operating in air-gapped environments with internally-issued certificates.
-
----
+When using private PKI or self-signed certificates, UDS Core provides a trust bundle mechanism that propagates CA certificates to platform components (including Keycloak). This ensures that TLS-dependent flows — such as SSO and inter-service mTLS — do not break when operating in air-gapped environments with internally-issued certificates. See [Manage trust bundles](/how-to-guides/networking/manage-trust-bundles/) for configuration steps.
 
 > [!TIP]
 > Ready to configure networking for your environment? See the [Networking How-to Guides](/how-to-guides/networking/overview/).

--- a/docs/how-to-guides/networking/allow-permissive-mesh-traffic.mdx
+++ b/docs/how-to-guides/networking/allow-permissive-mesh-traffic.mdx
@@ -1,7 +1,7 @@
 ---
 title: Allow permissive traffic through the mesh
 sidebar:
-  order: 2.8
+  order: 2.08
 ---
 
 import { Steps, Tabs, TabItem, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -170,12 +170,19 @@ In these cases, you can layer additional `ALLOW` [authorization policies](https:
 
    See the [Istio PeerAuthentication documentation](https://istio.io/latest/docs/reference/config/security/peer_authentication/) for details on scoping options.
 
-3. **Include manifests in your Zarf package and deploy**
+3. **Deploy your application**
 
-   Add the `AuthorizationPolicy` and `PeerAuthentication` manifests to your application's Zarf package, then build and deploy:
+   **(Recommended)** Include the `AuthorizationPolicy` and `PeerAuthentication` manifests in your application's Zarf package and create/deploy. See [Packaging applications](/how-to-guides/packaging-applications/overview/) for general packaging guidance.
 
    ```bash
-   uds zarf package create --confirm && uds zarf package deploy zarf-package-*.tar.zst --confirm
+   uds zarf package create --confirm
+   uds zarf package deploy zarf-package-*.tar.zst --confirm
+   ```
+
+   **Or** apply the manifests directly for quick testing:
+
+   ```bash
+   uds zarf tools kubectl apply -f authz-policy.yaml -f peer-auth.yaml
    ```
 
 </Steps>
@@ -193,7 +200,7 @@ Test that the previously-blocked traffic now flows as expected.
 
 ## Troubleshooting
 
-### Policy not taking effect
+### Problem: Policy not taking effect
 
 **Symptoms:** Traffic is still being denied after applying the authorization policy.
 
@@ -203,7 +210,7 @@ Test that the previously-blocked traffic now flows as expected.
 - Remember that Istio evaluates `DENY` policies before `ALLOW` policies — if a `DENY` policy exists, your `ALLOW` policy will not override it
 - Ensure you have also applied a permissive `PeerAuthentication` if the traffic source cannot present a valid mesh identity
 
-### Scope too broad
+### Problem: Scope too broad
 
 **Symptoms:** Unintended services are now receiving traffic they shouldn't.
 
@@ -211,7 +218,7 @@ Test that the previously-blocked traffic now flows as expected.
 - Narrow the scope: add a `selector` to target specific workloads, or add port restrictions
 - Move from a namespace-scoped policy to a workload-scoped one
 
-## Related documentation
+## Related Documentation
 
 - [Package CR Reference](/reference/operator-and-crds/package/)
 - [Istio Authorization Policy Documentation](https://istio.io/latest/docs/concepts/security/#authorization-policies)

--- a/docs/how-to-guides/networking/configure-core-network-access.mdx
+++ b/docs/how-to-guides/networking/configure-core-network-access.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure network access for Core services
 sidebar:
-  order: 2.9
+  order: 2.09
 ---
 
 import { Steps, Tabs, TabItem, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -159,7 +159,7 @@ uds zarf tools kubectl get serviceentry -n istio-egress-ambient
 
 ## Troubleshooting
 
-### Additional rule not taking effect
+### Problem: Additional rule not taking effect
 
 **Symptoms:** The Core component still cannot reach the external or internal destination.
 
@@ -169,7 +169,7 @@ uds zarf tools kubectl get serviceentry -n istio-egress-ambient
 - For external hosts, verify the `remoteHost` matches exactly — no wildcards are supported
 - Ensure the component's Helm chart supports `additionalNetworkAllow` (check the chart's `values.yaml` for the field)
 
-### Override not applied
+### Problem: Override not applied
 
 **Symptoms:** The Package CR doesn't include your custom rules after deployment.
 
@@ -178,7 +178,7 @@ uds zarf tools kubectl get serviceentry -n istio-egress-ambient
 - Check that `additionalNetworkAllow` is a list (array), not an object
 - Run `uds zarf package inspect` on your deployed package to confirm the override was applied
 
-## Related documentation
+## Related Documentation
 
 - [Package CR Reference](/reference/operator-and-crds/package/)
 

--- a/docs/how-to-guides/networking/configure-l7-load-balancer.mdx
+++ b/docs/how-to-guides/networking/configure-l7-load-balancer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure an L7 load balancer
 sidebar:
-  order: 2.7
+  order: 2.07
 ---
 
 import { Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -74,7 +74,7 @@ After completing this guide, UDS Core will work correctly behind an L7 load bala
    > [!NOTE]
    > If you have multiple proxy layers (e.g., CDN + ALB), set `numTrustedProxies` to the total number of hops between the client and Istio. Changing this setting at runtime triggers the UDS Operator to automatically restart Istio gateway pods.
 
-2. **Configure client certificate forwarding** *(if using mTLS)*
+2. **(Optional) Configure client certificate forwarding**
 
    If your L7 load balancer performs mutual TLS and forwards client certificates to Keycloak (e.g., for DoD CAC authentication), configure Keycloak to read the certificate from the correct header:
 
@@ -125,19 +125,19 @@ After completing this guide, UDS Core will work correctly behind an L7 load bala
 
 ## Troubleshooting
 
-### Redirect loop
+### Problem: Redirect loop
 
 **Symptoms:** Browser shows "too many redirects" or ERR_TOO_MANY_REDIRECTS.
 
 **Solution:** Verify that HTTPS redirects are disabled for all gateway servers behind the load balancer. For the tenant gateway, both `tls.servers.keycloak.enableHttpsRedirect` and `tls.servers.tenant.enableHttpsRedirect` must be set to `false`. For the admin gateway, use `tls.servers.keycloak.enableHttpsRedirect` and `tls.servers.admin.enableHttpsRedirect`. If the admin gateway is also behind the L7 load balancer, disable redirects there too.
 
-### Incorrect client IP or forwarded headers
+### Problem: Incorrect client IP or forwarded headers
 
 **Symptoms:** Applications see the load balancer's IP instead of the client's IP; rate limiting or IP-based access control doesn't work correctly.
 
 **Solution:** Verify `numTrustedProxies` is set to the correct number of proxy hops between the client and Istio. If too low, Istio doesn't trust the `X-Forwarded-For` header; if too high, clients could spoof their IP.
 
-### Keycloak mTLS not working
+### Problem: Keycloak mTLS not working
 
 **Symptoms:** Client certificate authentication fails through the load balancer but works when connecting directly to Istio.
 
@@ -146,7 +146,7 @@ After completing this guide, UDS Core will work correctly behind an L7 load bala
 - Verify the `tlsCertificateFormat` matches your load balancer's format (`AWS` for ALB, `PEM` for others)
 - Ensure the load balancer is configured to forward client certificates
 
-## Related documentation
+## Related Documentation
 
 - [Networking & Service Mesh Concepts](/concepts/core-features/networking/)
 - [Istio Network Topology Documentation](https://istio.io/latest/docs/ops/configuration/traffic-management/network-topologies/)

--- a/docs/how-to-guides/networking/configure-non-http-ingress.mdx
+++ b/docs/how-to-guides/networking/configure-non-http-ingress.mdx
@@ -1,7 +1,7 @@
 ---
 title: Set up non-HTTP ingress
 sidebar:
-  order: 2.5
+  order: 2.05
 ---
 
 import { Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -142,12 +142,19 @@ This example configures SSH ingress, but the same process applies to any TCP pro
            description: "SSH Ingress"
    ```
 
-6. **Build and deploy your application's Zarf package**
+6. **Deploy your application**
 
-   Include the Gateway, VirtualService, and Package CR manifests in your Zarf package, then build and deploy:
+   **(Recommended)** Include the Gateway, VirtualService, and Package CR manifests in your Zarf package and create/deploy. See [Packaging applications](/how-to-guides/packaging-applications/overview/) for general packaging guidance.
 
    ```bash
-   uds zarf package create --confirm && uds zarf package deploy zarf-package-*.tar.zst --confirm
+   uds zarf package create --confirm
+   uds zarf package deploy zarf-package-*.tar.zst --confirm
+   ```
+
+   **Or** apply the manifests directly for quick testing:
+
+   ```bash
+   uds zarf tools kubectl apply -f gateway.yaml -f virtualservice.yaml -f uds-package.yaml
    ```
 
 </Steps>
@@ -164,7 +171,7 @@ For other protocols, test with the appropriate client on the external port you c
 
 ## Troubleshooting
 
-### Connection refused
+### Problem: Connection refused
 
 **Symptoms:** Client receives "connection refused" immediately.
 
@@ -173,7 +180,7 @@ For other protocols, test with the appropriate client on the external port you c
 - Check that the Gateway CR exists: `uds zarf tools kubectl get gateway -n istio-tenant-gateway`
 - Confirm `targetPort` in the service matches `port.number` in the Gateway CR
 
-### Connection timeout
+### Problem: Connection timeout
 
 **Symptoms:** Client hangs without a response.
 
@@ -182,7 +189,7 @@ For other protocols, test with the appropriate client on the external port you c
 - Verify the network policy allows ingress from the gateway namespace: `uds zarf tools kubectl get package example -n example`
 - Confirm the destination service and port are correct: `uds zarf tools kubectl get svc -n example`
 
-## Related documentation
+## Related Documentation
 
 - [Networking & Service Mesh Concepts](/concepts/core-features/networking/)
 - [Package CR Reference](/reference/operator-and-crds/package/)

--- a/docs/how-to-guides/networking/configure-tls-certificates.mdx
+++ b/docs/how-to-guides/networking/configure-tls-certificates.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure TLS certificates for gateways
 sidebar:
-  order: 2.1
+  order: 2.01
 ---
 
 import { Steps, Tabs, TabItem, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -25,9 +25,9 @@ After completing this guide, your UDS Core ingress gateways will serve traffic u
 > The certificate value must include your domain certificate **and** any intermediate certificates between it and a trusted root CA (the full certificate chain). The order matters: your server certificate (e.g., `*.yourdomain.com`) must come **first**, followed by intermediates in order, and finally your root CA. Failing to include intermediates can cause unexpected behavior, as some container images may not inherently trust them.
 
 > [!NOTE]
-> If you are using private PKI or self-signed certificates, you will also need to configure the UDS trust bundle. See [Manage trust bundles and private PKI](/how-to-guides/policy-and-compliance/manage-trust-bundles/) for details.
+> If you are using private PKI or self-signed certificates, you will also need to configure the UDS trust bundle. See [Manage trust bundles](/how-to-guides/networking/manage-trust-bundles/) for details.
 
-## Provide certificates
+## Steps
 
 <Tabs>
   <TabItem label="Bundle variables">
@@ -185,13 +185,13 @@ You should see your domain certificate and the correct certificate chain. You ca
 
 ## Troubleshooting
 
-### Certificate chain errors
+### Problem: Certificate chain errors
 
 **Symptoms:** Browsers show "certificate not trusted" or curl reports `SSL certificate problem: unable to get local issuer certificate`.
 
 **Solution:** Ensure your certificate bundle includes the full chain in the correct order: server cert first, then intermediates, then root CA.
 
-### Base64 encoding issues
+### Problem: Base64 encoding issues
 
 **Symptoms:** Gateway pods fail to start or TLS handshake fails immediately.
 
@@ -202,16 +202,16 @@ base64 -w0 < my-cert.pem                    # Linux
 base64 -i my-cert.pem | tr -d '\n'          # macOS
 ```
 
-### TLS 1.2 clients can't connect
+### Problem: TLS 1.2 clients can't connect
 
 **Symptoms:** Older clients or tools fail to connect, newer clients work fine.
 
 **Solution:** Enable TLS 1.2 support as shown above. This is common in environments with legacy systems or specific compliance requirements.
 
-## Related documentation
+## Related Documentation
 
 - [Networking & Service Mesh Concepts](/concepts/core-features/networking/)
-- [Manage trust bundles and private PKI](/how-to-guides/policy-and-compliance/manage-trust-bundles/)
+- [Manage trust bundles](/how-to-guides/networking/manage-trust-bundles/)
 
 ## Next steps
 

--- a/docs/how-to-guides/networking/configure-tls-certificates.mdx
+++ b/docs/how-to-guides/networking/configure-tls-certificates.mdx
@@ -17,7 +17,7 @@ After completing this guide, your UDS Core ingress gateways will serve traffic u
 - A wildcard TLS certificate and private key (PEM format) for each gateway domain. If using a private or non-public CA, the root CA must be loaded in your OS trust store for browser and CLI verification to work.
   - Tenant gateway: `*.yourdomain.com`
   - Admin gateway: `*.admin.yourdomain.com` (or your custom admin domain)
-  - Root domain (optional): `yourdomain.com` — only needed if you [expose a service on the root domain](/how-to-guides/networking/expose-apps-on-gateways/#expose-a-service-on-the-root-apex-domain)
+  - Root domain (optional): `yourdomain.com` — only needed if you [expose a service on the root domain](/how-to-guides/networking/expose-apps-on-gateways/)
 
 ## Before you begin
 
@@ -141,7 +141,7 @@ After completing this guide, your UDS Core ingress gateways will serve traffic u
 
 ## Root domain TLS certificates
 
-If you have enabled [root (apex) domain support](/how-to-guides/networking/expose-apps-on-gateways/#expose-a-service-on-the-root-apex-domain), provide TLS certificates separately for the root domain:
+If you are planning to [expose an app on the root (apex) domain](/how-to-guides/networking/expose-apps-on-gateways/), provide TLS certificates separately for the root domain:
 
 ```yaml title="uds-bundle.yaml"
 overrides:

--- a/docs/how-to-guides/networking/create-custom-gateways.mdx
+++ b/docs/how-to-guides/networking/create-custom-gateways.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create a custom gateway
 sidebar:
-  order: 2.6
+  order: 2.06
 ---
 
 import { Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -170,7 +170,7 @@ curl -v https://my-app.mydomain.dev
 
 ## Troubleshooting
 
-### Traffic not routing through the custom gateway
+### Problem: Traffic not routing through the custom gateway
 
 **Symptoms:** Package CR reconciles but traffic doesn't reach the service.
 
@@ -181,13 +181,13 @@ curl -v https://my-app.mydomain.dev
 
 A mismatch in any of these will prevent the Package CR from connecting to your gateway.
 
-### TLS errors on non-passthrough gateway
+### Problem: TLS errors on non-passthrough gateway
 
 **Symptoms:** TLS handshake failures when accessing services.
 
 **Solution:** Ensure you have provided TLS certificates for the gateway. Gateways in `SIMPLE`, `MUTUAL`, or `OPTIONAL_MUTUAL` mode require a valid cert and key.
 
-## Related documentation
+## Related Documentation
 
 - [Networking & Service Mesh Concepts](/concepts/core-features/networking/)
 - [Package CR Reference](/reference/operator-and-crds/package/)

--- a/docs/how-to-guides/networking/define-network-access.mdx
+++ b/docs/how-to-guides/networking/define-network-access.mdx
@@ -1,7 +1,7 @@
 ---
 title: Define network access for your application
 sidebar:
-  order: 2.4
+  order: 2.04
 ---
 
 import { Steps, Tabs, TabItem, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -275,12 +275,26 @@ Each `allow` entry specifies a `direction` (`Ingress` or `Egress`), a `selector`
      </TabItem>
    </Tabs>
 
-4. **Build and deploy**
+   > [!WARNING]
+   > **Security implications of external egress:**
+   > - **TLS passthrough**: External egress uses TLS passthrough mode, meaning traffic exits the mesh as-is. Without TLS origination, HTTP paths cannot be inspected, restricted, or logged.
+   > - **Domain fronting**: TLS passthrough only verifies the SNI header, not the actual destination. This is only safe for trusted hosts. See [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) for background.
+   > - **DNS exfiltration**: UDS Core does not currently block DNS-based data exfiltration.
+   > - **Audit all egress entries**: Platform engineers should review all `Package` custom resources to verify that every `Egress` entry is scoped appropriately — each one represents a traffic path that will be opened.
 
-   Include the Package CR in your application's Zarf package, then build and deploy:
+4. **Deploy your application**
+
+   **(Recommended)** Include the Package CR in your application's Zarf package and create/deploy. See [Packaging applications](/how-to-guides/packaging-applications/overview/) for general packaging guidance.
 
    ```bash
-   uds zarf package create --confirm && uds zarf package deploy zarf-package-*.tar.zst --confirm
+   uds zarf package create --confirm
+   uds zarf package deploy zarf-package-*.tar.zst --confirm
+   ```
+
+   **Or** apply the Package CR directly for quick testing:
+
+   ```bash
+   uds zarf tools kubectl apply -f uds-package.yaml
    ```
 
 </Steps>
@@ -307,7 +321,7 @@ uds zarf tools kubectl get virtualservice -n istio-egress-gateway
 
 ## Troubleshooting
 
-### Intra-cluster traffic blocked
+### Problem: Intra-cluster traffic blocked
 
 **Symptoms:** Application cannot reach a service in another namespace; connection timeouts or resets.
 
@@ -316,7 +330,7 @@ uds zarf tools kubectl get virtualservice -n istio-egress-gateway
 - Check that the `port` matches the port the remote service is listening on
 - Ensure both sides have the necessary rules — if app A needs to talk to app B, app A needs an `Egress` rule and app B needs an `Ingress` rule
 
-### External egress blocked
+### Problem: External egress blocked
 
 **Symptoms:** Application cannot reach an external service; connection timeouts or resets.
 
@@ -325,20 +339,13 @@ uds zarf tools kubectl get virtualservice -n istio-egress-gateway
 - Check that your `selector` and `serviceAccount` match the workloads you expect
 - For sidecar mode, run `istioctl proxy-config listeners <egress-pod> -n <egress-namespace>` to verify expected routes
 
-### Port not exposed (sidecar egress)
+### Problem: Port not exposed (sidecar egress)
 
 **Symptoms:** Operator logs a warning; traffic on custom ports does not egress.
 
 **Solution:** The port is not exposed on the egress gateway service. Add it to `service.ports` in the gateway overrides as shown in the sidecar mode tab.
 
-## Security considerations
-
-- **TLS passthrough**: External egress uses TLS passthrough mode, meaning traffic exits the mesh as-is. Without TLS origination, HTTP paths cannot be inspected, restricted, or logged.
-- **Domain fronting**: TLS passthrough only verifies the SNI header, not the actual destination. This is only safe for trusted hosts. See [domain fronting](https://en.wikipedia.org/wiki/Domain_fronting) for background.
-- **DNS exfiltration**: UDS Core does not currently block DNS-based data exfiltration.
-- **Audit all egress entries**: Platform engineers should review all `Package` custom resources to verify that every `Egress` entry is scoped appropriately — each one represents a traffic path that will be opened. Ensure all declared egress is either intra-cluster communication or intentional external access.
-
-## Related documentation
+## Related Documentation
 
 - [Package CR Reference](/reference/operator-and-crds/package/)
 

--- a/docs/how-to-guides/networking/enable-passthrough-gateway.mdx
+++ b/docs/how-to-guides/networking/enable-passthrough-gateway.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enable and use the passthrough gateway
 sidebar:
-  order: 2.3
+  order: 2.03
 ---
 
 import { Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -69,12 +69,19 @@ After completing this guide, you will have the optional passthrough gateway depl
 
    Traffic to `https://my-tls-app.yourdomain.com` will be forwarded to your application with the original TLS connection intact.
 
-3. **Build and deploy your application's Zarf package**
+3. **Deploy your application**
 
-   Include the Package CR in your application's Zarf package, then build and deploy:
+   **(Recommended)** Include the Package CR in your application's Zarf package and create/deploy. See [Packaging applications](/how-to-guides/packaging-applications/overview/) for general packaging guidance.
 
    ```bash
-   uds zarf package create --confirm && uds zarf package deploy zarf-package-*.tar.zst --confirm
+   uds zarf package create --confirm
+   uds zarf package deploy zarf-package-*.tar.zst --confirm
+   ```
+
+   **Or** apply the Package CR directly for quick testing:
+
+   ```bash
+   uds zarf tools kubectl apply -f uds-package.yaml
    ```
 
 </Steps>
@@ -95,19 +102,19 @@ curl -v https://my-tls-app.yourdomain.com
 
 ## Troubleshooting
 
-### Gateway not deploying
+### Problem: Gateway not deploying
 
-**Symptoms:** No pods in the `istio-passthrough-gateway` namespace.
+**Symptom:** No pods in the `istio-passthrough-gateway` namespace.
 
 **Solution:** Verify that `istio-passthrough-gateway` is listed under `optionalComponents` in your bundle configuration. The component name must match exactly.
 
-### TLS handshake failures
+### Problem: TLS handshake failures
 
 **Symptoms:** Connection resets or TLS errors when accessing the application.
 
 **Solution:** Ensure your application is correctly configured to terminate TLS on the port specified in the Package CR. The passthrough gateway does not perform any TLS termination — the application must handle it.
 
-## Related documentation
+## Related Documentation
 
 - [Networking & Service Mesh Concepts](/concepts/core-features/networking/)
 

--- a/docs/how-to-guides/networking/expose-apps-on-gateways.mdx
+++ b/docs/how-to-guides/networking/expose-apps-on-gateways.mdx
@@ -1,10 +1,10 @@
 ---
 title: Expose applications on gateways
 sidebar:
-  order: 2.2
+  order: 2.02
 ---
 
-import { Steps, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## What you'll accomplish
 
@@ -27,85 +27,9 @@ After completing this guide, your application will be accessible through one of 
 
 <Steps>
 
-1. **Define a Package CR for your application**
+1. **(Optional) Enable root domain support**
 
-   Add an `expose` entry to route traffic through a gateway. The UDS Operator creates the necessary `VirtualService` and `AuthorizationPolicy` resources automatically.
-
-   To expose on the **tenant gateway** (end-user traffic):
-
-   ```yaml title="uds-package.yaml"
-   apiVersion: uds.dev/v1alpha1
-   kind: Package
-   metadata:
-     name: my-app
-     namespace: my-app
-   spec:
-     network:
-       expose:
-         - service: my-app-service
-           selector:
-             app.kubernetes.io/name: my-app
-           host: my-app
-           gateway: tenant
-           port: 8080
-   ```
-
-   This exposes the application at `https://my-app.yourdomain.com`, routing traffic to port 8080 on pods matching the selector.
-
-   To expose on the **admin gateway** (admin-facing interfaces), use `gateway: admin`:
-
-   ```yaml title="uds-package.yaml"
-   apiVersion: uds.dev/v1alpha1
-   kind: Package
-   metadata:
-     name: my-app
-     namespace: my-app
-   spec:
-     network:
-       expose:
-         - service: my-app-admin
-           selector:
-             app.kubernetes.io/name: my-app
-           host: my-app
-           gateway: admin
-           port: 9090
-   ```
-
-   This exposes the application at `https://my-app.admin.yourdomain.com`. Since the admin and tenant gateways are logically separated, you can apply different security controls to each (IP allowlisting, mTLS client certificates, etc.).
-
-2. **Build and deploy your Zarf package**
-
-   Include the `Package` CR manifest in your [Zarf package](https://docs.zarf.dev/ref/create/) alongside your application's Helm chart. Then build and deploy:
-
-   ```bash
-   uds zarf package create --confirm && uds zarf package deploy zarf-package-*.tar.zst --confirm
-   ```
-
-   If your application is part of a [UDS Bundle](/concepts/configuration-and-packaging/bundles/), include the Zarf package in your bundle and deploy it with `uds create` and `uds deploy` instead.
-
-</Steps>
-
-## Verification
-
-Check that the Package CR was reconciled and shows the expected endpoints:
-
-```bash
-uds zarf tools kubectl get package my-app -n my-app
-```
-
-The `ENDPOINTS` column should show your application's URL(s). Test access:
-
-```bash
-curl -v https://my-app.yourdomain.com
-```
-
-## Expose a service on the root (apex) domain
-
-By default, UDS Core gateways use wildcard hosts (e.g., `*.yourdomain.com`), which match subdomains but not the root domain itself. To serve traffic at `https://yourdomain.com`, enable root domain support.
-
-<Steps>
-
-1. **Enable the root domain in your bundle**
+   By default, UDS Core gateways use wildcard hosts (e.g., `*.yourdomain.com`), which match subdomains but not the root domain itself. If you need to serve traffic at `https://yourdomain.com`, enable root domain support in your UDS Core bundle:
 
    ```yaml title="uds-bundle.yaml"
    packages:
@@ -137,72 +61,155 @@ By default, UDS Core gateways use wildcard hosts (e.g., `*.yourdomain.com`), whi
    > [!NOTE]
    > If you provide a non-empty value for `credentialName`, UDS Core assumes you have pre-created the Kubernetes secret and will not auto-generate it. If your SAN certificate covers both subdomains and the root, you can point `credentialName` to that existing secret (the default gateway TLS secret name is `gateway-tls`).
 
-2. **Expose your service using the `.` host**
-
-   ```yaml title="uds-package.yaml"
-   apiVersion: uds.dev/v1alpha1
-   kind: Package
-   metadata:
-     name: my-app
-     namespace: my-namespace
-   spec:
-     network:
-       expose:
-         - service: my-app-service
-           selector:
-             app.kubernetes.io/name: my-app
-           host: "."
-           gateway: tenant
-           port: 80
-   ```
-
-   Ensure your DNS has an A record for the root domain pointing to your ingress gateway.
-
-3. **Create and deploy your bundle and application**
-
-   Deploy the UDS Core bundle with the root domain overrides:
+   Create and deploy the bundle:
 
    ```bash
    uds create --confirm && uds deploy uds-bundle-*.tar.zst --confirm
    ```
 
-   Then build and deploy your application's Zarf package (which includes the Package CR):
+   Ensure your DNS has an A record for the root domain pointing to your ingress gateway.
+
+2. **Define a Package CR for your application**
+
+   Add an `expose` entry to route traffic through a gateway. The UDS Operator creates the necessary `VirtualService` and `AuthorizationPolicy` resources automatically.
+
+   <Tabs>
+     <TabItem label="Tenant gateway">
+
+     Expose on the **tenant gateway** for end-user traffic:
+
+     ```yaml title="uds-package.yaml"
+     apiVersion: uds.dev/v1alpha1
+     kind: Package
+     metadata:
+       name: my-app
+       namespace: my-app
+     spec:
+       network:
+         expose:
+           - service: my-app-service
+             selector:
+               app.kubernetes.io/name: my-app
+             host: my-app
+             gateway: tenant
+             port: 8080
+     ```
+
+     This exposes the application at `https://my-app.yourdomain.com`, routing traffic to port 8080 on pods matching the selector.
+
+     </TabItem>
+     <TabItem label="Admin gateway">
+
+     Expose on the **admin gateway** for admin-facing interfaces:
+
+     ```yaml title="uds-package.yaml"
+     apiVersion: uds.dev/v1alpha1
+     kind: Package
+     metadata:
+       name: my-app
+       namespace: my-app
+     spec:
+       network:
+         expose:
+           - service: my-app-admin
+             selector:
+               app.kubernetes.io/name: my-app
+             host: my-app
+             gateway: admin
+             port: 9090
+     ```
+
+     This exposes the application at `https://my-app.admin.yourdomain.com`. Since the admin and tenant gateways are logically separated, you can apply different security controls to each (IP allowlisting, mTLS client certificates, etc.).
+
+     </TabItem>
+     <TabItem label="Root domain">
+
+     Expose on the **root (apex) domain** (requires step 1):
+
+     ```yaml title="uds-package.yaml"
+     apiVersion: uds.dev/v1alpha1
+     kind: Package
+     metadata:
+       name: my-app
+       namespace: my-app
+     spec:
+       network:
+         expose:
+           - service: my-app-service
+             selector:
+               app.kubernetes.io/name: my-app
+             host: "."
+             gateway: tenant
+             port: 80
+     ```
+
+     The special `host: "."` value routes traffic from `https://yourdomain.com` to your application.
+
+     </TabItem>
+   </Tabs>
+
+3. **Deploy your application**
+
+   **(Recommended)** Include the Package CR manifest in your [Zarf package](https://docs.zarf.dev/ref/create/) alongside your application's Helm chart and create/deploy. See [Packaging applications](/how-to-guides/packaging-applications/overview/) for general packaging guidance.
 
    ```bash
-   uds zarf package create --confirm && uds zarf package deploy zarf-package-*.tar.zst --confirm
+   uds zarf package create --confirm
+   uds zarf package deploy zarf-package-*.tar.zst --confirm
    ```
+
+   **Or** apply the Package CR directly for quick testing:
+
+   ```bash
+   uds zarf tools kubectl apply -f uds-package.yaml
+   ```
+
+   If your application is part of a [UDS Bundle](/concepts/configuration-and-packaging/bundles/), include the Zarf package in your bundle and deploy it with `uds create` and `uds deploy` instead.
 
 </Steps>
 
+## Verification
+
+Check that the Package CR was reconciled and shows the expected endpoints:
+
+```bash
+uds zarf tools kubectl get package my-app -n my-app
+```
+
+The `ENDPOINTS` column should show your application's URL(s). Test access:
+
+```bash
+curl -v https://my-app.yourdomain.com
+```
+
 ## Troubleshooting
 
-### Service not reachable
+### Problem: Service not reachable
 
-**Symptoms:** Browser or curl returns connection refused or timeout.
+**Symptom:** Browser or curl returns connection refused or timeout.
 
 **Solution:**
 - Verify the Package CR was reconciled: `uds zarf tools kubectl get package my-app -n my-app` — check the `STATUS` column
 - Ensure your DNS resolves the hostname to the gateway load balancer IP
 
-### Wrong gateway or domain
+### Problem: Wrong gateway or domain
 
-**Symptoms:** Application accessible on an unexpected URL or not at all.
+**Symptom:** Application accessible on an unexpected URL or not at all.
 
 **Solution:**
 - Check the `gateway` field in your Package CR matches your intent (`tenant` or `admin`)
 - Verify the `host` field — it becomes the subdomain prefix (e.g., `host: my-app` → `my-app.yourdomain.com`)
 - Check `shared.domain` in your `uds-config.yaml`
 
-### Root domain not working
+### Problem: Root domain not working
 
-**Symptoms:** Subdomains work but `https://yourdomain.com` does not.
+**Symptom:** Subdomains work but `https://yourdomain.com` does not.
 
 **Solution:**
 - Confirm `rootDomain.enabled` is set to `true` in your bundle overrides
 - Verify DNS has an A record for the root domain (not just a wildcard)
 - Check that TLS certificates are provided for the root domain configuration
 
-## Related documentation
+## Related Documentation
 
 - [Networking & Service Mesh Concepts](/concepts/core-features/networking/)
 - [Package CR Reference](/reference/operator-and-crds/package/)

--- a/docs/how-to-guides/networking/manage-trust-bundles.mdx
+++ b/docs/how-to-guides/networking/manage-trust-bundles.mdx
@@ -1,0 +1,224 @@
+---
+title: Manage trust bundles
+sidebar:
+  order: 2.10
+---
+
+import { Steps, Tabs, TabItem, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+## What you'll accomplish
+
+You'll configure UDS Core to distribute custom CA certificates across your cluster, enabling platform components and your applications to trust private PKI, DoD CAs, or a curated set of public CAs.
+
+## Prerequisites
+
+- [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- Access to a Kubernetes cluster with UDS Core deployed
+- Your CA certificate bundle in **PEM format**
+
+## Before you begin
+
+UDS Core provides a centralized trust bundle system that automatically builds and distributes certificate trust bundles. When configured, UDS Core:
+
+- Creates `uds-trust-bundle` ConfigMaps in every namespace that contains a UDS Package CR
+- Syncs the bundle to `istio-system` for JWKS fetching
+- Injects the bundle into Authservice for OIDC TLS verification
+- Auto-mounts the bundle into platform components (Keycloak, Grafana, Loki, Vector, Velero, Prometheus, Alertmanager, Falcosidekick)
+
+> [!TIP]
+> If your environment uses only certificates from public, trusted CAs (e.g., Let's Encrypt, DigiCert), you do **not** need to configure trust bundles. This guide is for environments with self-signed certificates or certificates issued by a private CA.
+
+## Steps
+
+<Steps>
+
+1. **Configure the cluster trust bundle**
+
+   Set the trust bundle variables in your `uds-config.yaml`:
+
+   ```yaml title="uds-config.yaml"
+   variables:
+     core:
+       CA_BUNDLE_CERTS: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t..."  # Base64-encoded PEM bundle
+       CA_BUNDLE_INCLUDE_DOD_CERTS: "true"    # Include DoD CA certificates (default: false)
+       CA_BUNDLE_INCLUDE_PUBLIC_CERTS: "true"  # Include curated public CAs (default: false)
+   ```
+
+   > [!NOTE]
+   > `CA_BUNDLE_CERTS` must be **base64-encoded**. Encode your PEM bundle with: `cat ca-bundle.pem | base64 -w 0`
+
+   The three sources are concatenated into a single PEM bundle:
+
+   | Variable | Source | When to use |
+   |---|---|---|
+   | `CA_BUNDLE_CERTS` | Your custom CA certificates | If using private PKI (include domain CA at a minimum) |
+   | `CA_BUNDLE_INCLUDE_DOD_CERTS` | DoD CA certificates packaged with UDS Core | When using DoD PKI or external services |
+   | `CA_BUNDLE_INCLUDE_PUBLIC_CERTS` | Curated US-based public CAs from the Mozilla CA store | When applications need to reach public HTTPS endpoints in addition to the above |
+
+   > [!TIP]
+   > You can also set variables as environment variables prefixed with `UDS_` (e.g., `UDS_CA_BUNDLE_CERTS`) instead of using a config file.
+
+   Create and deploy your UDS Core bundle to apply the trust bundle configuration:
+
+   ```bash
+   uds create --confirm && uds deploy uds-bundle-*.tar.zst --confirm
+   ```
+
+2. **Customize trust bundle distribution for a package**
+
+   Trust bundle ConfigMaps are automatically created in all namespaces with a UDS Package CR. To customize the ConfigMap for a specific package, use the `caBundle` field:
+
+   ```yaml
+   apiVersion: uds.dev/v1alpha1
+   kind: Package
+   metadata:
+     namespace: my-package
+   spec:
+     caBundle:
+       configMap:
+         name: uds-trust-bundle        # default: uds-trust-bundle
+         key: ca-bundle.pem            # default: ca-bundle.pem
+         labels:
+           uds.dev/pod-reload: "true"  # enable pod reloads when the bundle changes
+         annotations:
+           uds.dev/pod-reload-selector: "app=my-app"  # only reload pods matching this selector
+   ```
+
+   > [!TIP]
+   > The `uds.dev/pod-reload: "true"` label triggers automatic pod restarts when the trust bundle ConfigMap is updated. Use `uds.dev/pod-reload-selector` to scope restarts to specific pods.
+
+3. **Mount the trust bundle in your application**
+
+   Platform components (Keycloak, Grafana, Loki, etc.) automatically mount the trust bundle — no manual configuration needed. For your own applications, mount the `uds-trust-bundle` ConfigMap as a volume.
+
+   Choose the mount approach based on your needs:
+
+   <Tabs>
+     <TabItem label="Additional CA (Go apps)">
+       Many Go-based applications check `/etc/ssl/certs/ca.pem` for additional CAs alongside the system bundle. This adds your private CAs without replacing the system CAs:
+
+       ```yaml
+       spec:
+         containers:
+           - name: my-app
+             volumeMounts:
+               - name: ca-certs
+                 mountPath: /etc/ssl/certs/ca.pem
+                 subPath: ca-bundle.pem
+                 readOnly: true
+         volumes:
+           - name: ca-certs
+             configMap:
+               name: uds-trust-bundle
+       ```
+     </TabItem>
+     <TabItem label="System CA replacement">
+       Replaces the entire system CA bundle. Your bundle must include both your private CAs and any public CAs the application needs:
+
+       ```yaml
+       spec:
+         containers:
+           - name: my-app
+             volumeMounts:
+               - name: ca-certs
+                 # Debian/Ubuntu:
+                 mountPath: /etc/ssl/certs/ca-certificates.crt
+                 # RedHat/CentOS:
+                 # mountPath: /etc/pki/tls/certs/ca-bundle.crt
+                 subPath: ca-bundle.pem
+                 readOnly: true
+         volumes:
+           - name: ca-certs
+             configMap:
+               name: uds-trust-bundle
+       ```
+     </TabItem>
+   </Tabs>
+
+   > [!CAUTION]
+   > Replacing the system CA bundle removes all default trusted CAs. Ensure your bundle includes all CAs your application needs. Also note that some programming languages and crypto libraries use their own embedded trust stores rather than the system trust store — consult your application's documentation.
+
+4. **Deploy your application**
+
+   **(Recommended)** Include the volume mount configuration and Package CR in your application's [Zarf package](https://docs.zarf.dev/ref/create/) alongside your Helm chart and create/deploy. See [Packaging applications](/how-to-guides/packaging-applications/overview/) for general packaging guidance.
+
+   ```bash
+   uds zarf package create --confirm
+   uds zarf package deploy zarf-package-*.tar.zst --confirm
+   ```
+
+   **Or** apply the Package CR directly for quick testing (along with your updated application with mount):
+
+   ```bash
+   uds zarf tools kubectl apply -f uds-package.yaml
+   ```
+
+</Steps>
+
+## Verification
+
+Confirm trust bundles are distributed:
+
+```bash
+# Check that the trust bundle ConfigMap exists in your namespace
+uds zarf tools kubectl get configmap uds-trust-bundle -n <namespace>
+
+# View the ConfigMap contents (should show PEM-formatted certificates)
+uds zarf tools kubectl get configmap uds-trust-bundle -n <namespace> -o jsonpath='{.data.ca-bundle\.pem}' | head -5
+```
+
+Verify that the ConfigMap contains PEM-formatted certificate data starting with `-----BEGIN CERTIFICATE-----`.
+
+To confirm that platform components are using the trust bundle, check that services like Keycloak (`https://sso.<domain>`) and Grafana (`https://grafana.<admin_domain>`) can be accessed without TLS errors.
+
+## Troubleshooting
+
+### Problem: Trust bundle ConfigMap not appearing in namespace
+
+**Symptom:** The `uds-trust-bundle` ConfigMap does not exist in your application's namespace.
+
+**Solution:** The ConfigMap is only created in namespaces that contain a UDS Package CR. Verify a Package CR exists:
+
+```bash
+uds zarf tools kubectl get packages -n <namespace>
+```
+
+If no Package CR exists, create one for your application. See the [Package CR reference](/reference/operator-and-crds/packages-v1alpha1-cr/) for details.
+
+### Problem: Application still rejects TLS connections
+
+**Symptom:** Your application returns certificate verification errors despite the trust bundle being mounted.
+
+**Solution:**
+1. Verify the mount path is correct for your container's base image (Debian vs RedHat)
+2. Check if your application uses a language-specific trust store (Java `cacerts`, Python `certifi`, Node.js `NODE_EXTRA_CA_CERTS`)
+3. Confirm the CA bundle contains the full certificate chain (including intermediate CAs)
+4. Verify the volume mount exists on the pod:
+
+```bash
+uds zarf tools kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[0].volumeMounts}' | jq .
+```
+
+## Related Documentation
+
+- [Package CR specification](/reference/operator-and-crds/packages-v1alpha1-cr/) — full Package CR schema including `caBundle` fields
+- [Java Keytool documentation](https://docs.oracle.com/en/java/javase/17/docs/specs/man/keytool.html) — managing Java `cacerts` trust stores
+- [Python certifi](https://pypi.org/project/certifi/) — Python's default CA bundle and how to override it
+- [Node.js `NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) — adding extra CAs for Node.js applications
+
+## Next steps
+
+These guides and concepts may be useful to explore next:
+
+<CardGrid>
+  <LinkCard
+    title="Configure TLS certificates"
+    description="Set up TLS certificates for your ingress gateways — often paired with trust bundle configuration."
+    href="/how-to-guides/networking/configure-tls-certificates/"
+  />
+  <LinkCard
+    title="Identity & access how-to guides"
+    description="Configure SSO with Keycloak, which may need trust bundle configuration for private PKI."
+    href="/how-to-guides/identity-access/overview/"
+  />
+</CardGrid>

--- a/docs/how-to-guides/networking/manage-trust-bundles.mdx
+++ b/docs/how-to-guides/networking/manage-trust-bundles.mdx
@@ -68,10 +68,11 @@ UDS Core provides a centralized trust bundle system that automatically builds an
 
    Trust bundle ConfigMaps are automatically created in all namespaces with a UDS Package CR. To customize the ConfigMap for a specific package, use the `caBundle` field:
 
-   ```yaml
+   ```yaml title="uds-package.yaml"
    apiVersion: uds.dev/v1alpha1
    kind: Package
    metadata:
+     name: my-package
      namespace: my-package
    spec:
      caBundle:

--- a/docs/how-to-guides/networking/manage-trust-bundles.mdx
+++ b/docs/how-to-guides/networking/manage-trust-bundles.mdx
@@ -91,6 +91,9 @@ UDS Core provides a centralized trust bundle system that automatically builds an
 
    Platform components (Keycloak, Grafana, Loki, etc.) automatically mount the trust bundle — no manual configuration needed. For your own applications, mount the `uds-trust-bundle` ConfigMap as a volume.
 
+   > [!WARNING]
+   > If you override Helm `volumeMounts` or `volumes` values for a Core component (e.g., via bundle overrides), the automatic trust bundle mount will be replaced. You must include the trust bundle mount in your override to preserve it.
+
    Choose the mount approach based on your needs:
 
    <Tabs>

--- a/docs/how-to-guides/networking/manage-trust-bundles.mdx
+++ b/docs/how-to-guides/networking/manage-trust-bundles.mdx
@@ -99,7 +99,7 @@ UDS Core provides a centralized trust bundle system that automatically builds an
 
    <Tabs>
      <TabItem label="Additional CA (Go apps)">
-       Many Go-based applications check `/etc/ssl/certs/ca.pem` for additional CAs alongside the system bundle. This adds your private CAs without replacing the system CAs:
+       Many Go-based applications check the `/etc/ssl/certs/` directory for additional CAs alongside the system bundle. This adds your private CAs without replacing the system CAs:
 
        ```yaml
        spec:

--- a/docs/how-to-guides/networking/overview.mdx
+++ b/docs/how-to-guides/networking/overview.mdx
@@ -58,4 +58,9 @@ For background on how the service mesh, gateways, and authorization model work, 
     description="Extend network rules for Core components like Falco, Vector, and Grafana."
     href="/how-to-guides/networking/configure-core-network-access/"
   />
+  <LinkCard
+    title="Manage trust bundles"
+    description="Distribute custom CA certificates across the cluster for private PKI or DoD CAs."
+    href="/how-to-guides/networking/manage-trust-bundles/"
+  />
 </CardGrid>


### PR DESCRIPTION
## Description

Adds a doc for central trust management (single doc since Core services automatically mount trust).

Fixes a few misalignments with the new template for docs:
- related doc capitalization
- problem syntax in troubleshooting
- zarf package / kubectl options
- rewrite to expose doc to better incorporate options for host (including root)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)