### PR TITLE
chore(docs): fix overview paths

### DIFF
--- a/docs/concepts/core-features/runtime-security.mdx
+++ b/docs/concepts/core-features/runtime-security.mdx
@@ -64,7 +64,7 @@ Runtime security is one layer of a broader defense model in UDS Core:
 > [!NOTE]
 > No single layer catches everything. The value of runtime security is specifically in catching compromise that the other layers cannot prevent — a legitimate container that has been exploited, or a supply chain attack that introduced a malicious binary into an otherwise-permitted image.
 
-For a broader look at how these layers fit together, see the [Security overview](/overview/security/).
+For a broader look at how these layers fit together, see the [Security overview](/security/).
 
 ---
 

--- a/docs/overview/overview.mdx
+++ b/docs/overview/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Ecosystem
+slug: ecosystem
 sidebar:
   order: 1
 ---
@@ -30,7 +31,7 @@ With UDS, platform and mission teams can:
     It handles networking, identity, logging, monitoring, runtime security, backup, and compliance—so application
     teams can focus on their software rather than the environment.
 
-    <LinkCard title="Learn about UDS Core" href="/overview/uds-core/" />
+    <LinkCard title="Learn about UDS Core" href="/uds-core/" />
   </Card>
 
   <Card title="UDS CLI" icon="laptop">

--- a/docs/overview/overview.mdx
+++ b/docs/overview/overview.mdx
@@ -71,7 +71,7 @@ With UDS, platform and mission teams can:
   <LinkCard
     title="Security & Compliance Stakeholders"
     description="Understand UDS Core's security posture, built-in controls, and how it supports authorization and audit requirements."
-    href="/overview/security/"
+    href="/security/"
   />
   <LinkCard
     title="Application Teams"

--- a/docs/overview/security.mdx
+++ b/docs/overview/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: Security
+slug: security
 sidebar:
   order: 3
 ---

--- a/docs/overview/uds-core.mdx
+++ b/docs/overview/uds-core.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Core
+slug: uds-core
 sidebar:
   order: 2
 ---

--- a/docs/overview/uds-core.mdx
+++ b/docs/overview/uds-core.mdx
@@ -71,7 +71,7 @@ Security is built into UDS Core by default, not bolted on. The platform provides
 - Runtime detection and alerting for malicious behavior.
 - Centralized logging and metrics for audit and incident response.
 
-For the full security overview, see [Security &rarr;](/overview/security/).
+For the full security overview, see [Security &rarr;](/security/).
 
 ---
 


### PR DESCRIPTION
## Description
instead of `/overview/overview` or `/overview/security` or `/overview/uds-core` this now removes the `/overview` portion of the path.


## Related Issue

Fixes [core-418](https://linear.app/defense-unicorns/issue/CORE-418/fix-slug-for-overviewoverview)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed