### PR TITLE
chore(docs): enable pagination override for getting started docs

### DIFF
--- a/docs/getting-started/local-demo/basic-requirements.mdx
+++ b/docs/getting-started/local-demo/basic-requirements.mdx
@@ -1,5 +1,7 @@
 ---
 title: Set Up Your Environment
+prev: true
+next: true
 sidebar:
   order: 2.2
 ---

--- a/docs/getting-started/local-demo/basic-requirements.mdx
+++ b/docs/getting-started/local-demo/basic-requirements.mdx
@@ -1,6 +1,5 @@
 ---
 title: Set Up Your Environment
-prev: true
 next: true
 sidebar:
   order: 2.2

--- a/docs/getting-started/local-demo/install-and-deploy-uds.mdx
+++ b/docs/getting-started/local-demo/install-and-deploy-uds.mdx
@@ -1,5 +1,7 @@
 ---
 title: Install and Deploy UDS
+prev: true
+next: true
 sidebar:
   order: 2.3
 ---

--- a/docs/getting-started/local-demo/integrate-your-package.mdx
+++ b/docs/getting-started/local-demo/integrate-your-package.mdx
@@ -1,7 +1,6 @@
 ---
 title: Add Your Own Package (Optional)
 prev: true
-next: true
 sidebar:
   order: 2.4
 ---

--- a/docs/getting-started/local-demo/integrate-your-package.mdx
+++ b/docs/getting-started/local-demo/integrate-your-package.mdx
@@ -1,5 +1,7 @@
 ---
 title: Add Your Own Package (Optional)
+prev: true
+next: true
 sidebar:
   order: 2.4
 ---

--- a/docs/getting-started/local-demo/overview.mdx
+++ b/docs/getting-started/local-demo/overview.mdx
@@ -1,5 +1,7 @@
 ---
 title: Overview
+prev: true
+next: true
 sidebar:
   order: 2.1
 ---

--- a/docs/getting-started/local-demo/overview.mdx
+++ b/docs/getting-started/local-demo/overview.mdx
@@ -1,6 +1,5 @@
 ---
 title: Overview
-prev: true
 next: true
 sidebar:
   order: 2.1

--- a/docs/getting-started/production/build-your-bundle.mdx
+++ b/docs/getting-started/production/build-your-bundle.mdx
@@ -1,5 +1,7 @@
 ---
 title: Build Your Bundle
+prev: true
+next: true
 sidebar:
   order: 3.4
 ---

--- a/docs/getting-started/production/deploy.mdx
+++ b/docs/getting-started/production/deploy.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploy to Production
+prev: true
 sidebar:
   order: 3.5
 ---

--- a/docs/getting-started/production/overview.mdx
+++ b/docs/getting-started/production/overview.mdx
@@ -1,6 +1,5 @@
 ---
 title: Overview
-prev: true
 next: true
 sidebar:
   order: 3.1

--- a/docs/getting-started/production/overview.mdx
+++ b/docs/getting-started/production/overview.mdx
@@ -1,5 +1,7 @@
 ---
 title: Overview
+prev: true
+next: true
 sidebar:
   order: 3.1
 ---

--- a/docs/getting-started/production/prerequisites.mdx
+++ b/docs/getting-started/production/prerequisites.mdx
@@ -1,5 +1,7 @@
 ---
 title: Prerequisites
+prev: true
+next: true
 sidebar:
   order: 3.2
 ---

--- a/docs/getting-started/production/prerequisites.mdx
+++ b/docs/getting-started/production/prerequisites.mdx
@@ -1,6 +1,5 @@
 ---
 title: Prerequisites
-prev: true
 next: true
 sidebar:
   order: 3.2

--- a/docs/getting-started/production/provision-services.mdx
+++ b/docs/getting-started/production/provision-services.mdx
@@ -1,5 +1,7 @@
 ---
 title: Provision External Services
+prev: true
+next: true
 sidebar:
   order: 3.3
 ---


### PR DESCRIPTION
## Description
After disabling pagination for all docs, we need to override that enable them for specific docs. this change does that for the getting started docs.

## Related Issue

Fixes [core-390](https://linear.app/defense-unicorns/issue/CORE-390/evaluate-disabling-pagination-on-most-docs-sections)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed