### PR TITLE
refactor!: remove x509LookupProvider and mtlsClientCert from KC values

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -18,7 +18,6 @@ When adding a deprecation, include:
 |---------|-----|---------------|--------|-----------|----------------|
 | `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | [#154](https://github.com/defenseunicorns/uds-core/pull/154) | 0.12.0 | Improve API naming and organization | Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | 1.0.0 |
 | Keycloak `fips` helm value | [#1518](https://github.com/defenseunicorns/uds-core/pull/1518) | 0.43.0 | FIPS mode is now enabled by default for all deployments | If you override `fips` to `false`, remove that override as soon as possible to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
-| Keycloak `x509LookupProvider`, `mtlsClientCert` helm values | [#1670](https://github.com/defenseunicorns/uds-core/pull/1670) | 0.47.0 | Values will be hardcoded; EnvoyFilter manages headers for third-party integrations | No action needed; remove any overrides of these values | 1.0.0 |
 | `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | [#1233](https://github.com/defenseunicorns/uds-core/pull/1233) | 0.48.0 | Moved to ClusterConfig CRD for centralized configuration | Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
 | `CA_CERT` Zarf variable | [#2167](https://github.com/defenseunicorns/uds-core/pull/2167) | 0.58.0 | Improved naming clarity for centralized trust bundle management | Use `CA_BUNDLE_CERTS` instead | 1.0.0 |
 | `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | 1.0.0 |
@@ -29,4 +28,4 @@ This section lists features that were removed in recent major releases for histo
 
 | Feature | Deprecated In | Removed In | Migration |
 |---------|---------------|------------|-----------|
-| _None_ | - | - | - |
+| Keycloak `x509LookupProvider`, `mtlsClientCert` helm values | 0.47.0 | 1.0.0 | Use `thirdPartyIntegration.tls.tlsCertificateHeader` and `thirdPartyIntegration.tls.tlsCertificateFormat`; remove any existing overrides utilizing the removed values |

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -192,12 +192,12 @@ spec:
 
             ## Activate the nginx provider
             - name: KC_SPI_X509CERT_LOOKUP__PROVIDER
-              value: {{ .Values.x509LookupProvider }}
+              value: nginx
             # Set nginx provider header name
-            - name: KC_SPI_X509CERT_LOOKUP__{{ .Values.x509LookupProvider | upper }}__SSL_CLIENT_CERT
+            - name: KC_SPI_X509CERT_LOOKUP__NGINX__SSL_CLIENT_CERT
               value: istio-mtls-client-certificate
             # Dumb value (not used in the nginx provider, but required by the SPI)
-            - name: KC_SPI_X509CERT_LOOKUP__{{ .Values.x509LookupProvider | upper }}__SSL_CLIENT_CERT_CHAIN_PREFIX
+            - name: KC_SPI_X509CERT_LOOKUP__NGINX__SSL_CLIENT_CERT_CHAIN_PREFIX
               value: UNUSED
             # Below 3 settings are a workaround for https://github.com/keycloak/keycloak/issues/43589
             # After Keycloak 26.6.0 release, they should be removed

--- a/src/keycloak/chart/templates/uds-package.yaml
+++ b/src/keycloak/chart/templates/uds-package.yaml
@@ -151,7 +151,7 @@ spec:
               remove:
                 - istio-mtls-client-certificate
               add:
-                istio-mtls-client-certificate: "{{ .Values.mtlsClientCert }}"
+                istio-mtls-client-certificate: "%DOWNSTREAM_PEER_CERT%"
           {{- end }}
 
       - description: "public auth access with optional client certificate"
@@ -167,7 +167,7 @@ spec:
               remove:
                 - istio-mtls-client-certificate
               add:
-                istio-mtls-client-certificate: "{{ .Values.mtlsClientCert }}"
+                istio-mtls-client-certificate: "%DOWNSTREAM_PEER_CERT%"
         {{- end }}
 
       - description: "admin access with optional client certificate"
@@ -188,6 +188,6 @@ spec:
               remove:
                 - istio-mtls-client-certificate
               add:
-                istio-mtls-client-certificate: "{{ .Values.mtlsClientCert }}"
+                istio-mtls-client-certificate: "%DOWNSTREAM_PEER_CERT%"
         {{- end }}
     # @lulaEnd 506992d2-64cf-4fb3-95de-40a8ad127626

--- a/src/keycloak/chart/tests/kc_third_party_tls_header_test.yaml
+++ b/src/keycloak/chart/tests/kc_third_party_tls_header_test.yaml
@@ -1,0 +1,102 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - Third Party TLS Header
+templates:
+  - uds-package.yaml
+  - alb-envoyfilter.yaml
+
+tests:
+  - it: should inject default client certificate header fallback
+    template: uds-package.yaml
+    asserts:
+      - contains:
+          path: spec.network.expose
+          any: true
+          content:
+            advancedHTTP:
+              headers:
+                request:
+                  remove:
+                    - istio-mtls-client-certificate
+                  add:
+                    istio-mtls-client-certificate: "%DOWNSTREAM_PEER_CERT%"
+
+  - it: should omit fallback header injection when third-party tls header is configured
+    set:
+      thirdPartyIntegration:
+        tls:
+          tlsCertificateHeader: x-amzn-mtls-clientcert
+    template: uds-package.yaml
+    asserts:
+      - notContains:
+          path: spec.network.expose
+          any: true
+          content:
+            advancedHTTP:
+              headers:
+                request:
+                  remove:
+                    - istio-mtls-client-certificate
+                  add:
+                    istio-mtls-client-certificate: "%DOWNSTREAM_PEER_CERT%"
+
+  - it: should not render alb envoy filter by default
+    template: alb-envoyfilter.yaml
+    asserts:
+      - notExists: {}
+
+  - it: should render alb envoy filter for generic PEM header forwarding
+    set:
+      thirdPartyIntegration:
+        tls:
+          tlsCertificateHeader: x-forwarded-client-cert
+          tlsCertificateFormat: PEM
+    template: alb-envoyfilter.yaml
+    asserts:
+      - isKind:
+          of: EnvoyFilter
+      - equal:
+          path: metadata.name
+          value: alb-client-cert-converter
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: local raw_cert = request_handle:headers\(\):get\("x-forwarded-client-cert"\)
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: decoded = raw_cert
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: local encoded = decoded
+      - notMatchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: function url_decode\(str\)
+      - notMatchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: decoded = url_decode\(raw_cert\)
+
+  - it: should render aws decoding branch when tlsCertificateFormat is AWS
+    set:
+      thirdPartyIntegration:
+        tls:
+          tlsCertificateHeader: x-amzn-mtls-clientcert
+          tlsCertificateFormat: AWS
+    template: alb-envoyfilter.yaml
+    asserts:
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: function url_decode\(str\)
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: local raw_cert = request_handle:headers\(\):get\("x-amzn-mtls-clientcert"\)
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: decoded = url_decode\(raw_cert\)
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: local encoded = request_handle:base64Escape\(decoded\)
+      - notMatchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.defaultSourceCode.inlineString
+          pattern: local encoded = decoded

--- a/src/keycloak/chart/tests/kc_x509_provider_test.yaml
+++ b/src/keycloak/chart/tests/kc_x509_provider_test.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - X509 Provider Hardcoded
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: should render hardcoded nginx x509 provider env vars by default
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_SPI_X509CERT_LOOKUP__PROVIDER
+            value: nginx
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_SPI_X509CERT_LOOKUP__NGINX__SSL_CLIENT_CERT
+            value: istio-mtls-client-certificate
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_SPI_X509CERT_LOOKUP__NGINX__SSL_CLIENT_CERT_CHAIN_PREFIX
+            value: UNUSED

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -191,9 +191,6 @@
     "configImage": {
       "type": "string"
     },
-    "mtlsClientCert": {
-      "type": "string"
-    },
     "dashboardAnnotations": {
       "type": "object"
     },
@@ -638,9 +635,6 @@
           }
         }
       }
-    },
-    "x509LookupProvider": {
-      "type": "string"
     },
     "migrations": {
       "type": "object",

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -406,12 +406,6 @@ waypoint:
 
 env: []
 
-# DEPRECATED: Use `thirdPartyIntegration` instead
-x509LookupProvider: nginx
-
-# DEPRECATED: Use `thirdPartyIntegration` instead
-mtlsClientCert: "%DOWNSTREAM_PEER_CERT%"
-
 # Custom migrations setting for UDS Core internal usage only
 migrations:
   # Deletes the generated truststore to enable recreating it by Keycloak


### PR DESCRIPTION
BREAKING CHANGE: Removed previously deprecated `x509LookupProvider` and `mtlsClientCert` values from Keycloak helm chart. Users should remove any existing overrides utilizing the removed values and use `thirdPartyIntegration.tls.tlsCertificateHeader` and `thirdPartyIntegration.tls.tlsCertificateFormat` instead.

## Description

Removed deprecated `x509LookupProvider` and `mtlsClientCert` values from Keycloak helm chart in preparation for 1.0.0 release. Added some additional testing to validate conditional helm behavior when using replacement functionality of the `thirdPartyIntegration.tls.tlsCertificateHeader` and `thirdPartyIntegration.tls.tlsCertificateFormat` values.

## Related Issue

Fixes # CORE-430

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Steps to Validate
- Run helm unit tests `uds run -f tasks/lint.yaml helm-unittest`

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed

BEGIN_COMMIT_OVERRIDE
chore!: remove x509LookupProvider and mtlsClientCert from KC values (#2486)

BREAKING CHANGE: Removed previously deprecated `x509LookupProvider` and `mtlsClientCert` values from Keycloak helm chart. Users should remove any existing overrides utilizing the removed values and use `thirdPartyIntegration.tls.tlsCertificateHeader` and `thirdPartyIntegration.tls.tlsCertificateFormat` instead.
END_COMMIT_OVERRIDE