### PR TITLE
chore!: remove deprecated `CA_CERT` variable

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,13 +16,12 @@ When adding a deprecation, include:
 - Removal Target: The projected major version for removal
 -->
 
-| Feature | Deprecated In | Details | Removal Target |
-|---------|---------------|---------|----------------|
-| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | 0.12.0 ([#154](https://github.com/defenseunicorns/uds-core/pull/154)) | **Reason:** API naming improved.<br/>**Migration:** Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | Package `v1beta1` |
-| Keycloak `fips` helm value | 0.43.0 ([#1518](https://github.com/defenseunicorns/uds-core/pull/1518)) | **Reason:** FIPS mode is now enabled by default.<br/>**Migration:** If you override `fips` to `false`, remove that override to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
-| `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | 0.48.0 ([#1233](https://github.com/defenseunicorns/uds-core/pull/1233)) | **Reason:** Moved to ClusterConfig CRD.<br/>**Migration:** Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
-| `CA_CERT` Zarf variable | 0.58.0 ([#2167](https://github.com/defenseunicorns/uds-core/pull/2167)) | **Reason:** Improved naming clarity.<br/>**Migration:** Use `CA_BUNDLE_CERTS` instead | 1.0.0 |
-| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | 0.60.0 ([#2264](https://github.com/defenseunicorns/uds-core/pull/2264)) | **Reason:** Simplified field structure.<br/>**Migration:** Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | Package `v1beta1` |
+| Feature | PR | Deprecated In | Reason | Migration | Removal Target |
+|---------|-----|---------------|--------|-----------|----------------|
+| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | [#154](https://github.com/defenseunicorns/uds-core/pull/154) | 0.12.0 | Improve API naming and organization | Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | Package `v1beta1` |
+| Keycloak `fips` helm value | [#1518](https://github.com/defenseunicorns/uds-core/pull/1518) | 0.43.0 | FIPS mode is now enabled by default for all deployments | If you override `fips` to `false`, remove that override as soon as possible to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
+| `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | [#1233](https://github.com/defenseunicorns/uds-core/pull/1233) | 0.48.0 | Moved to ClusterConfig CRD for centralized configuration | Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
+| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | Package `v1beta1` |
 
 ## Recently Removed
 
@@ -31,3 +30,4 @@ This section lists features that were removed in recent major releases for histo
 | Feature | Deprecated In | Removed In | Migration |
 |---------|---------------|------------|-----------|
 | Keycloak `x509LookupProvider`, `mtlsClientCert` helm values | 0.47.0 | 1.0.0 | Use `thirdPartyIntegration.tls.tlsCertificateHeader` and `thirdPartyIntegration.tls.tlsCertificateFormat`; remove any existing overrides utilizing the removed values |
+| `CA_CERT` Zarf variable | 0.58.0 | 1.0.0 | Use `CA_BUNDLE_CERTS` instead |

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,12 +16,12 @@ When adding a deprecation, include:
 - Removal Target: The projected major version for removal
 -->
 
-| Feature | PR | Deprecated In | Reason | Migration | Removal Target |
-|---------|-----|---------------|--------|-----------|----------------|
-| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | [#154](https://github.com/defenseunicorns/uds-core/pull/154) | 0.12.0 | Improve API naming and organization | Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | Package `v1beta1` |
-| Keycloak `fips` helm value | [#1518](https://github.com/defenseunicorns/uds-core/pull/1518) | 0.43.0 | FIPS mode is now enabled by default for all deployments | If you override `fips` to `false`, remove that override as soon as possible to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
-| `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | [#1233](https://github.com/defenseunicorns/uds-core/pull/1233) | 0.48.0 | Moved to ClusterConfig CRD for centralized configuration | Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
-| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | Package `v1beta1` |
+| Feature | Deprecated In | Details | Removal Target |
+|---------|---------------|---------|----------------|
+| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | 0.12.0 ([#154](https://github.com/defenseunicorns/uds-core/pull/154)) | **Reason:** API naming improved.<br/>**Migration:** Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | Package `v1beta1` |
+| Keycloak `fips` helm value | 0.43.0 ([#1518](https://github.com/defenseunicorns/uds-core/pull/1518)) | **Reason:** FIPS mode is now enabled by default.<br/>**Migration:** If you override `fips` to `false`, remove that override to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
+| `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | 0.48.0 ([#1233](https://github.com/defenseunicorns/uds-core/pull/1233)) | **Reason:** Moved to ClusterConfig CRD.<br/>**Migration:** Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
+| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | 0.60.0 ([#2264](https://github.com/defenseunicorns/uds-core/pull/2264)) | **Reason:** Simplified field structure.<br/>**Migration:** Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | Package `v1beta1` |
 
 ## Recently Removed
 

--- a/docs/dev/old-reference/configuration/single-sign-on/trusted-ca.md
+++ b/docs/dev/old-reference/configuration/single-sign-on/trusted-ca.md
@@ -14,8 +14,4 @@ variables:
     CA_BUNDLE_CERTS: <base64 encoded certificate authority>
 ```
 
-:::note[Legacy Support]
-The `CA_CERT` variable is still supported for backwards compatibility but is deprecated. Use `CA_BUNDLE_CERTS` for new deployments.
-:::
-
 See [configuring Istio Ingress](https://uds.defenseunicorns.com/reference/configuration/ingress/#configure-domain-name-and-tls-for-istio-gateways) for the relevant documentation on configuring ingress certificates.

--- a/docs/dev/old-reference/configuration/trust-management/central-trust-bundle-management.md
+++ b/docs/dev/old-reference/configuration/trust-management/central-trust-bundle-management.md
@@ -31,10 +31,6 @@ Trust bundles are configured during UDS Core deployment using UDS/Zarf variables
 | `CA_BUNDLE_INCLUDE_DOD_CERTS` | Include DoD CA certificates in the bundle | `false` |
 | `CA_BUNDLE_INCLUDE_PUBLIC_CERTS` | Include standard public CA certificates in the bundle | `false` |
 
-:::note[Legacy Support]
-The `CA_CERT` variable is still supported for backwards compatibility but is deprecated. Use `CA_BUNDLE_CERTS` for new deployments. This new variable is also used for Authservice configuration as described in the [trusted CA SSO documentation](/reference/configuration/single-sign-on/trusted-ca).
-:::
-
 ### Cluster Trust Bundle Configuration
 
 The UDS Core trust bundle is configured at deployment time at the cluster level.

--- a/docs/dev/old-reference/configuration/uds-cluster-configuration.md
+++ b/docs/dev/old-reference/configuration/uds-cluster-configuration.md
@@ -18,7 +18,6 @@ cluster:
     # Domain configuration (admin defaults to `admin.UDS_DOMAIN`)
     domain: "###ZARF_VAR_DOMAIN###"
     adminDomain: "###ZARF_VAR_ADMIN_DOMAIN###"
-    caCert: "###ZARF_VAR_CA_CERT###"
   policy:
     allowAllNsExemptions: "###ZARF_VAR_ALLOW_ALL_NS_EXEMPTIONS###"
   networking:

--- a/docs/reference/operator-and-crds/clusterconfig-v1alpha1-cr.md
+++ b/docs/reference/operator-and-crds/clusterconfig-v1alpha1-cr.md
@@ -126,7 +126,7 @@ sidebar:
     </tr>
   </thead>
   <tbody>
-    <tr><td style="white-space: nowrap;">domain</td><td style="white-space: nowrap;">string</td><td>Domain all cluster services will be exposed on</td></tr><tr><td style="white-space: nowrap;">adminDomain</td><td style="white-space: nowrap;">string</td><td>Domain all cluster services on the admin gateway will be exposed on</td></tr><tr><td style="white-space: nowrap;">caCert</td><td style="white-space: nowrap;">string</td><td>The trusted CA that signed your domain certificates if using Private PKI</td></tr>
+    <tr><td style="white-space: nowrap;">domain</td><td style="white-space: nowrap;">string</td><td>Domain all cluster services will be exposed on</td></tr><tr><td style="white-space: nowrap;">adminDomain</td><td style="white-space: nowrap;">string</td><td>Domain all cluster services on the admin gateway will be exposed on</td></tr>
   </tbody>
 </table>
 </div>

--- a/schemas/clusterconfig-v1alpha1.schema.json
+++ b/schemas/clusterconfig-v1alpha1.schema.json
@@ -105,10 +105,6 @@
           "type": "string",
           "description": "Domain all cluster services on the admin gateway will be exposed on"
         },
-        "caCert": {
-          "type": "string",
-          "description": "The trusted CA that signed your domain certificates if using Private PKI"
-        },
         "domain": {
           "type": "string",
           "description": "Domain all cluster services will be exposed on"

--- a/src/pepr/operator/controllers/config/config.spec.ts
+++ b/src/pepr/operator/controllers/config/config.spec.ts
@@ -947,32 +947,6 @@ describe("handleUDSConfig", () => {
     });
   });
 
-  describe("Legacy CA cert placeholder handling", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-      mockCfg = {
-        ...defaultConfig,
-        metadata: { ...defaultConfig.metadata, generation: 2 },
-        status: { observedGeneration: 1 },
-      };
-      mockClusterConfGet.mockResolvedValue(mockCfg);
-      mockSecretGet.mockResolvedValue(mockSecret);
-      mockConfigMapGet.mockResolvedValue({
-        data: { dodCACerts: "", publicCACerts: "" },
-      });
-      mockPatchStatus.mockResolvedValue({});
-    });
-
-    it("handles legacy ###ZARF_VAR_CA_CERT### placeholder", async () => {
-      mockCfg.spec!.caBundle!.certs = "###ZARF_VAR_CA_CERT###";
-      UDSConfig.caBundle.certs = "old-cert";
-
-      await handleCfg(mockCfg, ConfigAction.UPDATE);
-
-      expect(UDSConfig.caBundle.certs).toBe("");
-    });
-  });
-
   describe("loadUDSConfig pre-fetch logic", () => {
     beforeEach(() => {
       vi.clearAllMocks();

--- a/src/pepr/operator/controllers/config/config.ts
+++ b/src/pepr/operator/controllers/config/config.ts
@@ -252,15 +252,13 @@ async function fetchCACerts(): Promise<{ dodCerts: string; publicCerts: string }
  * @param updateClusterResources Whether to update cluster resources (ConfigMaps, etc.)
  */
 async function handleCABundleUpdate(caBundle: ConfigCABundle, updateClusterResources?: boolean) {
-  // no caCert then set to empty string
+  // no certs then set to empty string
   if (!caBundle.certs) {
     caBundle.certs = "";
   }
 
   // handle dev mode placeholder
   if (caBundle.certs === "###ZARF_VAR_CA_BUNDLE_CERTS###") {
-    caBundle.certs = "";
-  } else if (caBundle.certs === "###ZARF_VAR_CA_CERT###") {
     caBundle.certs = "";
   }
 

--- a/src/pepr/operator/crd/generated/clusterconfig-v1alpha1.ts
+++ b/src/pepr/operator/crd/generated/clusterconfig-v1alpha1.ts
@@ -60,10 +60,6 @@ export interface Expose {
    */
   adminDomain?: string;
   /**
-   * The trusted CA that signed your domain certificates if using Private PKI
-   */
-  caCert?: string;
-  /**
    * Domain all cluster services will be exposed on
    */
   domain: string;

--- a/src/pepr/operator/crd/sources/cluster-config/v1alpha1.ts
+++ b/src/pepr/operator/crd/sources/cluster-config/v1alpha1.ts
@@ -119,11 +119,6 @@ export const v1alpha1: V1CustomResourceDefinitionVersion = {
                   description:
                     "Domain all cluster services on the admin gateway will be exposed on",
                 },
-                caCert: {
-                  type: "string",
-                  description:
-                    "The trusted CA that signed your domain certificates if using Private PKI",
-                },
               },
               required: ["domain"],
             },

--- a/src/pepr/operator/crd/validators/clusterconfig-validator.spec.ts
+++ b/src/pepr/operator/crd/validators/clusterconfig-validator.spec.ts
@@ -115,20 +115,6 @@ invalid-cert-data
     expect(() => validateCfg(defaultCaBundle)).not.toThrowError();
   });
 
-  it("does not throw error if caBundle.certs is set to ###ZARF_VAR_CA_CERT###", () => {
-    const defaultCaBundle = {
-      ...mockCfg,
-      spec: {
-        ...mockCfg.spec!,
-        caBundle: {
-          ...mockCfg.spec!.caBundle,
-          certs: "###ZARF_VAR_CA_CERT###",
-        },
-      },
-    };
-    expect(() => validateCfg(defaultCaBundle)).not.toThrowError();
-  });
-
   it("validates multiple certificates in bundle", () => {
     const multipleCerts = validCert + "\n" + validCert;
     const validMultipleCaBundle = {

--- a/src/pepr/operator/crd/validators/clusterconfig-validator.ts
+++ b/src/pepr/operator/crd/validators/clusterconfig-validator.ts
@@ -19,10 +19,7 @@ export async function validateCfgUpdate(req: PeprValidateRequest<ClusterConfig>)
 
 export function validateCfg(cfg: ClusterConfig) {
   // Validate that the caBundle.certs is base64 encoded and is a valid cert bundle
-  if (
-    cfg.spec?.caBundle?.certs &&
-    cfg.spec.caBundle.certs !== "###ZARF_VAR_CA_BUNDLE_CERTS###"
-  ) {
+  if (cfg.spec?.caBundle?.certs && cfg.spec.caBundle.certs !== "###ZARF_VAR_CA_BUNDLE_CERTS###") {
     if (!isBase64(cfg.spec.caBundle.certs)) {
       throw new Error("ClusterConfig: caBundle.certs must be base64 encoded; found invalid value");
     }

--- a/src/pepr/operator/crd/validators/clusterconfig-validator.ts
+++ b/src/pepr/operator/crd/validators/clusterconfig-validator.ts
@@ -21,8 +21,7 @@ export function validateCfg(cfg: ClusterConfig) {
   // Validate that the caBundle.certs is base64 encoded and is a valid cert bundle
   if (
     cfg.spec?.caBundle?.certs &&
-    cfg.spec.caBundle.certs !== "###ZARF_VAR_CA_BUNDLE_CERTS###" &&
-    cfg.spec.caBundle.certs !== "###ZARF_VAR_CA_CERT###"
+    cfg.spec.caBundle.certs !== "###ZARF_VAR_CA_BUNDLE_CERTS###"
   ) {
     if (!isBase64(cfg.spec.caBundle.certs)) {
       throw new Error("ClusterConfig: caBundle.certs must be base64 encoded; found invalid value");

--- a/src/pepr/uds-cluster-crds/templates/clusterconfig.uds.dev.yaml
+++ b/src/pepr/uds-cluster-crds/templates/clusterconfig.uds.dev.yaml
@@ -106,11 +106,6 @@ spec:
                       description: >-
                         Domain all cluster services on the admin gateway will be
                         exposed on
-                    caCert:
-                      type: string
-                      description: >-
-                        The trusted CA that signed your domain certificates if
-                        using Private PKI
                   required:
                     - domain
                 policy:

--- a/src/pepr/uds-operator-config/templates/clusterconfig.yaml
+++ b/src/pepr/uds-operator-config/templates/clusterconfig.yaml
@@ -19,8 +19,8 @@ spec:
     {{- end }}
   {{- end }}
   caBundle:
-    {{- if or .Values.cluster.caBundle.certs .Values.cluster.expose.caCert }}
-    certs: {{ .Values.cluster.caBundle.certs | default .Values.cluster.expose.caCert | quote }}
+    {{- if .Values.cluster.caBundle.certs }}
+    certs: {{ .Values.cluster.caBundle.certs | quote }}
     {{- end }}
     includeDoDCerts: {{ .Values.cluster.caBundle.includeDoDCerts | default false | toString | eq "true" }}
     includePublicCerts: {{ .Values.cluster.caBundle.includePublicCerts | default false | toString | eq "true" }}
@@ -46,9 +46,6 @@ spec:
     adminDomain: {{ .Values.cluster.expose.adminDomain | quote }}
     {{- else }}
     adminDomain: "admin.{{ .Values.cluster.expose.domain }}"
-    {{- end }}
-    {{- if .Values.cluster.expose.caCert }}
-    caCert: {{ .Values.cluster.expose.caCert | quote }}
     {{- end }}
   policy:
     allowAllNsExemptions: {{ .Values.cluster.policy.allowAllNsExemptions }}

--- a/src/pepr/uds-operator-config/tests/clusterconfig_test.yaml
+++ b/src/pepr/uds-operator-config/tests/clusterconfig_test.yaml
@@ -22,43 +22,12 @@ tests:
           path: spec.caBundle.certs
           value: "LS0tLS1CRUdJTi...new-ca-bundle-certs"
 
-  - it: should render with legacy expose.caCert value when caBundle.certs is empty
+  - it: should not render certs field when caBundle.certs is empty
     set:
       cluster:
         caBundle:
           certs: ""
         expose:
-          caCert: "LS0tLS1CRUdJTi...legacy-ca-cert"
-          domain: "example.com"
-    asserts:
-      - isKind:
-          of: ClusterConfig
-      - equal:
-          path: spec.caBundle.certs
-          value: "LS0tLS1CRUdJTi...legacy-ca-cert"
-
-  - it: should prefer caBundle.certs over expose.caCert when both are set
-    set:
-      cluster:
-        caBundle:
-          certs: "LS0tLS1CRUdJTi...new-ca-bundle-certs"
-        expose:
-          caCert: "LS0tLS1CRUdJTi...legacy-ca-cert"
-          domain: "example.com"
-    asserts:
-      - isKind:
-          of: ClusterConfig
-      - equal:
-          path: spec.caBundle.certs
-          value: "LS0tLS1CRUdJTi...new-ca-bundle-certs"
-
-  - it: should not render certs field when both values are empty strings
-    set:
-      cluster:
-        caBundle:
-          certs: ""
-        expose:
-          caCert: ""
           domain: "example.com"
     asserts:
       - isKind:
@@ -74,7 +43,6 @@ tests:
           includeDoDCerts: true
           includePublicCerts: false
         expose:
-          caCert: ""
           domain: "example.com"
     asserts:
       - isKind:

--- a/src/pepr/uds-operator-config/values.schema.json
+++ b/src/pepr/uds-operator-config/values.schema.json
@@ -60,7 +60,7 @@
             "adminDomain": {
               "type": "string",
               "description": "Admin domain for cluster exposure."
-            },
+            }
           }
         },
         "policy": {

--- a/src/pepr/uds-operator-config/values.schema.json
+++ b/src/pepr/uds-operator-config/values.schema.json
@@ -61,10 +61,6 @@
               "type": "string",
               "description": "Admin domain for cluster exposure."
             },
-            "caCert": {
-              "type": "string",
-              "description": "Deprecated: CA certificate for cluster exposure. Use cluster.caBundle.certs instead."
-            }
           }
         },
         "policy": {

--- a/src/pepr/uds-operator-config/values.yaml
+++ b/src/pepr/uds-operator-config/values.yaml
@@ -17,8 +17,6 @@ cluster:
     includeDoDCerts: "###ZARF_VAR_CA_BUNDLE_INCLUDE_DOD_CERTS###"
     includePublicCerts: "###ZARF_VAR_CA_BUNDLE_INCLUDE_PUBLIC_CERTS###"
   expose:
-    # Note caCert is deprecated, use caBundle.certs instead
-    caCert: "###ZARF_VAR_CA_CERT###"
     # Domain configuration (admin defaults to `admin.UDS_DOMAIN`)
     domain: "###ZARF_VAR_DOMAIN###"
     adminDomain: "###ZARF_VAR_ADMIN_DOMAIN###"

--- a/src/pepr/zarf.yaml
+++ b/src/pepr/zarf.yaml
@@ -15,11 +15,6 @@ variables:
   - name: ADMIN_DOMAIN
     description: "Domain for admin services, defaults to `admin.DOMAIN`"
 
-  # Note: This variable is deprecated and will be removed in future releases. Please use CA_BUNDLE_CERTS instead.
-  - name: CA_CERT
-    description: "Base64 encoded CA cert that signed the domain wildcard certs used for Istio ingress"
-    default: ""
-
   - name: CA_BUNDLE_CERTS
     description: "Base64 encoded CA certs (bundle) in PEM format that UDS Core will inherently trust. At a minimum this must at least include your Domain CA Cert if using Private PKI for your UDS Core Deployment"
     default: ""


### PR DESCRIPTION
## Description
Remove deprecated `CA_CERT` variable and corresponding `caCert` cluster config field.

## Related Issue

Relates to #1705 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed


  
BEGIN_COMMIT_OVERRIDE
chore!: remove deprecated CA_CERT variable (#2489)

BREAKING CHANGE: Removed `CA_CERT` Zarf variable and `spec.expose.caCert` ClusterConfig field. Migrate to the `CA_BUNDLE_CERTS` Zarf variable / `spec.caBundle.certs` field.

Release-As: 1.0.0
END_COMMIT_OVERRIDE