### PR TITLE
docs: update deprecation table for Package deprecations

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -16,11 +16,11 @@ When adding a deprecation, include:
 
 | Feature | PR | Deprecated In | Reason | Migration | Removal Target |
 |---------|-----|---------------|--------|-----------|----------------|
-| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | [#154](https://github.com/defenseunicorns/uds-core/pull/154) | 0.12.0 | Improve API naming and organization | Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | 1.0.0 |
+| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | [#154](https://github.com/defenseunicorns/uds-core/pull/154) | 0.12.0 | Improve API naming and organization | Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | Package `v1beta1` |
 | Keycloak `fips` helm value | [#1518](https://github.com/defenseunicorns/uds-core/pull/1518) | 0.43.0 | FIPS mode is now enabled by default for all deployments | If you override `fips` to `false`, remove that override as soon as possible to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
 | `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | [#1233](https://github.com/defenseunicorns/uds-core/pull/1233) | 0.48.0 | Moved to ClusterConfig CRD for centralized configuration | Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
 | `CA_CERT` Zarf variable | [#2167](https://github.com/defenseunicorns/uds-core/pull/2167) | 0.58.0 | Improved naming clarity for centralized trust bundle management | Use `CA_BUNDLE_CERTS` instead | 1.0.0 |
-| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | 1.0.0 |
+| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | Package `v1beta1` |
 
 ## Recently Removed
 


### PR DESCRIPTION
## Description

Updates the deprecation table to change the target for Package CR removals to a Package version (rather than Core version). Alternatively could split into two tables - one for "core deprecations" and one for "package deprecations".