### PR TITLE
chore(docs): use registry references in new doc site instead of ghcr

### DIFF
--- a/.ai/docs/how-to-guide-template.md
+++ b/.ai/docs/how-to-guide-template.md
@@ -37,6 +37,7 @@ Brief intro paragraph (2-3 sentences) explaining what the user will configure an
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token <!-- include if guide references registry.defenseunicorns.com packages -->
 - Access to a Kubernetes cluster [qualifier, e.g., "(**multi-node**, multi-AZ recommended)"]
 - [Guide-specific: external dependency, credential requirement, or knowledge prereq]
 
@@ -160,6 +161,7 @@ These guides and concepts may be useful to explore next:
 
 ### Prerequisites
 - Always list: **UDS CLI installed** and **Access to a Kubernetes cluster** (with guide-specific qualifiers like "(**multi-node**, multi-AZ recommended)")
+- If the guide references `registry.defenseunicorns.com` packages (e.g., bundle YAML with `repository: registry.defenseunicorns.com/...`), include: **[UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token**
 - Guide-specific items: external dependencies (e.g., external PostgreSQL), credential requirements, knowledge prereqs (e.g., familiarity with bundle overrides)
 
 ### General

--- a/docs/concepts/configuration-and-packaging/bundles.mdx
+++ b/docs/concepts/configuration-and-packaging/bundles.mdx
@@ -44,9 +44,12 @@ packages:
     ref: x.x.x
 
   - name: core
-    repository: ghcr.io/defenseunicorns/packages/uds/core
+    repository: registry.defenseunicorns.com/public/core
     ref: x.x.x
 ```
+
+> [!NOTE]
+> Pulling packages from the UDS Registry requires a [UDS Registry](https://registry.defenseunicorns.com) account and local authentication with a read token.
 
 Each entry references a Zarf package by OCI repository and version tag. Deploy order matters — packages are deployed top to bottom, so the platform is ready before applications land.
 

--- a/docs/concepts/platform/flavors.mdx
+++ b/docs/concepts/platform/flavors.mdx
@@ -15,7 +15,7 @@ UDS Core is published in multiple **flavors**. A flavor determines the container
 | **`unicorn`** | Defense Unicorns curated registry | FIPS-validated, near-zero CVE posture | Private | Production deployments with Defense Unicorns support agreement |
 
 > [!NOTE]
-> The `unicorn` flavor is only available in a private container registry. It requires a Defense Unicorns support agreement. [Contact Defense Unicorns](https://www.defenseunicorns.com/contact) for access.
+> The `unicorn` flavor is only available in a private organization on the [UDS Registry](https://registry.defenseunicorns.com). It requires a Defense Unicorns support agreement. [Contact Defense Unicorns](https://www.defenseunicorns.com/contact) for access.
 
 > [!CAUTION]
 > The `upstream` flavor is not recommended for production. Upstream images are community-maintained and may not meet the hardening or CVE-scanning requirements of regulated environments.

--- a/docs/getting-started/local-demo/install-and-deploy-uds.mdx
+++ b/docs/getting-started/local-demo/install-and-deploy-uds.mdx
@@ -51,7 +51,7 @@ import { Steps } from '@astrojs/starlight/components';
    Confirm with `y` when prompted. The first run takes approximately **10–15 minutes** while images are pulled.
 
    > [!NOTE]
-   > To deploy a specific version, replace `latest` with a version tag. See all versions on the [package registry](https://github.com/defenseunicorns/uds-core/pkgs/container/packages%2Fuds%2Fbundles%2Fk3d-core-demo).
+   > To deploy a specific version, replace `latest` with a version tag. See all versions on the [UDS Registry](https://registry.defenseunicorns.com/repo/public/core/versions).
    >
    > To update UDS Core on an existing cluster without recreating it:
    > ```bash

--- a/docs/getting-started/local-demo/install-and-deploy-uds.mdx
+++ b/docs/getting-started/local-demo/install-and-deploy-uds.mdx
@@ -51,7 +51,7 @@ import { Steps } from '@astrojs/starlight/components';
    Confirm with `y` when prompted. The first run takes approximately **10–15 minutes** while images are pulled.
 
    > [!NOTE]
-   > To deploy a specific version, replace `latest` with a version tag. See all versions on the [UDS Registry](https://registry.defenseunicorns.com/repo/public/core/versions).
+   > To deploy a specific version, replace `latest` with a version tag. See all versions on the [package registry](https://github.com/defenseunicorns/uds-core/pkgs/container/packages%2Fuds%2Fbundles%2Fk3d-core-demo).
    >
    > To update UDS Core on an existing cluster without recreating it:
    > ```bash

--- a/docs/getting-started/production/build-your-bundle.mdx
+++ b/docs/getting-started/production/build-your-bundle.mdx
@@ -11,7 +11,7 @@ import { Steps } from '@astrojs/starlight/components';
 A [UDS Bundle](/concepts/configuration-and-packaging/bundles/) is a single deployable artifact that captures your environment's configuration alongside all packages and images. You'll create two files: a `uds-bundle.yaml` that defines what to deploy and how to configure it, and a `uds-config.yaml` that supplies runtime values (credentials, certificates, domain names).
 
 > [!NOTE]
-> Building a bundle requires a [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token.
+> Building a bundle that includes packages from the [UDS Registry](https://registry.defenseunicorns.com) requires an account created and authenticated locally with a read token.
 
 ---
 

--- a/docs/getting-started/production/build-your-bundle.mdx
+++ b/docs/getting-started/production/build-your-bundle.mdx
@@ -10,6 +10,9 @@ import { Steps } from '@astrojs/starlight/components';
 
 A [UDS Bundle](/concepts/configuration-and-packaging/bundles/) is a single deployable artifact that captures your environment's configuration alongside all packages and images. You'll create two files: a `uds-bundle.yaml` that defines what to deploy and how to configure it, and a `uds-config.yaml` that supplies runtime values (credentials, certificates, domain names).
 
+> [!NOTE]
+> Building a bundle requires a [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token.
+
 ---
 
 ## Choose a Core Flavor
@@ -50,7 +53,7 @@ packages:
     ref: v0.73.0
 
   - name: core
-    repository: ghcr.io/defenseunicorns/packages/uds/core
+    repository: registry.defenseunicorns.com/public/core
     ref: 0.62.0-upstream
 ```
 
@@ -266,7 +269,7 @@ packages:
     ref: v0.73.0
 
   - name: core
-    repository: ghcr.io/defenseunicorns/packages/uds/core
+    repository: registry.defenseunicorns.com/public/core
     ref: 0.62.0-upstream
     overrides:
       loki:

--- a/docs/getting-started/production/prerequisites.mdx
+++ b/docs/getting-started/production/prerequisites.mdx
@@ -149,6 +149,16 @@ Apply this as part of your node image build or cloud-init process.
 
 ---
 
+## UDS Registry Access
+
+UDS Core packages are published to the [UDS Registry](https://registry.defenseunicorns.com). You need an account and a read token to pull packages.
+
+1. **Create an account** at [registry.defenseunicorns.com](https://registry.defenseunicorns.com)
+2. **Create a read token** from your account settings in the registry web UI
+3. **Authenticate locally** using the command provided in the registry web UI after creating your token
+
+---
+
 ## Checklist
 
 Before moving on, confirm:
@@ -161,4 +171,5 @@ Before moving on, confirm:
 - Object storage buckets are created with credentials available
 - An external PostgreSQL database for Keycloak is available with credentials ready
 - UDS CLI is installed (`uds version`)
+- Authenticated to the [UDS Registry](https://registry.defenseunicorns.com) with a read token
 

--- a/docs/how-to-guides/backup-restore/configure-storage-backends.mdx
+++ b/docs/how-to-guides/backup-restore/configure-storage-backends.mdx
@@ -13,6 +13,7 @@ You'll configure Velero's backup storage destination, provide credentials, and c
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - An S3-compatible or Azure Blob storage endpoint for backup data
 

--- a/docs/how-to-guides/backup-restore/enable-volume-snapshots-aws-ebs.mdx
+++ b/docs/how-to-guides/backup-restore/enable-volume-snapshots-aws-ebs.mdx
@@ -13,6 +13,7 @@ You'll enable Velero to capture persistent volume data using AWS EBS snapshots, 
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to an EKS cluster with UDS Core deployed
 - Velero storage backend configured (see [Configure Velero storage backends](/how-to-guides/backup-restore/configure-storage-backends/))
 - AWS EBS CSI driver installed and an EBS-backed StorageClass available in the cluster

--- a/docs/how-to-guides/backup-restore/enable-volume-snapshots-vsphere.mdx
+++ b/docs/how-to-guides/backup-restore/enable-volume-snapshots-vsphere.mdx
@@ -13,6 +13,7 @@ You'll enable Velero to capture persistent volume data using vSphere CSI snapsho
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to an RKE2 cluster with UDS Core deployed
 - Velero storage backend configured (see [Configure Velero storage backends](/how-to-guides/backup-restore/configure-storage-backends/))
 - vSphere environment with a user account that has the required CSI roles and privileges (see [Broadcom vSphere Roles and Privileges](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/container-storage-plugin/3-0/getting-started-with-vmware-vsphere-container-storage-plug-in-3-0/vsphere-container-storage-plug-in-deployment/preparing-for-installation-of-vsphere-container-storage-plug-in.html))

--- a/docs/how-to-guides/high-availability/authservice.mdx
+++ b/docs/how-to-guides/high-availability/authservice.mdx
@@ -13,6 +13,7 @@ You'll configure [Authservice](https://github.com/istio-ecosystem/authservice) f
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster (**multi-node**, multi-AZ recommended)
 - A **Redis or Valkey** instance accessible from the cluster
 - Applications using Authservice for SSO (see [Identity & Authorization concepts](/concepts/core-features/identity-and-authorization/) for when Authservice is used vs. native SSO)

--- a/docs/how-to-guides/high-availability/keycloak.mdx
+++ b/docs/how-to-guides/high-availability/keycloak.mdx
@@ -13,6 +13,7 @@ You'll configure [Keycloak](https://www.keycloak.org/) for production high avail
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster (**multi-node**, multi-AZ recommended)
 - An **external PostgreSQL** instance accessible from the cluster
 - Familiarity with [UDS bundle overrides](/how-to-guides/packaging-applications/overview/)

--- a/docs/how-to-guides/high-availability/logging.mdx
+++ b/docs/how-to-guides/high-availability/logging.mdx
@@ -13,6 +13,7 @@ You'll configure UDS Core's logging pipeline for production high availability: c
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster (**multi-node**, multi-AZ recommended)
 - An **S3-compatible object storage** endpoint for Loki (AWS S3, MinIO, or equivalent)
 - Storage credentials with read/write access to the target bucket

--- a/docs/how-to-guides/high-availability/monitoring.mdx
+++ b/docs/how-to-guides/high-availability/monitoring.mdx
@@ -13,6 +13,7 @@ You'll configure UDS Core's monitoring stack for production high availability: e
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster (**multi-node**, multi-AZ recommended)
 - An **external PostgreSQL** instance accessible from the cluster (for Grafana HA)
 

--- a/docs/how-to-guides/high-availability/runtime-security.mdx
+++ b/docs/how-to-guides/high-availability/runtime-security.mdx
@@ -15,6 +15,7 @@ Falco detects runtime threats like unexpected process execution, file access, an
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster (**multi-node**, multi-AZ recommended)
 
 ## Before you begin

--- a/docs/how-to-guides/high-availability/service-mesh.mdx
+++ b/docs/how-to-guides/high-availability/service-mesh.mdx
@@ -15,6 +15,7 @@ Istio's control plane manages service discovery, certificate rotation, and confi
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster (**multi-node**, multi-AZ recommended)
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/build-deploy-custom-image.mdx
+++ b/docs/how-to-guides/identity-and-authorization/build-deploy-custom-image.mdx
@@ -14,6 +14,7 @@ You'll build a custom uds-identity-config image containing your theme, plugin, o
 
 - Docker installed and running
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - A container registry accessible from your cluster
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/configure-account-lockout.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-account-lockout.mdx
@@ -14,6 +14,7 @@ You'll configure Keycloak's brute-force protection to control how accounts are l
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 
 ## Before you begin
 

--- a/docs/how-to-guides/identity-and-authorization/configure-authentication-flows.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-authentication-flows.mdx
@@ -14,6 +14,7 @@ You'll enable or disable the authentication methods available on the UDS Core lo
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 
 ## Before you begin
 

--- a/docs/how-to-guides/identity-and-authorization/configure-google-idp.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-google-idp.mdx
@@ -14,6 +14,7 @@ You'll connect an external social or enterprise identity provider to UDS Core's 
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to your identity provider's admin console to collect the required SAML values
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-http-retries.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-http-retries.mdx
@@ -14,6 +14,7 @@ You'll enable and tune Keycloak's outbound HTTP retry behavior for requests to e
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Familiarity with [UDS bundle overrides](/how-to-guides/packaging-applications/overview/)
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-login-policies.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-login-policies.mdx
@@ -14,6 +14,7 @@ You'll configure Keycloak login behavior for your UDS Core deployment: setting c
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Familiarity with [UDS bundle overrides](/how-to-guides/packaging-applications/overview/)
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/configure-truststore.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-truststore.mdx
@@ -15,6 +15,7 @@ You'll replace the default DoD CA certificate bundle in the uds-identity-config 
 - UDS Core deployed
 - Docker installed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Custom CA certificates available
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/configure-user-account-settings.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-user-account-settings.mdx
@@ -14,6 +14,7 @@ You'll configure user account behavior for your UDS Core Keycloak realm: setting
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 
 ## Before you begin
 

--- a/docs/how-to-guides/identity-and-authorization/configure-x509-crl-airgap.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-x509-crl-airgap.mdx
@@ -13,6 +13,7 @@ You'll configure Keycloak to validate X.509/CAC certificates against locally loa
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Docker installed (on the machine where you run the packaging script)
 - `bash`, `curl`, `unzip`, `find`, and `sort` available on the machine running the script
 - Access to a Kubernetes cluster running Kubernetes 1.31+

--- a/docs/how-to-guides/identity-and-authorization/customize-branding.mdx
+++ b/docs/how-to-guides/identity-and-authorization/customize-branding.mdx
@@ -14,6 +14,7 @@ You'll replace the default Keycloak login page images (logo, background, footer,
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Custom image files (PNG format) for whichever assets you want to replace
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu.mdx
@@ -14,6 +14,7 @@ You'll enable the built-in `uds-opentofu-client` in UDS Core's Keycloak realm an
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - [OpenTofu](https://opentofu.org/docs/intro/install/) installed
 
 ## Before you begin

--- a/docs/how-to-guides/logging/configure-log-retention.mdx
+++ b/docs/how-to-guides/logging/configure-log-retention.mdx
@@ -13,6 +13,7 @@ After completing this guide, Loki will automatically delete log data older than 
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - Loki connected to external object storage — see [Configure HA logging](/how-to-guides/high-availability/logging/) for object storage setup
 

--- a/docs/how-to-guides/logging/forward-logs-to-external-system.mdx
+++ b/docs/how-to-guides/logging/forward-logs-to-external-system.mdx
@@ -13,6 +13,7 @@ After completing this guide, Vector will forward logs to an external S3-compatib
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - An S3-compatible bucket with write access (AWS S3, MinIO, or equivalent)
 - For AWS: an IAM role for [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) with `s3:PutObject` permission on the target bucket

--- a/docs/how-to-guides/monitoring-observability/add-custom-dashboards.mdx
+++ b/docs/how-to-guides/monitoring-observability/add-custom-dashboards.mdx
@@ -13,6 +13,7 @@ Deploy application-specific Grafana dashboards as code using Kubernetes ConfigMa
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - A Grafana dashboard exported as JSON (or a JSON dashboard definition)
 

--- a/docs/how-to-guides/monitoring-observability/add-grafana-datasources.mdx
+++ b/docs/how-to-guides/monitoring-observability/add-grafana-datasources.mdx
@@ -13,6 +13,7 @@ Connect Grafana to additional data sources beyond the defaults that ship with UD
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - URL and any credentials for the external datasource you want to add
 

--- a/docs/how-to-guides/monitoring-observability/create-metric-alerting-rules.mdx
+++ b/docs/how-to-guides/monitoring-observability/create-metric-alerting-rules.mdx
@@ -13,6 +13,7 @@ Define alerting conditions based on Prometheus metrics using PrometheusRule CRDs
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - Familiarity with [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/)
 

--- a/docs/how-to-guides/monitoring-observability/route-alerts-to-notification-channels.mdx
+++ b/docs/how-to-guides/monitoring-observability/route-alerts-to-notification-channels.mdx
@@ -13,6 +13,7 @@ Configure Alertmanager to deliver alerts from Prometheus and Loki to notificatio
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - A webhook URL or credentials for your notification service (e.g., Slack incoming webhook)
 

--- a/docs/how-to-guides/networking/configure-core-network-access.mdx
+++ b/docs/how-to-guides/networking/configure-core-network-access.mdx
@@ -13,6 +13,7 @@ After completing this guide, you will have extended the network access rules for
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - Familiarity with [UDS Bundles](/concepts/configuration-and-packaging/bundles/)
 

--- a/docs/how-to-guides/networking/configure-l7-load-balancer.mdx
+++ b/docs/how-to-guides/networking/configure-l7-load-balancer.mdx
@@ -13,6 +13,7 @@ After completing this guide, UDS Core will work correctly behind an L7 load bala
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with [prerequisites](/getting-started/production/prerequisites/) met
 - An L7 load balancer (AWS ALB, Azure Application Gateway, or similar) provisioned
 

--- a/docs/how-to-guides/networking/configure-non-http-ingress.mdx
+++ b/docs/how-to-guides/networking/configure-non-http-ingress.mdx
@@ -19,6 +19,7 @@ After completing this guide, your cluster will accept non-HTTP traffic (such as 
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - An application with a service listening on a TCP port
 

--- a/docs/how-to-guides/networking/configure-tls-certificates.mdx
+++ b/docs/how-to-guides/networking/configure-tls-certificates.mdx
@@ -13,6 +13,7 @@ After completing this guide, your UDS Core ingress gateways will serve traffic u
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with [prerequisites](/getting-started/production/prerequisites/) met
 - A wildcard TLS certificate and private key (PEM format) for each gateway domain. If using a private or non-public CA, the root CA must be loaded in your OS trust store for browser and CLI verification to work.
   - Tenant gateway: `*.yourdomain.com`

--- a/docs/how-to-guides/networking/define-network-access.mdx
+++ b/docs/how-to-guides/networking/define-network-access.mdx
@@ -13,6 +13,7 @@ After completing this guide, your application will have the network access rules
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 - Familiarity with the [Package CR](/reference/operator-and-crds/packages-v1alpha1-cr/)
 

--- a/docs/how-to-guides/networking/enable-passthrough-gateway.mdx
+++ b/docs/how-to-guides/networking/enable-passthrough-gateway.mdx
@@ -13,6 +13,7 @@ After completing this guide, you will have the optional passthrough gateway depl
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with [prerequisites](/getting-started/production/prerequisites/) met
 - An application that manages its own TLS termination
 - Familiarity with [Zarf packages](https://docs.zarf.dev/ref/create/) and [UDS Bundles](/concepts/configuration-and-packaging/bundles/)

--- a/docs/how-to-guides/networking/expose-apps-on-gateways.mdx
+++ b/docs/how-to-guides/networking/expose-apps-on-gateways.mdx
@@ -13,6 +13,7 @@ After completing this guide, your application will be accessible through one of 
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed and TLS configured — see [Configure TLS certificates](/how-to-guides/networking/configure-tls-certificates/)
 - A domain configured in your `uds-config.yaml`:
   ```yaml title="uds-config.yaml"

--- a/docs/how-to-guides/platform-features/enable-classification-banner.mdx
+++ b/docs/how-to-guides/platform-features/enable-classification-banner.mdx
@@ -13,6 +13,7 @@ After completing this guide, web applications exposed through the Istio service 
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed
 
 ## Before you begin

--- a/docs/how-to-guides/policy-and-compliance/configure-infrastructure-exemptions.mdx
+++ b/docs/how-to-guides/policy-and-compliance/configure-infrastructure-exemptions.mdx
@@ -13,6 +13,7 @@ You'll configure policy exemptions for infrastructure workloads that legitimatel
 ## Prerequisites
 
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster with UDS Core deployed (or ready to deploy Core to)
 - Familiarity with [UDS Bundles](/concepts/configuration-and-packaging/bundles/)
 - The exemption policy names for your workload (see [Policy Engine](/reference/operator-and-crds/policy-engine/) reference)

--- a/docs/how-to-guides/runtime-security/route-runtime-alerts.mdx
+++ b/docs/how-to-guides/runtime-security/route-runtime-alerts.mdx
@@ -14,6 +14,7 @@ You'll configure Falcosidekick to forward runtime security alerts to Slack, Matt
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster
 - Webhook URL for your target platform (Slack, Mattermost, or Teams)
 

--- a/docs/how-to-guides/runtime-security/tune-falco-detections.mdx
+++ b/docs/how-to-guides/runtime-security/tune-falco-detections.mdx
@@ -14,6 +14,7 @@ You'll customize which threats Falco detects by enabling additional rulesets, di
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- [UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token
 - Access to a Kubernetes cluster
 
 ## Before you begin


### PR DESCRIPTION
## Description

Update docs site to use UDS Registry (`registry.defenseunicorns.com`) instead of GHCR for package references.

**Decisions:**
- UDS Core → `registry.defenseunicorns.com/public/core`
- Zarf init stays on `ghcr.io/zarf-dev/packages/init` (not in UDS Registry)
- Non-core public UDS packages (e.g., postgres-operator) stay on GHCR (only relevant in the packaging docs)
- Upstream app images (e.g., podinfo) stay as-is

## Related Issue

Fixes CORE-395

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- `uds run dev-docs` 
- search for all ghcr.io references in the docs

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed