### PR TITLE
chore: update dev-docs to align with cli

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -159,7 +159,6 @@ tasks:
     actions:
       - task: lint:fix
 
-  # Note that due to cloning the docs repo (which is private) this task will require organization access to the repo
   # This task does not clone in/manage docs outside of the core repo so you may hit some 404s during development
   # This task does not run the integration-script in the uds-docs repo, the sidebar will not be the same as the live docs
   - name: dev-docs
@@ -170,25 +169,25 @@ tasks:
           rm -rf uds-docs
       - description: "Clone the docs repo and symlink the reference docs"
         cmd: |
-          # Clone uds-docs repo
           git clone https://github.com/defenseunicorns/uds-docs.git uds-docs
-
-          # Clean up old runs (including dot-dirs like .c4 and .images)
-          rm -rf uds-docs/src/content/docs/core/{*,.*} 2>/dev/null || true
           mkdir -p uds-docs/src/content/docs/core
 
-          # Symlink relevant docs folders (skip dev - not for public docs site)
-          for f in $(pwd)/docs/*; do [ "$(basename "$f")" = "dev" ] || [ "$(basename "$f")" = "README.md" ] && continue; ln -s "$f" uds-docs/src/content/docs/core; done
+          # Symlink only dirs listed in sidebarOrder (mirrors integration-script cleanup logic)
+          allowed=$(./uds zarf tools yq -r '.sidebarOrder[] | (.dir // .)' docs/docs.config.json)
+          for dir in $(pwd)/docs/*/; do
+            name="$(basename "$dir")"
+            echo "$allowed" | grep -qx "$name" && ln -s "$dir" uds-docs/src/content/docs/core/
+          done
+          # Also symlink the top-level index page if present
+          [ -f "$(pwd)/docs/index.mdx" ] && ln -s "$(pwd)/docs/index.mdx" uds-docs/src/content/docs/core/
           ln -s $(pwd)/docs/.c4 uds-docs/src/content/docs/.c4
           ln -s $(pwd)/docs/.images uds-docs/src/content/docs/.images
-
       - description: "Create product config for dev server"
         cmd: |
           mkdir -p uds-docs/.product-configs
 
           jq '. + {repo: "defenseunicorns/uds-core"}' docs/docs.config.json \
             > uds-docs/.product-configs/uds-core.json
-
       - description: "Start the docs server with npm (this will run until you stop it)"
         cmd: |
           # Actual startup takes up to a minute because of the npm install


### PR DESCRIPTION
## Description

Aligns dev-docs with how UDS CLI dev-docs works, with exception that in this case we actually link c4/image content (since they exist).