### PR TITLE
fix: incr loki backend replicas to 3 in upgrade test

### DIFF
--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -87,6 +87,9 @@ packages:
             - name: LOKI_S3_SECRET_ACCESS_KEY
               path: loki.storage.s3.secretAccessKey
               description: "The S3 Secret Access Key"
+            # NOTE: Loki write/read/backend replicas are scaled down to 1 to reduce resource
+            # consumption for demo and CI scenarios. These values are not recommended or supported
+            # for production and are known to cause issues in some scenarios.
             - name: LOKI_WRITE_REPLICAS
               path: write.replicas
               description: "Loki write replicas"
@@ -98,7 +101,7 @@ packages:
             - name: LOKI_BACKEND_REPLICAS
               path: backend.replicas
               description: "Loki backend replicas"
-              default: "3"
+              default: "1"
       istio-admin-gateway:
         uds-istio-config:
           variables:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -98,7 +98,7 @@ packages:
             - name: LOKI_BACKEND_REPLICAS
               path: backend.replicas
               description: "Loki backend replicas"
-              default: "1"
+              default: "3"
       istio-admin-gateway:
         uds-istio-config:
           variables:

--- a/bundles/k3d-standard/uds-ha-config.yaml
+++ b/bundles/k3d-standard/uds-ha-config.yaml
@@ -7,6 +7,10 @@ variables:
     AUTHSERVICE_REDIS_URI: redis://authservice:authservice@host.k3d.internal:6379
     AUTHSERVICE_REPLICA_COUNT: 2
 
+    # Enable Falco sandbox and incubating rules
+    FALCO_SANDBOX_RULES_ENABLED: true
+    FALCO_INCUBATING_RULES_ENABLED: true
+
     # Grafana variables
     grafana_ha: true
     grafana_pg_host: host.k3d.internal

--- a/bundles/k3d-standard/uds-ha-config.yaml
+++ b/bundles/k3d-standard/uds-ha-config.yaml
@@ -3,13 +3,9 @@
 
 variables:
   core:
-    # Keycloak variables
-    keycloak_ha: true
-    keycloak_pg_username: postgres
-    keycloak_pg_password: unicorn123!@#UN
-    keycloak_pg_database: keycloak
-    keycloak_pg_host: host.k3d.internal
-    keycloak_devmode: false
+    # Authservice variables
+    AUTHSERVICE_REDIS_URI: redis://authservice:authservice@host.k3d.internal:6379
+    AUTHSERVICE_REPLICA_COUNT: 2
 
     # Grafana variables
     grafana_ha: true
@@ -20,6 +16,15 @@ variables:
     grafana_pg_user: postgres
     grafana_pg_ssl_mode: disable
 
-    # Authservice variables
-    AUTHSERVICE_REDIS_URI: redis://authservice:authservice@host.k3d.internal:6379
-    AUTHSERVICE_REPLICA_COUNT: 2
+    # Loki variables
+    LOKI_BACKEND_REPLICAS: 3
+    LOKI_READ_REPLICAS: 3
+    LOKI_WRITE_REPLICAS: 3
+
+    # Keycloak variables
+    keycloak_ha: true
+    keycloak_pg_username: postgres
+    keycloak_pg_password: unicorn123!@#UN
+    keycloak_pg_database: keycloak
+    keycloak_pg_host: host.k3d.internal
+    keycloak_devmode: false

--- a/bundles/k3d-standard/uds-private-pki-config.yaml
+++ b/bundles/k3d-standard/uds-private-pki-config.yaml
@@ -3,18 +3,14 @@
 
 variables:
   core:
-    # Admin Gateway TLS certificate and key
-    ADMIN_TLS_CERT: "PLACEHOLDER_ADMIN_TLS_CERT"
-    ADMIN_TLS_KEY: "PLACEHOLDER_ADMIN_TLS_KEY"
-
     # CA_CERTS
     CA_BUNDLE_CERTS: "PLACEHOLDER_CA_BUNDLE_CERTS"
     CA_BUNDLE_INCLUDE_DOD_CERTS: "true"
     CA_BUNDLE_INCLUDE_PUBLIC_CERTS: "true"
 
-    # Enable Falco sandbox and incubating rules
-    FALCO_SANDBOX_RULES_ENABLED: true
-    FALCO_INCUBATING_RULES_ENABLED: true
+    # Admin Gateway TLS certificate and key
+    ADMIN_TLS_CERT: "PLACEHOLDER_ADMIN_TLS_CERT"
+    ADMIN_TLS_KEY: "PLACEHOLDER_ADMIN_TLS_KEY"
 
     # Tenant Gateway TLS certificate and key
     TENANT_TLS_CERT: "PLACEHOLDER_TENANT_TLS_CERT"

--- a/bundles/k3d-standard/uds-private-pki-config.yaml
+++ b/bundles/k3d-standard/uds-private-pki-config.yaml
@@ -3,14 +3,18 @@
 
 variables:
   core:
+    # Admin Gateway TLS certificate and key
+    ADMIN_TLS_CERT: "PLACEHOLDER_ADMIN_TLS_CERT"
+    ADMIN_TLS_KEY: "PLACEHOLDER_ADMIN_TLS_KEY"
+
     # CA_CERTS
     CA_BUNDLE_CERTS: "PLACEHOLDER_CA_BUNDLE_CERTS"
     CA_BUNDLE_INCLUDE_DOD_CERTS: "true"
     CA_BUNDLE_INCLUDE_PUBLIC_CERTS: "true"
 
-    # Admin Gateway TLS certificate and key
-    ADMIN_TLS_CERT: "PLACEHOLDER_ADMIN_TLS_CERT"
-    ADMIN_TLS_KEY: "PLACEHOLDER_ADMIN_TLS_KEY"
+    # Enable Falco sandbox and incubating rules
+    FALCO_SANDBOX_RULES_ENABLED: true
+    FALCO_INCUBATING_RULES_ENABLED: true
 
     # Tenant Gateway TLS certificate and key
     TENANT_TLS_CERT: "PLACEHOLDER_TENANT_TLS_CERT"

--- a/bundles/k3d-standard/uds-upgrade-test-config.yaml
+++ b/bundles/k3d-standard/uds-upgrade-test-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 variables:

--- a/bundles/k3d-standard/uds-upgrade-test-config.yaml
+++ b/bundles/k3d-standard/uds-upgrade-test-config.yaml
@@ -6,3 +6,7 @@ variables:
     # Enable Falco sandbox and incubating rules
     FALCO_SANDBOX_RULES_ENABLED: true
     FALCO_INCUBATING_RULES_ENABLED: true
+
+    # The loki-backend statefulset is unable to restart cleanly when it contains a single replica.
+    # When the pod termination times out and the single replica is killed it leaves loki in a non-working state.
+    LOKI_BACKEND_REPLICAS: 3

--- a/bundles/k3d-standard/uds-upgrade-test-config.yaml
+++ b/bundles/k3d-standard/uds-upgrade-test-config.yaml
@@ -1,0 +1,8 @@
+# Copyright 2025 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+variables:
+  core:
+    # Enable Falco sandbox and incubating rules
+    FALCO_SANDBOX_RULES_ENABLED: true
+    FALCO_INCUBATING_RULES_ENABLED: true

--- a/src/loki/common/zarf.yaml
+++ b/src/loki/common/zarf.yaml
@@ -16,7 +16,7 @@ components:
         localPath: ../chart
       - name: loki
         url: https://grafana-community.github.io/helm-charts/
-        version: 6.55.0
+        version: 6.57.0
         namespace: loki
         valuesFiles:
           - ../values/values.yaml

--- a/src/loki/common/zarf.yaml
+++ b/src/loki/common/zarf.yaml
@@ -15,7 +15,7 @@ components:
         version: 0.2.0
         localPath: ../chart
       - name: loki
-        url: https://grafana.github.io/helm-charts/
+        url: https://grafana-community.github.io/helm-charts/
         version: 6.55.0
         namespace: loki
         valuesFiles:

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -18,7 +18,6 @@ includes:
   - private-pki: ../test/playwright/private-pki/tasks.yaml
   - trust-bundle: ../test/vitest/trust-bundle/tasks.yaml
 
-
 tasks:
   - name: base
     description: "Build and test the base layer"
@@ -184,6 +183,7 @@ tasks:
     inputs:
       configFile:
         description: "UDS_CONFIG file to use for the deployments"
+        default: "bundles/k3d-standard/uds-upgrade-test-config.yaml"
     description: "Test an upgrade from the latest released UDS Core package to current branch"
     actions:
       - task: deploy:latest-bundle-release
@@ -198,7 +198,7 @@ tasks:
       - cmd: |
           # Set UDS_CONFIG for bundle deployment
           export UDS_CONFIG="${{ .inputs.configFile }}"
-          uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set FALCO_SANDBOX_RULES_ENABLED=true --set FALCO_INCUBATING_RULES_ENABLED=true --packages core --confirm --no-progress
+          uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages core --confirm --no-progress
       - task: validate-packages
       - task: e2e-tests
 


### PR DESCRIPTION
## Description

Fixes issue where upgrade tests will fail when loki-backend stateful set is set to 1 replica. When deployed by itself, the loki-backend pod will hang when terminating (i.e. due to upgrade or restart) unless the loki-read is also cycled. If it does not terminate correctly, and is force killed, it leaves loki in a bad state and stops working correctly causing e2e tests to fail. 

In this particular instance, there were small, unrelated changes made to the loki-backend statefulset which triggered a restart which got hung as described above and caused the tests to fail.

Verified this behavior existed prior to recent helm chart changes but was likely masked previously by the fact that normally the loki pods are all cycling out at the same time instead of just the backend by itself.

We fix this by setting loki-backend replicas to 3 during the upgrade test. The upgrade test task was also refactored to use a default uds-upgrade-test-config.yaml rather than command line args to ensure consistent settings are used for both the initial deployment of the previous release in `deploy:latest-bundle-release` as well as during deployment of the current version.

Loki read, write, and backend replicas were set to 3 in the HA upgrade test to make it more representative of an HA configuration.

Additional commit title to include during merge for release-please:
chore: incr loki backend/read/write replicas to 3 in ha upgrade test
chore: switch loki helm chart to grafana-community chart
chore: bump loki helm chart to 6.57.0


## Related Issue

Fixes # CORE-451

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Run  `uds run test-uds-core-upgrade`

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed

BEGIN_COMMIT_OVERRIDE
fix: incr loki backend replicas to 3 in upgrade test
chore: incr loki backend/read/write replicas to 3 in ha upgrade test
chore: switch loki helm chart to grafana-community chart
chore: bump loki helm chart to 6.57.0
END_COMMIT_OVERRIDE