### PR TITLE
chore: cleanup deprecations table so it renders better on docs site

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -11,20 +11,18 @@ This document tracks all currently deprecated features in UDS Core. Deprecated f
 <!--
 When adding a deprecation, include:
 - Feature: What is being deprecated
-- PR: Link to the pull request that introduced the deprecation
-- Deprecated In: The version where deprecation was announced
-- Reason: Why it is being deprecated
-- Migration: The recommended replacement or migration path
+- Deprecated In: The version where deprecation was announced (link to the PR)
+- Details: Why it is being deprecated (Reason) and the recommended migration path (Migration)
 - Removal Target: The projected major version for removal
 -->
 
-| Feature | PR | Deprecated In | Reason | Migration | Removal Target |
-|---------|-----|---------------|--------|-----------|----------------|
-| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | [#154](https://github.com/defenseunicorns/uds-core/pull/154) | 0.12.0 | Improve API naming and organization | Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | Package `v1beta1` |
-| Keycloak `fips` helm value | [#1518](https://github.com/defenseunicorns/uds-core/pull/1518) | 0.43.0 | FIPS mode is now enabled by default for all deployments | If you override `fips` to `false`, remove that override as soon as possible to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
-| `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | [#1233](https://github.com/defenseunicorns/uds-core/pull/1233) | 0.48.0 | Moved to ClusterConfig CRD for centralized configuration | Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
-| `CA_CERT` Zarf variable | [#2167](https://github.com/defenseunicorns/uds-core/pull/2167) | 0.58.0 | Improved naming clarity for centralized trust bundle management | Use `CA_BUNDLE_CERTS` instead | 1.0.0 |
-| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | [#2264](https://github.com/defenseunicorns/uds-core/pull/2264) | 0.60.0 | Simplify fields and make more coherent | Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | Package `v1beta1` |
+| Feature | Deprecated In | Details | Removal Target |
+|---------|---------------|---------|----------------|
+| `allow.podLabels`, `allow.remotePodLabels`, `expose.podLabels`, `expose.match` | 0.12.0 ([#154](https://github.com/defenseunicorns/uds-core/pull/154)) | **Reason:** API naming improved.<br/>**Migration:** Use `allow.selector`, `allow.remoteSelector`, `expose.selector`, `expose.advancedHTTP.match` instead | Package `v1beta1` |
+| Keycloak `fips` helm value | 0.43.0 ([#1518](https://github.com/defenseunicorns/uds-core/pull/1518)) | **Reason:** FIPS mode is now enabled by default.<br/>**Migration:** If you override `fips` to `false`, remove that override to enable FIPS mode before it becomes the only allowed method | 1.0.0 |
+| `operator.KUBEAPI_CIDR`, `operator.KUBENODE_CIDRS` | 0.48.0 ([#1233](https://github.com/defenseunicorns/uds-core/pull/1233)) | **Reason:** Moved to ClusterConfig CRD.<br/>**Migration:** Use `cluster.networking.kubeApiCIDR` and `cluster.networking.kubeNodeCIDRs` instead | 1.0.0 |
+| `CA_CERT` Zarf variable | 0.58.0 ([#2167](https://github.com/defenseunicorns/uds-core/pull/2167)) | **Reason:** Improved naming clarity.<br/>**Migration:** Use `CA_BUNDLE_CERTS` instead | 1.0.0 |
+| `sso.secretName`, `sso.secretLabels`, `sso.secretAnnotations`, `sso.secretTemplate` | 0.60.0 ([#2264](https://github.com/defenseunicorns/uds-core/pull/2264)) | **Reason:** Simplified field structure.<br/>**Migration:** Use `sso.secretConfig.name`, `.labels`, `.annotations`, `.template` instead | Package `v1beta1` |
 
 ## Recently Removed
 


### PR DESCRIPTION
## Description

Cleans up the deprecations table so it renders better on docs site:

Old (has scroll bar because of content):
<img width="1095" height="972" alt="image" src="https://github.com/user-attachments/assets/0d123937-bd8d-4821-add8-e336628debea" />

New:
<img width="952" height="839" alt="image" src="https://github.com/user-attachments/assets/0cfb133c-d32e-4687-a69b-80065f5d4f05" />

It also renders nicely in github view as well:
<img width="1240" height="626" alt="image" src="https://github.com/user-attachments/assets/77c0ae67-4cc2-483b-86ff-7c5df5c54844" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- `uds run dev-docs`

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed