### PR TITLE
chore(deps): update identity-config from 0.24.0 to 0.25.0

### DIFF
--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 # renovate: datasource=github-tags depName=defenseunicorns/uds-identity-config versioning=semver
-configImage: ghcr.io/defenseunicorns/uds/identity-config:0.24.0
+configImage: ghcr.io/defenseunicorns/uds/identity-config:0.25.0
 
 # The public domain name of the Keycloak server
 domain: "###ZARF_VAR_DOMAIN###"

--- a/src/keycloak/tasks.yaml
+++ b/src/keycloak/tasks.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
-  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.24.0/tasks.yaml
+  - config: https://raw.githubusercontent.com/defenseunicorns/uds-identity-config/v0.25.0/tasks.yaml
 
 tasks:
   - name: validate
@@ -29,7 +29,7 @@ tasks:
     actions:
       - cmd: |
           # renovate: datasource=docker depName=ghcr.io/defenseunicorns/uds/identity-config versioning=semver
-          IMAGE_TAG="0.24.0"
+          IMAGE_TAG="0.25.0"
           # Pre-pull image to simplify output
           docker pull ghcr.io/defenseunicorns/uds/identity-config:${IMAGE_TAG} -q
           # This is written to a file because it is larger than the max env size in the shell

--- a/src/keycloak/values/registry1-values.yaml
+++ b/src/keycloak/values/registry1-values.yaml
@@ -13,4 +13,4 @@ securityContext:
   capabilities:
     drop:
       - ALL
-configImage: registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.24.0
+configImage: registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.25.0

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -32,7 +32,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.5.5
-      - ghcr.io/defenseunicorns/uds/identity-config:0.24.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.25.0
 
   - name: keycloak
     required: true
@@ -46,7 +46,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.5.5-fips
-      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.24.0
+      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.25.0
 
   - name: keycloak
     required: true
@@ -60,4 +60,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - quay.io/rfcurated/keycloak:26.5.5-jammy-fips-rfcurated
-      - ghcr.io/defenseunicorns/uds/identity-config:0.24.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.25.0


### PR DESCRIPTION
## Description

Updates identity-config to 0.25.0. This brings in the new realm theme name options.

## Related Issue

Relates to https://github.com/defenseunicorns/uds-core/pull/2502

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)