### PR TITLE
fix(ci): handle flaky behavior around policy test and probe check

### DIFF
--- a/test/vitest/prometheus.spec.ts
+++ b/test/vitest/prometheus.spec.ts
@@ -69,7 +69,11 @@ describe("Prometheus and Alertmanager", { retry: 1 }, () => {
         return body.data.activeTargets;
       },
       targets => {
-        const unhealthy = targets.filter(target => target.health !== "up");
+        // Exclude policy-tests namespace — probes created there by pepr-policies/probe.spec.ts
+        // may linger in Prometheus briefly after teardown, causing false failures.
+        const unhealthy = targets.filter(
+          target => target.health !== "up" && !target.scrapePool.includes("/policy-tests/"),
+        );
         for (const target of unhealthy) {
           console.warn(`Target ${target.scrapePool} is ${target.health}`);
         }
@@ -80,6 +84,11 @@ describe("Prometheus and Alertmanager", { retry: 1 }, () => {
       10000,
     );
 
-    expect(targets.every(target => target.health === "up")).toBe(true);
+    // Same exclusion as the polling condition above — see pepr-policies/probe.spec.ts
+    expect(
+      targets
+        .filter(target => !target.scrapePool.includes("/policy-tests/"))
+        .every(target => target.health === "up"),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

Observed a flaky behavior in several PRs today: https://github.com/defenseunicorns/uds-core/actions/runs/23455137257/job/68242426000?pr=2516

Probes created by the policy tests sometimes may linger in prometheus, causing false failures. These probes are only created to test admission behavior and SHOULD be torn down before hitting the Prometheus test, but this is not always the case since Prometheus eval window may still see them or the ns may be stuck terminating for a bit. This change filters them from results on the prometheus side.