### PR TITLE
feat: add default endpoint probe and TLS expiry alerts

### DIFF
--- a/docs/concepts/core-features/monitoring-observability.mdx
+++ b/docs/concepts/core-features/monitoring-observability.mdx
@@ -28,13 +28,13 @@ By including monitoring as a platform layer, UDS Core provides:
 
 ## Uptime monitoring
 
-UDS Core monitors the availability of its own services through two mechanisms: Prometheus recording rules that track workload health (pod/deployment status), and Blackbox Exporter endpoint probes that verify HTTPS reachability from outside the service mesh. Together, these feed two built-in Grafana dashboards (**Core Uptime** and **Probe Uptime**), giving operators a single view of platform health.
+UDS Core monitors the availability of its own services through three built-in mechanisms: Prometheus recording rules that track workload health (pod and deployment status), Blackbox Exporter endpoint probes that verify HTTPS reachability from outside the service mesh, and default probe alert rules that notify you when endpoints go down or certificates approach expiry. Together, these feed two built-in Grafana dashboards (**Core Uptime** and **Probe Uptime**) and the default Alertmanager pipeline, giving operators a comprehensive view of platform health.
 
-For full details on available metrics, recording rules, probe configuration, and dashboard behavior, see the [Monitoring & Observability reference](/reference/configuration/monitoring-and-observability/).
+For full details on available metrics, recording rules, default probe alerts, probe configuration, and dashboard behavior, see the [Monitoring & Observability reference](/reference/configuration/monitoring-and-observability/).
 
 ## How application teams add metrics
 
-Applications declare their monitoring needs in the `Package` CR's `monitor` block. The UDS Operator automatically creates the appropriate [`ServiceMonitor`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitor), [`PodMonitor`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor), and [`Probe`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Probe) resources for Prometheus to scrape. Alert rules for application-specific conditions are expressed as [`PrometheusRule`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PrometheusRule) CRDs deployed alongside the application, keeping alerting logic version-controlled with the application code.
+Applications declare their monitoring needs in the `Package` CR's `monitor` block. The UDS Operator automatically creates the appropriate [`ServiceMonitor`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitor), [`PodMonitor`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor), and [`Probe`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Probe) resources for Prometheus to scrape. UDS Core's built-in probe alert rules cover generic endpoint downtime and TLS certificate expiry. Additional application-specific alert needs are expressed as [`PrometheusRule`](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PrometheusRule) CRDs deployed alongside the application, keeping alerting logic version-controlled with the application code.
 
 ## Alert routing principles
 
@@ -43,4 +43,4 @@ UDS Core follows the principle that alerts should be evaluated at the source, no
 This keeps alerting configuration declarative, version-controllable, and consistent across environments. The same `PrometheusRule` works whether it is deployed to a local development cluster or a production environment.
 
 > [!TIP]
-> For configuration details, defaults, and available metrics, see the [Monitoring & Observability reference](/reference/configuration/monitoring-and-observability/). For task-oriented guides, see the [Monitoring How-to Guides](/how-to-guides/monitoring-and-observability/overview/).
+> For configuration details, defaults, and available metrics, see the [Monitoring & Observability reference](/reference/configuration/monitoring-and-observability/). To create custom alerts or tune the shipped defaults, see [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/). For additional task-oriented guides, see the [Monitoring How-to Guides](/how-to-guides/monitoring-and-observability/overview/).

--- a/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
@@ -91,7 +91,7 @@ Runbooks for upstream defaults are available at [runbooks.prometheus-operator.de
 
    If default alerts are too noisy or not relevant to your environment, you can tune both upstream kube-prometheus-stack and UDS Core defaults through bundle overrides.
 
-   UDS Core default probe alerts can be tuned or disabled like so:
+   UDS Core default probe alerts can be tuned or disabled as follows:
 
    ```yaml title="uds-bundle.yaml"
    packages:
@@ -120,7 +120,7 @@ Runbooks for upstream defaults are available at [runbooks.prometheus-operator.de
                  value: critical
    ```
 
-   Upstream kube-prometheus-stack default rules can be disabled like so:
+   Upstream kube-prometheus-stack default rules can be disabled as follows:
 
    ```yaml title="uds-bundle.yaml"
    packages:

--- a/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
@@ -94,53 +94,45 @@ Runbooks for upstream defaults are available at [runbooks.prometheus-operator.de
    UDS Core default probe alerts can be tuned or disabled as follows:
 
    ```yaml title="uds-bundle.yaml"
-   packages:
-     - name: core
-       repository: registry.defenseunicorns.com/public/core
-       ref: x.x.x-upstream
-       overrides:
-         kube-prometheus-stack:
-           uds-prometheus-config:
-             values:
-               # Disable all UDS Core probe default alerts
-               - path: udsCoreDefaultAlerts.enabled
-                 value: false
-               # Disable Endpoint Down alert
-               - path: udsCoreDefaultAlerts.probeEndpointDown.enabled
-                 value: false
-               # Tune threshold and severity for TLS expiry warning alerts
-               - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.days
-                 value: 21
-               - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.severity
-                 value: warning
-               # Tune threshold and severity for TLS expiry critical alerts
-               - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.days
-                 value: 7
-               - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.severity
-                 value: critical
+   overrides:
+     kube-prometheus-stack:
+       uds-prometheus-config:
+         values:
+           # Disable all UDS Core probe default alerts
+           - path: udsCoreDefaultAlerts.enabled
+             value: false
+           # Disable Endpoint Down alert
+           - path: udsCoreDefaultAlerts.probeEndpointDown.enabled
+             value: false
+           # Tune threshold and severity for TLS expiry warning alerts
+           - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.days
+             value: 21
+           - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.severity
+             value: warning
+           # Tune threshold and severity for TLS expiry critical alerts
+           - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.days
+             value: 7
+           - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.severity
+             value: critical
    ```
 
    Upstream kube-prometheus-stack default rules can be disabled as follows:
 
    ```yaml title="uds-bundle.yaml"
-   packages:
-     - name: core
-       repository: registry.defenseunicorns.com/public/core
-       ref: x.x.x-upstream
-       overrides:
-         kube-prometheus-stack:
-           kube-prometheus-stack:
-             values:
-               # Disable specific individual rules by name
-               - path: defaultRules.disabled
-                 value:
-                   KubeControllerManagerDown: true
-                   KubeSchedulerDown: true
-               # Disable entire rule groups with boolean toggles
-               - path: defaultRules.rules.kubeControllerManager
-                 value: false
-               - path: defaultRules.rules.kubeSchedulerAlerting
-                 value: false
+   overrides:
+     kube-prometheus-stack:
+       kube-prometheus-stack:
+         values:
+           # Disable specific individual rules by name
+           - path: defaultRules.disabled
+             value:
+               KubeControllerManagerDown: true
+               KubeSchedulerDown: true
+           # Disable entire rule groups with boolean toggles
+           - path: defaultRules.rules.kubeControllerManager
+             value: false
+           - path: defaultRules.rules.kubeSchedulerAlerting
+             value: false
    ```
 
    Use `defaultRules.disabled` for fine-tuned control over upstream individual rules. Use `defaultRules.rules.*` to disable upstream rule groups when broader changes are needed.

--- a/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
@@ -19,7 +19,9 @@ Define alerting conditions based on Prometheus metrics using PrometheusRule CRDs
 
 ## Before you begin
 
-UDS Core ships default alerting rules from the upstream kube-prometheus-stack chart covering cluster health, node conditions, and platform components. Runbooks for these default rules are available at [runbooks.prometheus-operator.dev](https://runbooks.prometheus-operator.dev/). This guide covers creating custom rules for your applications and optionally tuning the defaults.
+UDS Core ships default alerting rules from two sources. The upstream `kube-prometheus-stack` chart provides cluster and node health alerts, and UDS Core provides default probe alerts for endpoint downtime and TLS certificate expiry.
+
+Runbooks for upstream defaults are available at [runbooks.prometheus-operator.dev](https://runbooks.prometheus-operator.dev/). This guide covers creating custom rules for your applications and optionally tuning either default set.
 
 ## Steps
 
@@ -85,9 +87,40 @@ UDS Core ships default alerting rules from the upstream kube-prometheus-stack ch
 
    The Prometheus Operator picks up PrometheusRule CRs automatically.
 
-3. **Optional: Disable or tune default alert rules**
+3. **(Optional) Disable or tune default alert rules**
 
-   If default kube-prometheus-stack alerts are too noisy or not relevant to your environment, you can disable individual rules or entire rule groups through bundle overrides.
+   If default alerts are too noisy or not relevant to your environment, you can tune both upstream kube-prometheus-stack and UDS Core defaults through bundle overrides.
+
+   UDS Core default probe alerts can be tuned or disabled like so:
+
+   ```yaml title="uds-bundle.yaml"
+   packages:
+     - name: core
+       repository: registry.defenseunicorns.com/public/core
+       ref: x.x.x-upstream
+       overrides:
+         kube-prometheus-stack:
+           uds-prometheus-config:
+             values:
+               # Disable all UDS Core probe default alerts
+               - path: udsCoreDefaultAlerts.enabled
+                 value: false
+               # Disable Endpoint Down alert
+               - path: udsCoreDefaultAlerts.probeEndpointDown.enabled
+                 value: false
+               # Tune threshold and severity for TLS expiry warning alerts
+               - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.days
+                 value: 21
+               - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.severity
+                 value: warning
+               # Tune threshold and severity for TLS expiry critical alerts
+               - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.days
+                 value: 7
+               - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.severity
+                 value: critical
+   ```
+
+   Upstream kube-prometheus-stack default rules can be disabled like so:
 
    ```yaml title="uds-bundle.yaml"
    packages:
@@ -110,7 +143,7 @@ UDS Core ships default alerting rules from the upstream kube-prometheus-stack ch
                  value: false
    ```
 
-   Use `defaultRules.disabled` for fine-tuned control over individual rules. Use `defaultRules.rules.*` to disable entire rule groups when broader changes are needed.
+   Use `defaultRules.disabled` for fine-tuned control over upstream individual rules. Use `defaultRules.rules.*` to disable upstream rule groups when broader changes are needed.
 
    Create and deploy your bundle:
 

--- a/docs/how-to-guides/monitoring-and-observability/overview.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/overview.mdx
@@ -35,7 +35,7 @@ These guides assume you already have UDS Core deployed and are familiar with [UD
   />
   <LinkCard
     title="Create metric alerting rules"
-    description="Define Prometheus-based alerting conditions with PrometheusRule CRDs."
+    description="Define custom PrometheusRule alerts and tune built-in default probe alerts."
     href="/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/"
   />
   <LinkCard

--- a/docs/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring.mdx
@@ -24,6 +24,9 @@ Monitor HTTPS endpoint availability using Blackbox Exporter probes. Probes are c
 > [!NOTE]
 > Uptime checks for Authservice-protected applications are fully supported. The UDS Operator automatically creates a dedicated Keycloak service account client and configures OAuth2 authentication for the probe.
 
+> [!NOTE]
+> UDS Core ships default probe alerts through `PrometheusRule` resources in the `uds-prometheus-config` chart. By default, UDS Core creates `UDSProbeEndpointDown`, `UDSProbeTLSExpiryWarning`, and `UDSProbeTLSExpiryCritical` alerts. To tune or disable these defaults, reference [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/).
+
 ## Steps
 
 <Steps>
@@ -52,7 +55,7 @@ Monitor HTTPS endpoint availability using Blackbox Exporter probes. Probes are c
                  - /
    ```
 
-2. **Optional: Monitor custom health endpoints**
+2. **(Optional) Monitor custom health endpoints**
 
    Specify multiple paths to monitor specific health endpoints on a single service.
 
@@ -72,7 +75,7 @@ Monitor HTTPS endpoint availability using Blackbox Exporter probes. Probes are c
                  - /ready
    ```
 
-3. **Optional: Monitor multiple services**
+3. **(Optional) Monitor multiple services**
 
    Add uptime checks to multiple expose entries within a single `Package` CR to monitor several services at once.
 
@@ -109,7 +112,7 @@ Monitor HTTPS endpoint availability using Blackbox Exporter probes. Probes are c
                  - /
    ```
 
-4. **Optional: Monitor Authservice-protected applications**
+4. **(Optional) Monitor Authservice-protected applications**
 
    For applications protected by Authservice, add `uptime.checks` to the expose entry as normal. The UDS Operator detects the `enableAuthserviceSelector` on the matching SSO entry and automatically:
 
@@ -223,6 +226,6 @@ uds zarf tools kubectl describe package <name> -n <namespace>
 
 - [Prometheus: Blackbox Exporter](https://github.com/prometheus/blackbox_exporter): upstream project documentation
 - [Prometheus Operator: Probe API](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Probe): Probe CRD field reference
-- [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/): Alert when probe_success drops to 0 or SSL certificates near expiry.
+- [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/): Create custom alerts beyond the UDS Core default probe alerts.
 - [Monitoring & Observability concepts](/concepts/core-features/monitoring-observability/): Background on how the monitoring stack fits together in UDS Core.
 - [Monitoring & Observability reference](/reference/configuration/monitoring-and-observability/): Default probes, recording rules, and how to disable built-in uptime probes.

--- a/docs/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring.mdx
@@ -23,9 +23,8 @@ Monitor HTTPS endpoint availability using Blackbox Exporter probes. Probes are c
 
 > [!NOTE]
 > Uptime checks for Authservice-protected applications are fully supported. The UDS Operator automatically creates a dedicated Keycloak service account client and configures OAuth2 authentication for the probe.
-
-> [!NOTE]
-> UDS Core ships default probe alerts through `PrometheusRule` resources in the `uds-prometheus-config` chart. By default, UDS Core creates `UDSProbeEndpointDown`, `UDSProbeTLSExpiryWarning`, and `UDSProbeTLSExpiryCritical` alerts. To tune or disable these defaults, reference [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/).
+>
+> UDS Core also ships default probe alerts (`UDSProbeEndpointDown`, `UDSProbeTLSExpiryWarning`, and `UDSProbeTLSExpiryCritical`) through `PrometheusRule` resources in the `uds-prometheus-config` chart. To tune or disable these defaults, see [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/).
 
 ## Steps
 

--- a/docs/reference/configuration/monitoring-and-observability.md
+++ b/docs/reference/configuration/monitoring-and-observability.md
@@ -4,7 +4,7 @@ sidebar:
   order: 3.002
 ---
 
-UDS Core's monitoring stack exposes configuration surfaces at two levels: built-in platform monitoring that works out of the box, and application-level uptime probes that operators configure through the Package CR.
+UDS Core's monitoring stack exposes configuration surfaces at two levels: built-in platform monitoring that works out of the box, and application-level uptime probes that operators configure through the `Package` CR.
 
 ## Built-in monitoring
 
@@ -33,7 +33,7 @@ Each service has an `uptime.enabled` Helm value (boolean, default: `true`) that 
 
 To disable probes for Keycloak and Grafana, add a value override in your bundle:
 
-```yaml
+```yaml title="uds-bundle.yaml"
 overrides:
   keycloak:
     keycloak:
@@ -76,6 +76,78 @@ All endpoint probes (both built-in and application) produce standard Blackbox Ex
 | `probe_http_status_code`         | HTTP response status code                     |
 | `probe_ssl_earliest_cert_expiry` | SSL certificate expiration timestamp          |
 
+## Default probe alert rules
+
+UDS Core ships opinionated probe alert rules in the `uds-prometheus-config` chart. These rules cover endpoint downtime and TLS certificate expiry for any series emitted by Blackbox Exporter probes, including built-in Core probes and application probes you configure through the `Package` CR.
+
+### Shipped rules
+
+The following rules are enabled by default:
+
+| Rule | Default `for` | Default threshold | Default severity | Description |
+|---|---|---|---|---|
+| `UDSProbeEndpointDown` | `5m` | `probe_success == 0` | `warning` | Fires when a probe reports endpoint failure for longer than the configured duration |
+| `UDSProbeTLSExpiryWarning` | `10m` | certificate expires in less than `30` days | `warning` | Fires when a healthy probe reports a TLS certificate nearing expiry |
+| `UDSProbeTLSExpiryCritical` | `10m` | certificate expires in less than `14` days | `critical` | Fires when a healthy probe reports a TLS certificate nearing critical expiry |
+
+All three rules preserve probe labels from the source series, such as `instance` and `job`. UDS Core also adds the following labels to support routing and filtering:
+
+| Label | Value | Description |
+|---|---|---|
+| `severity` | value-specific | Alertmanager routing severity set by the matching `udsCoreDefaultAlerts.*.severity` field |
+| `source` | `blackbox` | Identifies the alert as originating from Blackbox Exporter probe data |
+| `category` | `probe` | Identifies the alert as a probe-focused alert rule |
+
+> [!NOTE]
+> The TLS expiry rules only evaluate for healthy probes. UDS Core joins the TLS expiry expression with `probe_success == 1`, so an unreachable endpoint does not trigger a false TLS expiry alert.
+
+### Configuration surface
+
+Use the following Helm values to tune or disable the built-in probe alert rules:
+
+> [!NOTE]
+> All field paths in the table below are relative to `udsCoreDefaultAlerts`.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `.enabled` | boolean | `true` | Enables or disables the full UDS Core default probe alert ruleset |
+| `.probeEndpointDown.enabled` | boolean | `true` | Enables or disables the `UDSProbeEndpointDown` rule |
+| `.probeEndpointDown.for` | string | `5m` | Sets how long `probe_success == 0` must remain true before `UDSProbeEndpointDown` fires |
+| `.probeEndpointDown.severity` | string | `warning` | Sets the `severity` label for `UDSProbeEndpointDown` |
+| `.probeTLSExpiryWarning.enabled` | boolean | `true` | Enables or disables the `UDSProbeTLSExpiryWarning` rule |
+| `.probeTLSExpiryWarning.for` | string | `10m` | Sets how long the TLS warning condition must remain true before `UDSProbeTLSExpiryWarning` fires |
+| `.probeTLSExpiryWarning.days` | integer | `30` | Sets the warning threshold, in days before certificate expiry |
+| `.probeTLSExpiryWarning.severity` | string | `warning` | Sets the `severity` label for `UDSProbeTLSExpiryWarning` |
+| `.probeTLSExpiryCritical.enabled` | boolean | `true` | Enables or disables the `UDSProbeTLSExpiryCritical` rule |
+| `.probeTLSExpiryCritical.for` | string | `10m` | Sets how long the TLS critical condition must remain true before `UDSProbeTLSExpiryCritical` fires |
+| `.probeTLSExpiryCritical.days` | integer | `14` | Sets the critical threshold, in days before certificate expiry |
+| `.probeTLSExpiryCritical.severity` | string | `critical` | Sets the `severity` label for `UDSProbeTLSExpiryCritical` |
+
+The following example shows common tuning patterns for the default probe alerts:
+
+```yaml title="uds-bundle.yaml"
+overrides:
+  kube-prometheus-stack:
+    uds-prometheus-config:
+      values:
+        # Disable all UDS Core default probe alerts
+        - path: udsCoreDefaultAlerts.enabled
+          value: false
+        # Disable only the endpoint-down alert
+        - path: udsCoreDefaultAlerts.probeEndpointDown.enabled
+          value: false
+        # Adjust TLS warning threshold and severity
+        - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.days
+          value: 21
+        - path: udsCoreDefaultAlerts.probeTLSExpiryWarning.severity
+          value: warning
+        # Adjust TLS critical threshold and severity
+        - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.days
+          value: 7
+        - path: udsCoreDefaultAlerts.probeTLSExpiryCritical.severity
+          value: critical
+```
+
 ## Application uptime probes
 
 Applications configure uptime monitoring through the `uptime` block on `expose` entries in the Package CR. The UDS Operator creates Prometheus Probe resources and configures Blackbox Exporter automatically. For step-by-step setup, see [Set up uptime monitoring](/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring/).
@@ -85,7 +157,7 @@ Applications configure uptime monitoring through the `uptime` block on `expose` 
 - [Monitoring & Observability concepts](/concepts/core-features/monitoring-observability/): high-level overview of the monitoring stack
 - [Set up uptime monitoring](/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring/): configure application uptime probes
 - [Capture application metrics](/how-to-guides/monitoring-and-observability/capture-application-metrics/): expose metrics from your application for Prometheus scraping
-- [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/): define PrometheusRule alerts for probe and application metrics
+- [Create metric alerting rules](/how-to-guides/monitoring-and-observability/create-metric-alerting-rules/): define custom `PrometheusRule` alerts and tune built-in defaults
 - [Create log-based alerting and recording rules](/how-to-guides/monitoring-and-observability/create-log-based-alerting-and-recording-rules/): configure Loki Ruler alerts and recording rules
 - [Route alerts to notification channels](/how-to-guides/monitoring-and-observability/route-alerts-to-notification-channels/): configure Alertmanager receivers and routing
 - [Add custom dashboards](/how-to-guides/monitoring-and-observability/add-custom-dashboards/): deploy Grafana dashboards alongside your application

--- a/docs/reference/configuration/monitoring-and-observability.md
+++ b/docs/reference/configuration/monitoring-and-observability.md
@@ -123,7 +123,7 @@ Use the following Helm values to tune or disable the built-in probe alert rules:
 | `.probeTLSExpiryCritical.days` | integer | `14` | Sets the critical threshold, in days before certificate expiry |
 | `.probeTLSExpiryCritical.severity` | string | `critical` | Sets the `severity` label for `UDSProbeTLSExpiryCritical` |
 
-The following example shows common tuning patterns for the default probe alerts:
+The following snippet shows several examples of how the default probe alert settings can be modified:
 
 ```yaml title="uds-bundle.yaml"
 overrides:

--- a/src/prometheus-stack/chart/templates/probe-alerting-rules.yaml
+++ b/src/prometheus-stack/chart/templates/probe-alerting-rules.yaml
@@ -1,0 +1,61 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+{{- $endpointDownEnabled := .Values.udsCoreDefaultAlerts.probeEndpointDown.enabled }}
+{{- $tlsWarningEnabled := .Values.udsCoreDefaultAlerts.probeTLSExpiryWarning.enabled }}
+{{- $tlsCriticalEnabled := .Values.udsCoreDefaultAlerts.probeTLSExpiryCritical.enabled }}
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.udsCoreDefaultAlerts.enabled (or $endpointDownEnabled $tlsWarningEnabled $tlsCriticalEnabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: uds-prometheus-stack-probe-alerts
+  namespace: {{ .Release.Namespace }}
+spec:
+  groups:
+    - name: uds-monitoring-probe-alerts
+      rules:
+        {{- if $endpointDownEnabled }}
+        - alert: UDSProbeEndpointDown
+          expr: probe_success == 0
+          for: {{ .Values.udsCoreDefaultAlerts.probeEndpointDown.for }}
+          labels:
+            severity: {{ .Values.udsCoreDefaultAlerts.probeEndpointDown.severity }}
+            source: blackbox
+            category: probe
+          annotations:
+            summary: "Endpoint probe down: {{`{{ $labels.instance }}`}}"
+            description: "Blackbox probe for {{`{{ $labels.instance }}`}} has reported probe_success=0 for more than {{ .Values.udsCoreDefaultAlerts.probeEndpointDown.for }}."
+        {{- end }}
+
+        {{- if $tlsWarningEnabled }}
+        - alert: UDSProbeTLSExpiryWarning
+          expr: |
+            ((probe_ssl_earliest_cert_expiry - time()) / 86400 < {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryWarning.days }})
+            and on(instance, job)
+            (probe_success == 1)
+          for: {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryWarning.for }}
+          labels:
+            severity: {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryWarning.severity }}
+            source: blackbox
+            category: probe
+          annotations:
+            summary: "TLS certificate expiring soon: {{`{{ $labels.instance }}`}}"
+            description: "TLS certificate for {{`{{ $labels.instance }}`}} expires in less than {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryWarning.days }} days."
+        {{- end }}
+
+        {{- if $tlsCriticalEnabled }}
+        - alert: UDSProbeTLSExpiryCritical
+          expr: |
+            ((probe_ssl_earliest_cert_expiry - time()) / 86400 < {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryCritical.days }})
+            and on(instance, job)
+            (probe_success == 1)
+          for: {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryCritical.for }}
+          labels:
+            severity: {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryCritical.severity }}
+            source: blackbox
+            category: probe
+          annotations:
+            summary: "TLS certificate expiring critically: {{`{{ $labels.instance }}`}}"
+            description: "TLS certificate for {{`{{ $labels.instance }}`}} expires in less than {{ .Values.udsCoreDefaultAlerts.probeTLSExpiryCritical.days }} days."
+        {{- end }}
+{{- end }}

--- a/src/prometheus-stack/chart/tests/probe_alerting_rules_no_crd_test.yaml
+++ b/src/prometheus-stack/chart/tests/probe_alerting_rules_no_crd_test.yaml
@@ -1,0 +1,16 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: UDS Prometheus probe alerting rules without PrometheusRule CRD
+templates:
+  - probe-alerting-rules.yaml
+capabilities:
+  apiVersions: []
+
+tests:
+  - it: should not render when monitoring.coreos.com/v1 is unavailable
+    template: probe-alerting-rules.yaml
+    asserts:
+      - notExists: {}

--- a/src/prometheus-stack/chart/tests/probe_alerting_rules_test.yaml
+++ b/src/prometheus-stack/chart/tests/probe_alerting_rules_test.yaml
@@ -1,0 +1,147 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: UDS Prometheus probe alerting rules
+templates:
+  - probe-alerting-rules.yaml
+capabilities:
+  apiVersions:
+    - monitoring.coreos.com/v1
+
+tests:
+  - it: should render probe alerting PrometheusRule by default
+    template: probe-alerting-rules.yaml
+    asserts:
+      - isKind:
+          of: PrometheusRule
+      - equal:
+          path: metadata.name
+          value: uds-prometheus-stack-probe-alerts
+      - equal:
+          path: spec.groups[0].name
+          value: uds-monitoring-probe-alerts
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeEndpointDown")]
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryWarning")]
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryCritical")]
+
+  - it: should not render probe alerts when top-level toggle is disabled
+    set:
+      udsCoreDefaultAlerts:
+        enabled: false
+    template: probe-alerting-rules.yaml
+    asserts:
+      - notExists: {}
+
+  - it: should not render probe alerts when all individual alerts are disabled
+    set:
+      udsCoreDefaultAlerts:
+        enabled: true
+        probeEndpointDown:
+          enabled: false
+        probeTLSExpiryWarning:
+          enabled: false
+        probeTLSExpiryCritical:
+          enabled: false
+    template: probe-alerting-rules.yaml
+    asserts:
+      - notExists: {}
+
+  - it: should not render endpoint down alert when probeEndpointDown is disabled
+    set:
+      udsCoreDefaultAlerts:
+        probeEndpointDown:
+          enabled: false
+    template: probe-alerting-rules.yaml
+    asserts:
+      - notExists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeEndpointDown")]
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryWarning")]
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryCritical")]
+
+  - it: should not render tls warning alert when probeTLSExpiryWarning is disabled
+    set:
+      udsCoreDefaultAlerts:
+        probeTLSExpiryWarning:
+          enabled: false
+    template: probe-alerting-rules.yaml
+    asserts:
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeEndpointDown")]
+      - notExists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryWarning")]
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryCritical")]
+
+  - it: should not render tls critical alert when probeTLSExpiryCritical is disabled
+    set:
+      udsCoreDefaultAlerts:
+        probeTLSExpiryCritical:
+          enabled: false
+    template: probe-alerting-rules.yaml
+    asserts:
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeEndpointDown")]
+      - exists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryWarning")]
+      - notExists:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryCritical")]
+
+  - it: should render override values for probeEndpointDown
+    set:
+      udsCoreDefaultAlerts:
+        probeEndpointDown:
+          for: 7m
+          severity: critical
+    template: probe-alerting-rules.yaml
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeEndpointDown")].for
+          value: 7m
+      - equal:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeEndpointDown")].labels.severity
+          value: critical
+
+  - it: should render override values for probeTLSExpiryWarning
+    set:
+      udsCoreDefaultAlerts:
+        probeTLSExpiryWarning:
+          for: 3m
+          days: 21
+          severity: info
+    template: probe-alerting-rules.yaml
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryWarning")].for
+          value: 3m
+      - equal:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryWarning")].labels.severity
+          value: info
+      - matchRegex:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryWarning")].expr
+          pattern: "< 21"
+
+  - it: should render override values for probeTLSExpiryCritical
+    set:
+      udsCoreDefaultAlerts:
+        probeTLSExpiryCritical:
+          for: 2m
+          days: 7
+          severity: high
+    template: probe-alerting-rules.yaml
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryCritical")].for
+          value: 2m
+      - equal:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryCritical")].labels.severity
+          value: high
+      - matchRegex:
+          path: spec.groups[0].rules[?(@.alert == "UDSProbeTLSExpiryCritical")].expr
+          pattern: "< 7"

--- a/src/prometheus-stack/chart/values.schema.json
+++ b/src/prometheus-stack/chart/values.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "additionalNetworkAllow": {
+      "type": "array",
+      "description": "Additional entries merged into the UDS Package spec.network.allow list. Ref: https://docs.defenseunicorns.com/core/reference/operator--crds/packages-v1alpha1-cr/#allow",
+      "items": {
+        "type": "object"
+      }
+    },
+    "rke2CorednsNetpol": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable the extra network policy needed for RKE2 CoreDNS deployments."
+        }
+      }
+    },
+    "udsCoreDefaultAlerts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable the UDS Core default probe alert rules shipped with this chart."
+        },
+        "probeEndpointDown": {
+          "$ref": "#/definitions/alertConfig"
+        },
+        "probeTLSExpiryWarning": {
+          "$ref": "#/definitions/tlsAlertConfig"
+        },
+        "probeTLSExpiryCritical": {
+          "$ref": "#/definitions/tlsAlertConfig"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "alertConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "for": {
+          "type": "string",
+          "description": "The duration for which the condition must remain true before the alert fires."
+        },
+        "severity": {
+          "type": "string",
+          "description": "Severity label applied to the rendered alert."
+        }
+      }
+    },
+    "tlsAlertConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "for": {
+          "type": "string",
+          "description": "The duration for which the condition must remain true before the alert fires."
+        },
+        "days": {
+          "type": "integer",
+          "description": "The certificate expiry threshold, in days."
+        },
+        "severity": {
+          "type": "string",
+          "description": "Severity label applied to the rendered alert."
+        }
+      }
+    }
+  }
+}

--- a/src/prometheus-stack/chart/values.yaml
+++ b/src/prometheus-stack/chart/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # Support for custom `network.allow` entries on the Package CR

--- a/src/prometheus-stack/chart/values.yaml
+++ b/src/prometheus-stack/chart/values.yaml
@@ -12,3 +12,21 @@ additionalNetworkAllow: []
 #     port: 443
 rke2CorednsNetpol:
   enabled: false
+
+# UDS Core opinionated default alerts shipped with this chart.
+udsCoreDefaultAlerts:
+  enabled: true
+  probeEndpointDown:
+    enabled: true
+    for: 5m
+    severity: warning
+  probeTLSExpiryWarning:
+    enabled: true
+    for: 10m
+    days: 30
+    severity: warning
+  probeTLSExpiryCritical:
+    enabled: true
+    for: 10m
+    days: 14
+    severity: critical

--- a/src/prometheus-stack/tasks.yaml
+++ b/src/prometheus-stack/tasks.yaml
@@ -65,12 +65,20 @@ tasks:
 
   - name: e2e-test
     actions:
+      - description: "Install vitest dependencies"
+        cmd: |
+          npm ci
+        dir: test/vitest
       - description: "Run Prometheus-Stack E2E tests"
         cmd: |
-          npm ci && npx vitest run "prometheus"
+          npx vitest run "prometheus"
+        dir: test/vitest
+      - description: "Run UDS Core default probe alert tests"
+        cmd: |
+          npx vitest run "default-probe-alerts"
         dir: test/vitest
       - description: "Run Blackbox Exporter integration tests"
         cmd: |
           echo "Running Blackbox Exporter integration tests..."
-          npm ci && npx vitest run "blackbox-exporter"
+          npx vitest run "blackbox-exporter"
         dir: test/vitest

--- a/src/prometheus-stack/tasks.yaml
+++ b/src/prometheus-stack/tasks.yaml
@@ -79,6 +79,5 @@ tasks:
         dir: test/vitest
       - description: "Run Blackbox Exporter integration tests"
         cmd: |
-          echo "Running Blackbox Exporter integration tests..."
           npx vitest run "blackbox-exporter"
         dir: test/vitest

--- a/test/vitest/default-probe-alerts.spec.ts
+++ b/test/vitest/default-probe-alerts.spec.ts
@@ -25,7 +25,14 @@ describe("UDS Core Default Alerts", { timeout: 180000, retry: 1 }, () => {
     "UDSProbeTLSExpiryCritical",
   ] as const;
 
-  const fetchAlertRuleNames = async (): Promise<string[]> => {
+  type PrometheusAlertRule = {
+    type?: string;
+    name?: string;
+    health?: string;
+    state?: string;
+  };
+
+  const fetchAlertRules = async (): Promise<PrometheusAlertRule[]> => {
     const response = await fetch(`${prometheusProxy.url}/api/v1/rules`);
     if (!response.ok) {
       throw new Error(`Prometheus rules API returned ${response.status}`);
@@ -35,10 +42,7 @@ describe("UDS Core Default Alerts", { timeout: 180000, retry: 1 }, () => {
       status: string;
       data?: {
         groups?: Array<{
-          rules?: Array<{
-            type?: string;
-            name?: string;
-          }>;
+          rules?: PrometheusAlertRule[];
         }>;
       };
     };
@@ -49,21 +53,26 @@ describe("UDS Core Default Alerts", { timeout: 180000, retry: 1 }, () => {
 
     return (body.data?.groups ?? [])
       .flatMap(group => group.rules ?? [])
-      .filter(rule => rule.type === "alerting" && Boolean(rule.name))
-      .map(rule => rule.name as string);
+      .filter(rule => rule.type === "alerting" && Boolean(rule.name));
   };
 
-  const expectAlertRulePresent = (alertName: string) =>
+  const expectAlertRuleHealthy = (alertName: string) =>
     pollUntilSuccess(
-      fetchAlertRuleNames,
-      names => names.includes(alertName),
-      `${alertName} alert rule to be loaded`,
+      async () => {
+        const rules = await fetchAlertRules();
+        return rules.find(rule => rule.name === alertName) ?? null;
+      },
+      rule => rule?.health === "ok" && rule?.state === "inactive",
+      `${alertName} alert rule to be loaded and healthy`,
       120000,
       5000,
     );
 
-  test.concurrent.each(alertRules)("alert rule %s should be loaded", async alertRule => {
-    const alertRuleNames = await expectAlertRulePresent(alertRule);
-    expect(alertRuleNames).toContain(alertRule);
+  test.concurrent.each(alertRules)("alert rule %s should be loaded and healthy", async alertRule => {
+    const rule = await expectAlertRuleHealthy(alertRule);
+    expect(rule).not.toBeNull();
+    expect(rule?.name).toBe(alertRule);
+    expect(rule?.health).toBe("ok");
+    expect(rule?.state).toBe("inactive");
   });
 });

--- a/test/vitest/default-probe-alerts.spec.ts
+++ b/test/vitest/default-probe-alerts.spec.ts
@@ -68,11 +68,14 @@ describe("UDS Core Default Alerts", { timeout: 180000, retry: 1 }, () => {
       5000,
     );
 
-  test.concurrent.each(alertRules)("alert rule %s should be loaded and healthy", async alertRule => {
-    const rule = await expectAlertRuleHealthy(alertRule);
-    expect(rule).not.toBeNull();
-    expect(rule?.name).toBe(alertRule);
-    expect(rule?.health).toBe("ok");
-    expect(rule?.state).toBe("inactive");
-  });
+  test.concurrent.each(alertRules)(
+    "alert rule %s should be loaded and healthy",
+    async alertRule => {
+      const rule = await expectAlertRuleHealthy(alertRule);
+      expect(rule).not.toBeNull();
+      expect(rule?.name).toBe(alertRule);
+      expect(rule?.health).toBe("ok");
+      expect(rule?.state).toBe("inactive");
+    },
+  );
 });

--- a/test/vitest/default-probe-alerts.spec.ts
+++ b/test/vitest/default-probe-alerts.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+import * as net from "net";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { closeForward, getForward } from "./helpers/forward";
+import { pollUntilSuccess } from "./helpers/polling";
+
+describe("UDS Core Default Alerts", { timeout: 180000, retry: 1 }, () => {
+  let prometheusProxy: { server: net.Server; url: string };
+
+  beforeAll(async () => {
+    prometheusProxy = await getForward("kube-prometheus-stack-prometheus", "monitoring", 9090);
+  });
+
+  afterAll(async () => {
+    await closeForward(prometheusProxy.server);
+  });
+
+  const alertRules = [
+    "UDSProbeEndpointDown",
+    "UDSProbeTLSExpiryWarning",
+    "UDSProbeTLSExpiryCritical",
+  ] as const;
+
+  const fetchAlertRuleNames = async (): Promise<string[]> => {
+    const response = await fetch(`${prometheusProxy.url}/api/v1/rules`);
+    if (!response.ok) {
+      throw new Error(`Prometheus rules API returned ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      status: string;
+      data?: {
+        groups?: Array<{
+          rules?: Array<{
+            type?: string;
+            name?: string;
+          }>;
+        }>;
+      };
+    };
+
+    if (body.status !== "success") {
+      throw new Error("Prometheus rules API did not return success");
+    }
+
+    return (body.data?.groups ?? [])
+      .flatMap(group => group.rules ?? [])
+      .filter(rule => rule.type === "alerting" && Boolean(rule.name))
+      .map(rule => rule.name as string);
+  };
+
+  const expectAlertRulePresent = (alertName: string) =>
+    pollUntilSuccess(
+      fetchAlertRuleNames,
+      names => names.includes(alertName),
+      `${alertName} alert rule to be loaded`,
+      120000,
+      5000,
+    );
+
+  test.concurrent.each(alertRules)("alert rule %s should be loaded", async alertRule => {
+    const alertRuleNames = await expectAlertRulePresent(alertRule);
+    expect(alertRuleNames).toContain(alertRule);
+  });
+});


### PR DESCRIPTION
## Description

Adds default UDS Core probe alert rules for endpoint downtime and TLS certificate expiry, with Helm-configurable thresholds, durations, and severities. 

### Included changes
- Adds default probe alerts via the `uds-prometheus-config` chart:
  - `UDSProbeEndpointDown`
  - `UDSProbeTLSExpiryWarning`
  - `UDSProbeTLSExpiryCritical`
- Includes Helm unittest and Vitest coverage for default probe alerts
- Updates monitoring docs across how-to, reference, concepts, and overview pages to document the new defaults and configuration paths

## Related Issue

Fixes # CORE-72

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
1. Run `uds run test-single-layer --set LAYER=monitoring` to deploy and run e2e tests
2. Use Grafana's web UI to verify presence and intended configuration of alerts


## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md) followed