### PR TITLE
fix: update registry1 istio to be compatible with latest bottlerocket fips amis

### DIFF
--- a/.github/test-infra/aws/eks/cluster.tf
+++ b/.github/test-infra/aws/eks/cluster.tf
@@ -3,7 +3,7 @@
 
 locals {
   # renovate: datasource=github-releases depName=bottlerocket-os/bottlerocket
-  bottlerocket_ami_version = "v1.53.0"
+  bottlerocket_ami_version = "v1.56.0"
 }
 
 data "aws_ami" "eks_bottlerocket_ami" {

--- a/src/istio/values/registry1/cni.yaml
+++ b/src/istio/values/registry1/cni.yaml
@@ -3,3 +3,7 @@
 
 cni:
   image: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.29.1-fips
+
+# Tetrate's FIPS image sets GODEBUG in an incompatible way with native Go FIPS on some node types (Bottlerocket FIPS)
+env:
+  GODEBUG: ""


### PR DESCRIPTION
## Description

...

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/2490

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)