### PR TITLE
docs: fix incorrect link to configuration overview on reference overview

### DIFF
--- a/docs/reference/overview.mdx
+++ b/docs/reference/overview.mdx
@@ -13,9 +13,9 @@ Authoritative details for UDS Core-specific configuration surfaces, CRD schemas,
     UDS Operator behavior, complete field-level schema reference for `Package`, `Exemption`, and `ClusterConfig` custom resources, and the Pepr policy engine.
     <LinkCard title="View reference" href="/reference/operator-and-crds/overview/" />
   </Card>
-  <Card title="Identity & Authorization" icon="setting">
-    Keycloak and Authservice configuration surfaces: SSO fields, group mapping, session behavior, and identity provider integration.
-    <LinkCard title="View reference" href="/reference/configuration/identity-and-authorization/" />
+  <Card title="Configuration" icon="setting">
+    Configuration surfaces exposed by UDS Core components.
+    <LinkCard title="View reference" href="/reference/configuration/overview/" />
   </Card>
   <Card title="Policies" icon="information">
     Versioning strategy, deprecation tracking, and security policy.


### PR DESCRIPTION
## Description

Replaces incorrect Identity and Authorization link/card on reference overview with link/card for Configuration overview page.

## Related Issue

Fixes # CORE-467

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Steps to Validate
- Run dev docs, navigate Core -> Reference, verify page content and replaced link to Configuration overview page is as-intended.

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
