### PR TITLE
fix(docs): llm friendly docs

### DIFF
--- a/.ai/docs/how-to-guide-template.md
+++ b/.ai/docs/how-to-guide-template.md
@@ -26,6 +26,7 @@ How-to guides live under `docs/how-to-guides/<section>/` and are grouped by doma
 ```mdx
 ---
 title: Topic Name
+description: One or two sentences describing what this page covers or what the reader will accomplish. Used in llms.txt, search, and SEO; required on every page.
 sidebar:
   order: X.XXX
 ---
@@ -151,6 +152,9 @@ uds zarf tools kubectl get pods -n namespace
 - Always list: **UDS CLI installed** and **Access to a Kubernetes cluster** (with guide-specific qualifiers like "(**multi-node**, multi-AZ recommended)")
 - If the guide references `registry.defenseunicorns.com` packages (e.g., bundle YAML with `repository: registry.defenseunicorns.com/...`), include: **[UDS Registry](https://registry.defenseunicorns.com) account created and authenticated locally with a read token**
 - Guide-specific items: external dependencies (e.g., external PostgreSQL), credential requirements, knowledge prereqs (e.g., familiarity with bundle overrides)
+
+### Frontmatter
+- `description:` is **required** on every page. Write 1–2 sentences in active voice describing what the page covers or what the reader will accomplish. This drives `llms.txt` navigation, search snippets, and SEO. A good description for a how-to guide starts with a verb: "Configure...", "Enable...", "Set up..." Example: "Configure valid TLS certificates for UDS Core ingress gateways using cert-manager, manual secrets, or cloud-managed certificate options."
 
 ### General
 - Use an optional "Before you begin" section for context about defaults or architecture; keep steps action-only

--- a/.ai/docs/reference-page-template.md
+++ b/.ai/docs/reference-page-template.md
@@ -28,6 +28,7 @@ Reference pages live under `docs/reference/<section>/` and use the `.md` extensi
 ```md
 ---
 title: Section Name
+description: One or two sentences describing what this reference page covers. Used in llms.txt, search, and SEO; required on every page. A good description summarizes what configuration surface is documented and who needs it.
 sidebar:
   order: X.XXX
 ---
@@ -99,6 +100,9 @@ overrides:
 - Minimize callouts in reference pages. Most information belongs in the table itself or prose
 - Use `> [!NOTE]` for timing constraints (e.g., "requires redeployment to take effect")
 - Use `> [!CAUTION]` for security implications only
+
+### Frontmatter
+- `description:` is **required** on every page. Write 1–2 sentences in active voice summarizing what configuration surface the page documents and who needs it. This drives `llms.txt` navigation, search snippets, and SEO. Example: "Complete reference for UDS Core identity and authorization configuration: Keycloak Helm values, realmInitEnv variables, theme and plugin settings, and SSO defaults."
 
 ### Related documentation
 - List external upstream docs (e.g., Keycloak, Istio) with brief descriptions

--- a/.ai/docs/release-notes-template.md
+++ b/.ai/docs/release-notes-template.md
@@ -35,6 +35,7 @@ Files are named by version number with hyphens replacing dots: `X-Y.mdx`
 ```mdx
 ---
 title: <Product> X.Y
+description: UDS Core X.Y release notes summarizing the key changes. One sentence covering the most significant breaking change or headline feature is ideal. Used in llms.txt, search, and SEO; required on every page.
 sidebar:
   order: N.NNN
 ---
@@ -118,6 +119,10 @@ Summary of what changed in this version and why it matters to operators (2-3 sen
 - Include a full diff link comparing the latest patch of the previous minor version to the latest patch of the current one (e.g., `v0.60.2...v0.61.1`, not `v0.60.0...v0.61.0`)
 - In the dependency updates table, link the "Updated" version to the upstream release page (e.g., GitHub release or project release page). Leave unlinked for entries without a meaningful upstream release page (e.g., DoD CA Certs)
 - When a Helm chart version is bumped independently of the application version, include it in the same dependency table with a "Helm chart" suffix in the package name (e.g., "Falco Helm chart", "Grafana Helm chart"). Link the updated version to the chart's release page.
+
+### Frontmatter
+
+- `description:` is **required** on every page. Write 1 sentence summarizing the key change in the release, typically the most significant breaking change or headline feature. This drives `llms.txt` navigation, search snippets, and SEO. Example: "UDS Core 0.63 release notes: built-in uptime observability with recording rules, Core Uptime dashboard, and standalone CRDs functional layer."
 
 ### Naming
 

--- a/.ai/docs/troubleshooting-runbook-template.md
+++ b/.ai/docs/troubleshooting-runbook-template.md
@@ -27,6 +27,7 @@ Runbooks live under `docs/operations/troubleshooting-and-runbooks/` and are `.md
 ```mdx
 ---
 title: Topic Name
+description: One or two sentences describing what issue this runbook addresses and what the reader will be able to do. Used in llms.txt, search, and SEO; required on every page. A good description starts with a verb: "Diagnose and resolve...", "Recover...", "Resize..."
 sidebar:
   order: X.XXX
 ---
@@ -157,6 +158,9 @@ If this runbook doesn't resolve your issue:
 - For procedural runbooks, Overview explains why the procedure is needed, "Pre-checks" covers preconditions, and Procedure is a single set of steps
 - Keep sections focused. If a section requires extensive configuration, link to the relevant how-to guide instead of duplicating it
 - Prevention tips should be `> [!TIP]` callouts inline within Procedure or Verification. Do not create a separate Prevention section
+
+### Frontmatter
+- `description:` is **required** on every page. Write 1–2 sentences summarizing what issue the runbook addresses and what the reader will accomplish. This drives `llms.txt` navigation, search snippets, and SEO. Example: "Diagnose and resolve issues where UDS Exemption or Package CRs are not being reconciled by the UDS Operator."
 
 ### Formatting
 - Files use `.mdx` extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We appreciate contributions in several forms:
 - **Report Issues or Bugs**: If you encounter a problem, feel free to open a [GitHub issue](https://github.com/defenseunicorns/uds-core/issues/new?template=bug_report.md). Include details on your environment, how to reproduce the bug, and any relevant logs or screenshots. This helps us improve UDS Core’s stability.
 - **Suggest Enhancements**: Have an idea for a new feature or an improvement? You can [open an issue](https://github.com/defenseunicorns/uds-core/issues/new?template=feature_request.md) to propose it. For significant feature ideas, please start with an issue only to gather feedback before spending time on code. This ensures the idea aligns with our project goals and roadmap, which is primarily driven by internal needs (we’ll evaluate suggestions for alignment).
 - **Submit Code Changes (Pull Requests)**: You can contribute fixes, minor enhancements, or even new features via pull requests (PRs). We especially welcome contributions that fix bugs or improve performance/stability. If you plan to work on something, it’s a good idea to open an issue first to ensure you are aligned with the maintainers.
-- **Improve Documentation**: Contributions to documentation (e.g. tutorials, configuration reference, even code comments) are valuable. If you find areas of the docs that can be clearer, you can submit changes. Follow the [style rules](docs/dev/style-rules.md) and [voice profile](docs/dev/voice-profile.md) for writing conventions, and the templates in `.ai/docs/` for page structure.
+- **Improve Documentation**: Contributions to documentation (e.g. tutorials, configuration reference, even code comments) are valuable. If you find areas of the docs that can be clearer, you can submit changes. Follow the [style rules](docs/dev/style-rules.md) and [voice profile](docs/dev/voice-profile.md) for writing conventions, and the templates in `.ai/docs/` for page structure. See [Documentation Standards](#documentation-standards) below for requirements.
 
 Please note that large-scale changes or new features might not be immediately incorporated if they don’t fit with our current focus. We’ll do our best to communicate politely and provide guidance on such contributions (e.g. suggesting a smaller scope or alternative approaches) – our intent is not to discourage ideas, but to keep the project stable and aligned with its vision.
 
@@ -161,6 +161,61 @@ When opening a pull request make sure to follow the below guidelines to ensure t
 > When submitting a pull request (PR) from a forked repository, please note that our CI/CD processes may not run completely due to security restrictions. This is because certain secrets required for the full CI/CD pipeline are not accessible from forks.
 >
 > If you notice CI/CD failures, it might be due to these limitations rather than issues with your code. Our maintainers will review your PR and, if necessary, check out your branch and push it to the main repository. This step allows the full CI/CD process to run with the required secrets, ensuring that all checks are performed.
+
+## Documentation Standards
+
+All documentation contributions must follow these standards.
+
+### Page structure
+
+Use the templates in `.ai/docs/` for the correct structure for each page type:
+
+| Page type | Template |
+|---|---|
+| How-to guide | `.ai/docs/how-to-guide-template.md` |
+| Reference page | `.ai/docs/reference-page-template.md` |
+| Troubleshooting runbook | `.ai/docs/troubleshooting-runbook-template.md` |
+| Release notes | `.ai/docs/release-notes-template.md` |
+
+For voice, tone, and formatting conventions that apply across all page types, see [docs/dev/style-rules.md](docs/dev/style-rules.md) and [docs/dev/voice-profile.md](docs/dev/voice-profile.md).
+
+### Required: `description` frontmatter
+
+Every docs page must have a `description` field in its frontmatter. This is not optional.
+
+```yaml
+---
+title: Configure TLS certificates for gateways
+description: Configure valid TLS certificates for UDS Core ingress gateways using cert-manager, manual secrets, or cloud-managed certificate options.
+sidebar:
+  order: X.XXX
+---
+```
+
+**Why it's required:**
+- **`llms.txt`**: the description appears next to each page in the AI-readable docs index so LLMs can navigate to the right content. Without it, AI-assisted answers about UDS Core degrade.
+- **Search**: used as the snippet below each search result on the docs site.
+- **SEO**: used as the HTML `<meta name="description">` tag.
+
+**Writing a good description** (1–2 sentences, active voice):
+- How-to guide: start with a verb, e.g. "Configure...", "Enable...", "Set up..."
+- Reference page: summarize what configuration surface is documented, e.g. "Complete reference for..."
+- Concept page: describe how the component works, e.g. "How UDS Core uses Falco to detect runtime threats..."
+- Runbook: start with "Diagnose and resolve..." or "Recover..."
+- Overview/index page: start with "Guides for..." or "Index of...", e.g. "Guides for configuring UDS Core networking: TLS, gateways, and network access rules."
+- Release notes: "UDS Core X.Y release notes: [headline feature or breaking change]."
+- Avoid "This page..." or "Learn about..." openings
+
+### Where docs live
+
+Product docs live under `docs/` in this repo and are published to the UDS docs site via automated integration. Docs are organized into these sections (controlled by `docs/docs.config.json`):
+- `docs/getting-started/`: installation and first deployment steps
+- `docs/concepts/`: architectural concepts and feature explanations
+- `docs/how-to-guides/`: task-oriented configuration guides
+- `docs/reference/`: configuration surfaces, CRD schemas, policies
+- `docs/operations/`: upgrades, troubleshooting runbooks, release notes
+
+The `docs/dev/` directory contains internal development documentation (style guides, CI setup) that is not published to the public docs site.
 
 ## Additional Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We appreciate contributions in several forms:
 - **Report Issues or Bugs**: If you encounter a problem, feel free to open a [GitHub issue](https://github.com/defenseunicorns/uds-core/issues/new?template=bug_report.md). Include details on your environment, how to reproduce the bug, and any relevant logs or screenshots. This helps us improve UDS Core’s stability.
 - **Suggest Enhancements**: Have an idea for a new feature or an improvement? You can [open an issue](https://github.com/defenseunicorns/uds-core/issues/new?template=feature_request.md) to propose it. For significant feature ideas, please start with an issue only to gather feedback before spending time on code. This ensures the idea aligns with our project goals and roadmap, which is primarily driven by internal needs (we’ll evaluate suggestions for alignment).
 - **Submit Code Changes (Pull Requests)**: You can contribute fixes, minor enhancements, or even new features via pull requests (PRs). We especially welcome contributions that fix bugs or improve performance/stability. If you plan to work on something, it’s a good idea to open an issue first to ensure you are aligned with the maintainers.
-- **Improve Documentation**: Contributions to documentation (e.g. tutorials, configuration reference, even code comments) are valuable. If you find areas of the docs that can be clearer, you can submit changes. Follow the [style rules](docs/dev/style-rules.md) and [voice profile](docs/dev/voice-profile.md) for writing conventions, and the templates in `.ai/docs/` for page structure. See [Documentation Standards](#documentation-standards) below for requirements.
+- **Improve Documentation**: Contributions to documentation (e.g. tutorials, configuration reference, even code comments) are valuable. If you find areas of the docs that can be clearer, you can submit changes. Follow the [style rules](docs/dev/style-rules.md) and [voice profile](docs/dev/voice-profile.md) for writing conventions, and the templates in `.ai/docs/` for page structure.
 
 Please note that large-scale changes or new features might not be immediately incorporated if they don’t fit with our current focus. We’ll do our best to communicate politely and provide guidance on such contributions (e.g. suggesting a smaller scope or alternative approaches) – our intent is not to discourage ideas, but to keep the project stable and aligned with its vision.
 
@@ -161,61 +161,6 @@ When opening a pull request make sure to follow the below guidelines to ensure t
 > When submitting a pull request (PR) from a forked repository, please note that our CI/CD processes may not run completely due to security restrictions. This is because certain secrets required for the full CI/CD pipeline are not accessible from forks.
 >
 > If you notice CI/CD failures, it might be due to these limitations rather than issues with your code. Our maintainers will review your PR and, if necessary, check out your branch and push it to the main repository. This step allows the full CI/CD process to run with the required secrets, ensuring that all checks are performed.
-
-## Documentation Standards
-
-All documentation contributions must follow these standards.
-
-### Page structure
-
-Use the templates in `.ai/docs/` for the correct structure for each page type:
-
-| Page type | Template |
-|---|---|
-| How-to guide | `.ai/docs/how-to-guide-template.md` |
-| Reference page | `.ai/docs/reference-page-template.md` |
-| Troubleshooting runbook | `.ai/docs/troubleshooting-runbook-template.md` |
-| Release notes | `.ai/docs/release-notes-template.md` |
-
-For voice, tone, and formatting conventions that apply across all page types, see [docs/dev/style-rules.md](docs/dev/style-rules.md) and [docs/dev/voice-profile.md](docs/dev/voice-profile.md).
-
-### Required: `description` frontmatter
-
-Every docs page must have a `description` field in its frontmatter. This is not optional.
-
-```yaml
----
-title: Configure TLS certificates for gateways
-description: Configure valid TLS certificates for UDS Core ingress gateways using cert-manager, manual secrets, or cloud-managed certificate options.
-sidebar:
-  order: X.XXX
----
-```
-
-**Why it's required:**
-- **`llms.txt`**: the description appears next to each page in the AI-readable docs index so LLMs can navigate to the right content. Without it, AI-assisted answers about UDS Core degrade.
-- **Search**: used as the snippet below each search result on the docs site.
-- **SEO**: used as the HTML `<meta name="description">` tag.
-
-**Writing a good description** (1–2 sentences, active voice):
-- How-to guide: start with a verb, e.g. "Configure...", "Enable...", "Set up..."
-- Reference page: summarize what configuration surface is documented, e.g. "Complete reference for..."
-- Concept page: describe how the component works, e.g. "How UDS Core uses Falco to detect runtime threats..."
-- Runbook: start with "Diagnose and resolve..." or "Recover..."
-- Overview/index page: start with "Guides for..." or "Index of...", e.g. "Guides for configuring UDS Core networking: TLS, gateways, and network access rules."
-- Release notes: "UDS Core X.Y release notes: [headline feature or breaking change]."
-- Avoid "This page..." or "Learn about..." openings
-
-### Where docs live
-
-Product docs live under `docs/` in this repo and are published to the UDS docs site via automated integration. Docs are organized into these sections (controlled by `docs/docs.config.json`):
-- `docs/getting-started/`: installation and first deployment steps
-- `docs/concepts/`: architectural concepts and feature explanations
-- `docs/how-to-guides/`: task-oriented configuration guides
-- `docs/reference/`: configuration surfaces, CRD schemas, policies
-- `docs/operations/`: upgrades, troubleshooting runbooks, release notes
-
-The `docs/dev/` directory contains internal development documentation (style guides, CI setup) that is not published to the public docs site.
 
 ## Additional Notes
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,5 +1,6 @@
 ---
 title: Deprecations
+description: Complete reference for UDS Core deprecations: currently deprecated features and their scheduled removal versions.
 sidebar:
   order: 2.2
 ---

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,6 +1,6 @@
 ---
 title: Deprecations
-description: Complete reference for UDS Core deprecations: currently deprecated features and their scheduled removal versions.
+description: Complete reference for UDS Core deprecations, listing currently deprecated features and their scheduled removal versions.
 sidebar:
   order: 2.2
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 ---
 title: Security Policy
-description: UDS Core security policy: supported version window for patch support and instructions for reporting vulnerabilities.
+description: UDS Core security policy covering the supported version window for patch support and instructions for reporting vulnerabilities.
 sidebar:
   order: 2.3
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,6 @@
 ---
 title: Security Policy
+description: UDS Core security policy: supported version window for patch support and instructions for reporting vulnerabilities.
 sidebar:
   order: 2.3
 ---

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,5 +1,6 @@
 ---
 title: Versioning
+description: UDS Core versioning policy defining what constitutes the API surface and what changes require a major version increment.
 sidebar:
   order: 2.1
 ---

--- a/docs/concepts/configuration-and-packaging/bundles.mdx
+++ b/docs/concepts/configuration-and-packaging/bundles.mdx
@@ -1,5 +1,6 @@
 ---
 title: Bundles
+description: How UDS Bundles combine Zarf packages with environment configuration into a single versioned artifact defined in uds-bundle.yaml.
 sidebar:
   order: 4.001
 ---

--- a/docs/concepts/configuration-and-packaging/crd-overviews.mdx
+++ b/docs/concepts/configuration-and-packaging/crd-overviews.mdx
@@ -1,5 +1,6 @@
 ---
 title: Core CRDs
+description: How the three UDS custom resources (Package, Exemption, and ClusterConfig) tell the UDS Operator what to configure at the application and cluster level.
 sidebar:
   order: 4.002
 ---

--- a/docs/concepts/configuration-and-packaging/overview.mdx
+++ b/docs/concepts/configuration-and-packaging/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration and Packaging
+description: How UDS separates delivery (Zarf packages and bundles) from platform integration (UDS Operator CRDs) and how the two work together.
 sidebar:
   order: 4.000
 ---

--- a/docs/concepts/configuration-and-packaging/package-requirements.mdx
+++ b/docs/concepts/configuration-and-packaging/package-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Package Requirements
+description: How UDS Packages must integrate with the UDS Operator, meet security requirements, and follow Zarf packaging standards.
 sidebar:
   order: 4.003
 ---

--- a/docs/concepts/core-features/backup-restore.mdx
+++ b/docs/concepts/core-features/backup-restore.mdx
@@ -1,5 +1,6 @@
 ---
 title: Backup & Restore
+description: How UDS Core uses Velero to provide cluster-level backup and restore for Kubernetes resources and persistent volumes.
 sidebar:
   order: 2.006
 ---

--- a/docs/concepts/core-features/identity-and-authorization.mdx
+++ b/docs/concepts/core-features/identity-and-authorization.mdx
@@ -1,5 +1,6 @@
 ---
 title: Identity & Authorization
+description: How UDS Core centralizes authentication using Keycloak and Authservice, and when to use native OIDC versus Authservice for apps without SSO support.
 sidebar:
   order: 2.002
 ---

--- a/docs/concepts/core-features/logging.mdx
+++ b/docs/concepts/core-features/logging.mdx
@@ -1,5 +1,6 @@
 ---
 title: Logging
+description: How UDS Core uses Vector and Loki to collect, aggregate, and make queryable all cluster logs for both platform and application workloads.
 sidebar:
   order: 2.004
 ---

--- a/docs/concepts/core-features/monitoring-observability.mdx
+++ b/docs/concepts/core-features/monitoring-observability.mdx
@@ -1,5 +1,6 @@
 ---
 title: Monitoring & Observability
+description: How UDS Core's built-in Prometheus, Grafana, and Alertmanager stack provides automatic instrumentation, dashboards, and alerting for platform components.
 sidebar:
   order: 2.003
 ---

--- a/docs/concepts/core-features/networking.mdx
+++ b/docs/concepts/core-features/networking.mdx
@@ -1,5 +1,6 @@
 ---
 title: Networking & Service Mesh
+description: How Istio provides mTLS, authorization policies, and ingress/egress control as the service mesh backbone of UDS Core.
 sidebar:
   order: 2.001
 ---

--- a/docs/concepts/core-features/overview.mdx
+++ b/docs/concepts/core-features/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Core Features
+description: Index of UDS Core capability concept pages covering networking, identity, observability, logging, policy, runtime security, and backup.
 sidebar:
   order: 2.000
 ---

--- a/docs/concepts/core-features/policy-and-compliance.mdx
+++ b/docs/concepts/core-features/policy-and-compliance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Policy & Compliance
+description: How UDS Core uses Pepr admission webhooks to enforce security policies through automatic mutation and validation of Kubernetes resources.
 sidebar:
   order: 2.007
 ---

--- a/docs/concepts/core-features/runtime-security.mdx
+++ b/docs/concepts/core-features/runtime-security.mdx
@@ -1,5 +1,6 @@
 ---
 title: Runtime Security
+description: How UDS Core uses Falco to detect runtime threats by monitoring system calls, file access, and network connections inside running containers.
 sidebar:
   order: 2.005
 ---

--- a/docs/concepts/overview.mdx
+++ b/docs/concepts/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Concepts
+description: Index of UDS Core concept pages covering platform architecture, functional layers, core features, configuration, and packaging.
 sidebar:
   order: 1.000
 ---

--- a/docs/concepts/platform/environments.mdx
+++ b/docs/concepts/platform/environments.mdx
@@ -1,5 +1,6 @@
 ---
 title: Environments
+description: How UDS Core runs consistently from local dev to production using the same packages and policy baseline, with only cluster-level configuration differing.
 sidebar:
   order: 3.003
 ---

--- a/docs/concepts/platform/flavors.mdx
+++ b/docs/concepts/platform/flavors.mdx
@@ -1,5 +1,6 @@
 ---
 title: Flavors (Core Variants)
+description: How the three UDS Core flavors (upstream, registry1, unicorn) differ in image source, hardening posture, and availability.
 sidebar:
   order: 3.005
 ---

--- a/docs/concepts/platform/functional-layers.mdx
+++ b/docs/concepts/platform/functional-layers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Functional Layers
+description: How UDS Core's functional layers let you deploy only the platform capabilities your environment needs instead of the full package.
 sidebar:
   order: 3.001
 ---

--- a/docs/concepts/platform/overview.mdx
+++ b/docs/concepts/platform/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Platform
+description: How UDS Core provides shared platform services including networking, identity, observability, security, and backup on Kubernetes.
 sidebar:
   order: 3.000
 ---

--- a/docs/concepts/platform/platform-vs-app-layer.mdx
+++ b/docs/concepts/platform/platform-vs-app-layer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Platform vs Application Layer
+description: How UDS Core separates the platform layer (networking, identity, observability) from the application layer and where each ownership boundary falls.
 sidebar:
   order: 3.004
 ---

--- a/docs/concepts/platform/security.mdx
+++ b/docs/concepts/platform/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: Security
+description: How UDS Core implements defense-in-depth security across supply chain, airgap readiness, zero-trust networking, admission control, and compliance.
 sidebar:
   order: 3.006
 ---

--- a/docs/concepts/platform/supported-distributions.mdx
+++ b/docs/concepts/platform/supported-distributions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Supported Distributions
+description: How UDS Core tests compatibility across supported Kubernetes distributions (K3s/k3d, EKS, AKS, RKE2) and what each CI coverage level means.
 sidebar:
   order: 3.002
 ---

--- a/docs/concepts/platform/versioning-and-releases.mdx
+++ b/docs/concepts/platform/versioning-and-releases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Versioning & Releases
+description: How UDS Core applies semantic versioning with a two-week release cadence and defined criteria for patch, minor, and major releases.
 sidebar:
   order: 3.007
 ---

--- a/docs/docs.config.json
+++ b/docs/docs.config.json
@@ -2,6 +2,7 @@
   "id": "core",
   "label": "Core",
   "contentDir": "core",
+  "description": "The platform layer deployed onto a Kubernetes cluster. Bundles Istio (service mesh and ingress), Keycloak (identity and SSO), Authservice (SSO proxy for apps without native OIDC), Prometheus + Grafana + Alertmanager (monitoring), Vector + Loki (logging), Falco (runtime security), and Pepr (policy engine and operator framework). Exposes UDS Package, UDS Exemption, and UDS ClusterConfig CRDs for application and platform integration.",
   "sidebarOrder": [
     "getting-started",
     "concepts",

--- a/docs/getting-started/local-demo/basic-requirements.mdx
+++ b/docs/getting-started/local-demo/basic-requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set Up Your Environment
+description: Verify your local environment meets the CPU, RAM, and storage requirements before running the UDS Core local demo.
 next: true
 sidebar:
   order: 2.001

--- a/docs/getting-started/local-demo/install-and-deploy-uds.mdx
+++ b/docs/getting-started/local-demo/install-and-deploy-uds.mdx
@@ -1,5 +1,6 @@
 ---
 title: Install and Deploy UDS
+description: Install the UDS CLI and deploy the k3d-core-demo bundle to create a running local UDS Core cluster.
 prev: true
 next: true
 sidebar:

--- a/docs/getting-started/local-demo/integrate-your-package.mdx
+++ b/docs/getting-started/local-demo/integrate-your-package.mdx
@@ -1,5 +1,6 @@
 ---
 title: Add Your Own Package (Optional)
+description: Package a sample application and deploy it alongside UDS Core to see Istio ingress and Keycloak SSO wired up automatically by the UDS Operator.
 prev: true
 sidebar:
   order: 2.003

--- a/docs/getting-started/local-demo/overview.mdx
+++ b/docs/getting-started/local-demo/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Local Demo
+description: Deploy a full UDS Core environment locally on k3d, including Keycloak, Istio, Grafana, Loki, and Falco, in about 15 minutes.
 next: true
 sidebar:
   order: 2.000

--- a/docs/getting-started/overview.mdx
+++ b/docs/getting-started/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started with UDS Core
-description: Guides for getting started with UDS Core: choose between a local k3d demo or a production Kubernetes deployment.
+description: Guides for getting started with UDS Core, covering a local k3d demo and production Kubernetes deployment options.
 sidebar:
   order: 1.000
 ---

--- a/docs/getting-started/overview.mdx
+++ b/docs/getting-started/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started with UDS Core
+description: Guides for getting started with UDS Core: choose between a local k3d demo or a production Kubernetes deployment.
 sidebar:
   order: 1.000
 ---

--- a/docs/getting-started/production/build-your-bundle.mdx
+++ b/docs/getting-started/production/build-your-bundle.mdx
@@ -1,5 +1,6 @@
 ---
 title: Build Your Bundle
+description: Create the uds-bundle.yaml and uds-config.yaml that configure UDS Core for your environment, including flavor selection and bundle overrides.
 prev: true
 next: true
 sidebar:

--- a/docs/getting-started/production/deploy.mdx
+++ b/docs/getting-started/production/deploy.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploy to Production
+description: Deploy your configured UDS Core bundle to a production Kubernetes cluster and verify all components are healthy.
 prev: true
 sidebar:
   order: 3.004

--- a/docs/getting-started/production/overview.mdx
+++ b/docs/getting-started/production/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Production
+description: Deploy UDS Core to a real Kubernetes cluster for production use, bringing your own infrastructure and environment-specific configuration.
 next: true
 sidebar:
   order: 3.000

--- a/docs/getting-started/production/prerequisites.mdx
+++ b/docs/getting-started/production/prerequisites.mdx
@@ -1,5 +1,6 @@
 ---
 title: Prerequisites
+description: Verify Kubernetes distribution compatibility, resource requirements, and access prerequisites before deploying UDS Core to production.
 next: true
 sidebar:
   order: 3.001

--- a/docs/getting-started/production/provision-services.mdx
+++ b/docs/getting-started/production/provision-services.mdx
@@ -1,5 +1,6 @@
 ---
 title: Provision External Services
+description: Provision the external services UDS Core requires (DNS, TLS certificates, object storage, and a Keycloak database) before building your bundle.
 prev: true
 next: true
 sidebar:

--- a/docs/how-to-guides/backup-and-restore/configure-storage-backends.mdx
+++ b/docs/how-to-guides/backup-and-restore/configure-storage-backends.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Velero storage backends
+description: Configure Velero's backup storage destination, credentials, and retention schedule for a UDS Core deployment.
 sidebar:
   order: 7.001
 ---

--- a/docs/how-to-guides/backup-and-restore/enable-volume-snapshots-aws-ebs.mdx
+++ b/docs/how-to-guides/backup-and-restore/enable-volume-snapshots-aws-ebs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enable volume snapshots (AWS EBS)
+description: Enable Velero to capture persistent volume data using AWS EBS snapshots so backups include both Kubernetes resources and application disk state.
 sidebar:
   order: 7.002
 ---

--- a/docs/how-to-guides/backup-and-restore/enable-volume-snapshots-vsphere.mdx
+++ b/docs/how-to-guides/backup-and-restore/enable-volume-snapshots-vsphere.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enable volume snapshots (vSphere CSI)
+description: Enable Velero to capture persistent volume data using vSphere CSI snapshots on an RKE2 cluster.
 sidebar:
   order: 7.003
 ---

--- a/docs/how-to-guides/backup-and-restore/overview.mdx
+++ b/docs/how-to-guides/backup-and-restore/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Backup & restore
+description: Guides for configuring Velero storage backends, enabling volume snapshots, and performing backup and restore operations in UDS Core.
 sidebar:
   order: 7.000
 ---

--- a/docs/how-to-guides/backup-and-restore/perform-backup.mdx
+++ b/docs/how-to-guides/backup-and-restore/perform-backup.mdx
@@ -1,5 +1,6 @@
 ---
 title: Perform a manual backup
+description: Verify scheduled Velero backups are running and trigger a manual backup on demand.
 sidebar:
   order: 7.004
 ---

--- a/docs/how-to-guides/backup-and-restore/perform-restore.mdx
+++ b/docs/how-to-guides/backup-and-restore/perform-restore.mdx
@@ -1,5 +1,6 @@
 ---
 title: Restore from a backup
+description: Restore specific namespaces from a completed Velero backup and confirm the restored state.
 sidebar:
   order: 7.005
 ---

--- a/docs/how-to-guides/high-availability/authservice.mdx
+++ b/docs/how-to-guides/high-availability/authservice.mdx
@@ -1,5 +1,6 @@
 ---
 title: Authservice
+description: Configure Authservice for production HA by connecting it to an external Redis or Valkey session store and scaling to multiple replicas.
 sidebar:
   order: 1.004
 ---

--- a/docs/how-to-guides/high-availability/keycloak.mdx
+++ b/docs/how-to-guides/high-availability/keycloak.mdx
@@ -1,5 +1,6 @@
 ---
 title: Keycloak
+description: Configure Keycloak for production HA with an external PostgreSQL database, horizontal pod autoscaling, and Istio waypoint proxy scaling.
 sidebar:
   order: 1.001
 ---

--- a/docs/how-to-guides/high-availability/logging.mdx
+++ b/docs/how-to-guides/high-availability/logging.mdx
@@ -1,6 +1,6 @@
 ---
 title: Logging
-description: Configure the logging pipeline for production HA: connect Loki to external S3-compatible storage and tune replica counts and Vector resource allocation.
+description: Configure the logging pipeline for production HA by connecting Loki to external S3-compatible storage and tuning replica counts and Vector resource allocation.
 sidebar:
   order: 1.002
 ---

--- a/docs/how-to-guides/high-availability/logging.mdx
+++ b/docs/how-to-guides/high-availability/logging.mdx
@@ -1,5 +1,6 @@
 ---
 title: Logging
+description: Configure the logging pipeline for production HA: connect Loki to external S3-compatible storage and tune replica counts and Vector resource allocation.
 sidebar:
   order: 1.002
 ---

--- a/docs/how-to-guides/high-availability/monitoring.mdx
+++ b/docs/how-to-guides/high-availability/monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: Monitoring
+description: Configure the monitoring stack for production HA: multi-replica Grafana with external PostgreSQL, Prometheus resource allocation, and storage sizing.
 sidebar:
   order: 1.003
 ---

--- a/docs/how-to-guides/high-availability/monitoring.mdx
+++ b/docs/how-to-guides/high-availability/monitoring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Configure the monitoring stack for production HA: multi-replica Grafana with external PostgreSQL, Prometheus resource allocation, and storage sizing.
+description: Configure the monitoring stack for production HA with multi-replica Grafana on external PostgreSQL, Prometheus resource allocation, and storage sizing.
 sidebar:
   order: 1.003
 ---

--- a/docs/how-to-guides/high-availability/overview.mdx
+++ b/docs/how-to-guides/high-availability/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: High Availability
+description: Guides for configuring high availability per component: redundancy, autoscaling, and fault tolerance across the UDS Core platform stack.
 sidebar:
   order: 1.000
 ---

--- a/docs/how-to-guides/high-availability/overview.mdx
+++ b/docs/how-to-guides/high-availability/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: High Availability
-description: Guides for configuring high availability per component: redundancy, autoscaling, and fault tolerance across the UDS Core platform stack.
+description: Guides for configuring high availability per component, covering redundancy, autoscaling, and fault tolerance across the UDS Core platform stack.
 sidebar:
   order: 1.000
 ---

--- a/docs/how-to-guides/high-availability/runtime-security.mdx
+++ b/docs/how-to-guides/high-availability/runtime-security.mdx
@@ -1,5 +1,6 @@
 ---
 title: Runtime Security
+description: Verify and tune HA defaults for Falco and Falcosidekick so runtime threat detection and alert delivery remain available during node failures.
 sidebar:
   order: 1.005
 ---

--- a/docs/how-to-guides/high-availability/service-mesh.mdx
+++ b/docs/how-to-guides/high-availability/service-mesh.mdx
@@ -1,5 +1,6 @@
 ---
 title: Service Mesh
+description: Configure Istio's control plane and ingress gateways for production HA with minimum replica counts, resource tuning, and pod anti-affinity.
 sidebar:
   order: 1.006
 ---

--- a/docs/how-to-guides/identity-and-authorization/build-deploy-custom-image.mdx
+++ b/docs/how-to-guides/identity-and-authorization/build-deploy-custom-image.mdx
@@ -1,5 +1,6 @@
 ---
 title: Build a custom Keycloak configuration image
+description: Build a custom uds-identity-config image with your Keycloak theme, plugin, or truststore changes and deploy it via the configImage Helm override.
 sidebar:
   order: 3.007
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-account-lockout.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-account-lockout.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Keycloak account lockout
+description: Configure Keycloak's brute-force protection to set temporary and permanent account lockout thresholds via bundle overrides.
 sidebar:
   order: 3.011
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-authentication-flows.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-authentication-flows.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Keycloak authentication methods
+description: Enable or disable Keycloak login methods (including X.509/CAC, WebAuthn, OTP, and social login) using bundle overrides.
 sidebar:
   order: 3.003
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-device-flow.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-device-flow.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure OAuth 2.0 device flow
+description: Configure a UDS Package to use OAuth 2.0 Device Authorization Grant for CLI tools and headless devices that cannot use browser-based redirects.
 sidebar:
   order: 3.010
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-google-idp.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-google-idp.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Google SAML as an identity provider
+description: Connect Google SAML as an external identity provider in Keycloak using bundle overrides, with no Keycloak admin UI configuration required.
 sidebar:
   order: 3.015
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-http-retries.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-http-retries.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Keycloak HTTP retries
+description: Enable and tune Keycloak's outbound HTTP retry behavior for requests to external identity providers and services.
 sidebar:
   order: 3.006
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-login-policies.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-login-policies.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Keycloak login policies
+description: Configure Keycloak session limits, idle timeouts, and logout confirmation behavior via bundle overrides.
 sidebar:
   order: 3.005
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-notifications-and-alerts.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-notifications-and-alerts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Keycloak notifications and alerts
+description: Enable Prometheus alerting rules for Keycloak realm and user account changes, routing notifications through Alertmanager.
 sidebar:
   order: 3.019
 ---
@@ -62,7 +63,7 @@ Because logging and dashboards are enabled by default, you can already view Keyc
    | `KeycloakSystemAdminModificationsDetected` | **critical:** Fires on system administrator membership changes within a 5-minute window |
 
    > [!NOTE]
-   > `KeycloakSystemAdminModificationsDetected` uses two detection branches. When `JSONLogEventListenerProvider` is active, it filters specifically on `/UDS Core/Admin` group membership changes. When the standard `org.keycloak.events` logger is active, it matches all `USER|GROUP_MEMBERSHIP` resource changes — that logger does not expose group paths, so narrower filtering is not possible.
+   > `KeycloakSystemAdminModificationsDetected` uses two detection branches. When `JSONLogEventListenerProvider` is active, it filters specifically on `/UDS Core/Admin` group membership changes. When the standard `org.keycloak.events` logger is active, it matches all `USER|GROUP_MEMBERSHIP` resource changes; that logger does not expose group paths, so narrower filtering is not possible.
 
    > [!NOTE]
    > All three alerts have a 1-minute pending period (`for: 1m`). An alert stays in `PENDING` state for up to 60 seconds after the condition first evaluates true before transitioning to `FIRING` and notifying Alertmanager.

--- a/docs/how-to-guides/identity-and-authorization/configure-service-accounts.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-service-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure service account clients
+description: Configure a Keycloak client with OAuth 2.0 Client Credentials Grant so automated processes can obtain tokens without a user session.
 sidebar:
   order: 3.009
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-truststore.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-truststore.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure the CA truststore
+description: Replace the default DoD CA bundle in the uds-identity-config image with a custom CA bundle for X.509/CAC certificate validation.
 sidebar:
   order: 3.008
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-user-account-settings.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-user-account-settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure user accounts and security policies
+description: Configure Keycloak user account behavior (password policy, email verification, username format, and security allow lists) via bundle overrides.
 sidebar:
   order: 3.013
 ---

--- a/docs/how-to-guides/identity-and-authorization/configure-x509-crl-airgap.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-x509-crl-airgap.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Keycloak Airgap CRLs
+description: Configure Keycloak to validate X.509/CAC certificates against locally loaded CRLs in an airgapped environment where OCSP is unreachable.
 sidebar:
   order: 3.017
 ---

--- a/docs/how-to-guides/identity-and-authorization/connect-azure-ad-idp.mdx
+++ b/docs/how-to-guides/identity-and-authorization/connect-azure-ad-idp.mdx
@@ -1,5 +1,6 @@
 ---
 title: Connect Azure AD as an identity provider
+description: Configure Azure Entra ID as a SAML identity provider in Keycloak so users authenticate via Azure instead of local Keycloak accounts.
 sidebar:
   order: 3.004
 ---

--- a/docs/how-to-guides/identity-and-authorization/customize-branding.mdx
+++ b/docs/how-to-guides/identity-and-authorization/customize-branding.mdx
@@ -1,5 +1,6 @@
 ---
 title: Customize Keycloak login page branding
+description: Replace the default Keycloak login page images and Terms & Conditions content with custom versions using bundle overrides and ConfigMaps.
 sidebar:
   order: 3.012
 ---

--- a/docs/how-to-guides/identity-and-authorization/enforce-group-based-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/enforce-group-based-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enforce group-based access controls
+description: Restrict a UDS application to only users in specific Keycloak groups, denying access to all others even with valid accounts.
 sidebar:
   order: 3.002
 ---

--- a/docs/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu.mdx
@@ -1,5 +1,6 @@
 ---
 title: Manage Keycloak with OpenTofu
+description: Use the uds-opentofu-client and OpenTofu Keycloak provider to programmatically manage Keycloak groups, clients, and identity providers.
 sidebar:
   order: 3.014
 ---

--- a/docs/how-to-guides/identity-and-authorization/overview.mdx
+++ b/docs/how-to-guides/identity-and-authorization/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Identity and Authorization
-description: Guides for common Keycloak and Authservice tasks: SSO configuration, identity providers, login policies, authentication flows, and branding.
+description: Guides for common Keycloak and Authservice tasks including SSO configuration, identity providers, login policies, authentication flows, and branding.
 sidebar:
   order: 3.000
 ---

--- a/docs/how-to-guides/identity-and-authorization/overview.mdx
+++ b/docs/how-to-guides/identity-and-authorization/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Identity and Authorization
+description: Guides for common Keycloak and Authservice tasks: SSO configuration, identity providers, login policies, authentication flows, and branding.
 sidebar:
   order: 3.000
 ---

--- a/docs/how-to-guides/identity-and-authorization/protect-apps-with-authservice.mdx
+++ b/docs/how-to-guides/identity-and-authorization/protect-apps-with-authservice.mdx
@@ -1,5 +1,6 @@
 ---
 title: Protect non-OIDC apps with SSO
+description: Add SSO protection to applications without native OIDC support by configuring Authservice to intercept requests and handle the auth flow.
 sidebar:
   order: 3.001
 ---

--- a/docs/how-to-guides/identity-and-authorization/register-and-customize-sso-clients.mdx
+++ b/docs/how-to-guides/identity-and-authorization/register-and-customize-sso-clients.mdx
@@ -1,5 +1,6 @@
 ---
 title: Register and customize SSO clients
+description: Register a native OIDC or SAML SSO client in Keycloak, customize the generated Kubernetes secret, and add protocol mappers for custom token claims.
 sidebar:
   order: 3.018
 ---

--- a/docs/how-to-guides/identity-and-authorization/upgrade-to-fips-mode.mdx
+++ b/docs/how-to-guides/identity-and-authorization/upgrade-to-fips-mode.mdx
@@ -1,5 +1,6 @@
 ---
 title: Upgrade to FIPS 140-2 mode
+description: Prepare an existing Keycloak deployment for upgrade to FIPS 140-2 Strict Mode by migrating password hashing and resetting incompatible credentials.
 sidebar:
   order: 3.016
 ---

--- a/docs/how-to-guides/logging/configure-log-retention.mdx
+++ b/docs/how-to-guides/logging/configure-log-retention.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure log retention
+description: Configure Loki to automatically delete log data older than a defined retention period to reduce storage costs and meet data retention requirements.
 sidebar:
   order: 4.003
 ---

--- a/docs/how-to-guides/logging/forward-logs-to-external-system.mdx
+++ b/docs/how-to-guides/logging/forward-logs-to-external-system.mdx
@@ -1,5 +1,6 @@
 ---
 title: Forward logs to an external system
+description: Configure Vector to forward logs to an external S3-compatible destination for SIEM ingestion or long-term archival alongside Loki.
 sidebar:
   order: 4.002
 ---

--- a/docs/how-to-guides/logging/overview.mdx
+++ b/docs/how-to-guides/logging/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Logging
+description: Guides for configuring and using the UDS Core logging pipeline: log retention, external forwarding to SIEM systems, and querying logs in Grafana.
 sidebar:
   order: 4.000
 ---

--- a/docs/how-to-guides/logging/overview.mdx
+++ b/docs/how-to-guides/logging/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Logging
-description: Guides for configuring and using the UDS Core logging pipeline: log retention, external forwarding to SIEM systems, and querying logs in Grafana.
+description: Guides for configuring and using the UDS Core logging pipeline, covering log retention, external forwarding to SIEM systems, and querying logs in Grafana.
 sidebar:
   order: 4.000
 ---

--- a/docs/how-to-guides/logging/query-application-logs.mdx
+++ b/docs/how-to-guides/logging/query-application-logs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Query application logs
+description: Find, filter, and analyze logs from any workload using Grafana's Explore interface and LogQL queries against Loki.
 sidebar:
   order: 4.001
 ---

--- a/docs/how-to-guides/monitoring-and-observability/add-custom-dashboards.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/add-custom-dashboards.mdx
@@ -1,5 +1,6 @@
 ---
 title: Add custom dashboards to Grafana
+description: Deploy application-specific Grafana dashboards as Kubernetes ConfigMaps alongside UDS Core's built-in platform dashboards.
 sidebar:
   order: 5.002
 ---

--- a/docs/how-to-guides/monitoring-and-observability/add-grafana-datasources.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/add-grafana-datasources.mdx
@@ -1,5 +1,6 @@
 ---
 title: Add Grafana datasources
+description: Connect Grafana to additional data sources (external metrics stores, tracing backends, or log aggregators) beyond the UDS Core defaults.
 sidebar:
   order: 5.003
 ---

--- a/docs/how-to-guides/monitoring-and-observability/capture-application-metrics.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/capture-application-metrics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Capture application metrics
+description: Configure Prometheus to scrape your application's metrics using the UDS Package CR's monitor block.
 sidebar:
   order: 5.001
 ---

--- a/docs/how-to-guides/monitoring-and-observability/create-log-based-alerting-and-recording-rules.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/create-log-based-alerting-and-recording-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: Create log-based alerting and recording rules
+description: Define alerting conditions from log patterns using Loki Ruler and derive Prometheus metrics from logs using recording rules.
 sidebar:
   order: 5.005
 ---

--- a/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/create-metric-alerting-rules.mdx
@@ -1,5 +1,6 @@
 ---
 title: Create metric alerting rules
+description: Define Prometheus alerting rules using PrometheusRule CRDs so alerts are automatically routed to Alertmanager.
 sidebar:
   order: 5.004
 ---

--- a/docs/how-to-guides/monitoring-and-observability/overview.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Monitoring & Observability
+description: Guides for integrating applications with UDS Core's monitoring stack: capturing metrics, adding dashboards, configuring alerting, and setting up uptime probes.
 sidebar:
   order: 5.000
 ---

--- a/docs/how-to-guides/monitoring-and-observability/overview.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Monitoring & Observability
-description: Guides for integrating applications with UDS Core's monitoring stack: capturing metrics, adding dashboards, configuring alerting, and setting up uptime probes.
+description: Guides for integrating applications with UDS Core's monitoring stack, covering metrics capture, dashboards, alerting, and uptime probes.
 sidebar:
   order: 5.000
 ---

--- a/docs/how-to-guides/monitoring-and-observability/route-alerts-to-notification-channels.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/route-alerts-to-notification-channels.mdx
@@ -1,5 +1,6 @@
 ---
 title: Route alerts to notification channels
+description: Configure Alertmanager to deliver alerts from Prometheus and Loki to Slack, PagerDuty, email, or other notification channels.
 sidebar:
   order: 5.006
 ---

--- a/docs/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring.mdx
+++ b/docs/how-to-guides/monitoring-and-observability/set-up-uptime-monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set up uptime monitoring
+description: Monitor HTTPS endpoint availability using Blackbox Exporter probes configured through the UDS Package CR's uptime block.
 sidebar:
   order: 5.007
 ---

--- a/docs/how-to-guides/networking/allow-permissive-mesh-traffic.mdx
+++ b/docs/how-to-guides/networking/allow-permissive-mesh-traffic.mdx
@@ -1,5 +1,6 @@
 ---
 title: Allow permissive traffic through the mesh
+description: Relax Istio's strict authorization policies for specific workloads or namespaces that need to receive traffic outside the mesh's default deny-all model.
 sidebar:
   order: 2.008
 ---

--- a/docs/how-to-guides/networking/configure-core-network-access.mdx
+++ b/docs/how-to-guides/networking/configure-core-network-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure network access for Core services
+description: Extend network access rules for UDS Core's own services to reach internal or external destinations not covered by the default configuration.
 sidebar:
   order: 2.009
 ---

--- a/docs/how-to-guides/networking/configure-l7-load-balancer.mdx
+++ b/docs/how-to-guides/networking/configure-l7-load-balancer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure an L7 load balancer
+description: Configure UDS Core to work correctly behind an L7 load balancer such as AWS ALB or Azure Application Gateway with external TLS termination.
 sidebar:
   order: 2.007
 ---

--- a/docs/how-to-guides/networking/configure-non-http-ingress.mdx
+++ b/docs/how-to-guides/networking/configure-non-http-ingress.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set up non-HTTP ingress
+description: Set up an Istio gateway to accept non-HTTP traffic such as SSH and route it to an application service.
 sidebar:
   order: 2.005
 ---

--- a/docs/how-to-guides/networking/configure-tls-certificates.mdx
+++ b/docs/how-to-guides/networking/configure-tls-certificates.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure TLS certificates for gateways
+description: Configure valid TLS certificates for UDS Core ingress gateways using cert-manager, manual secrets, or cloud-managed certificate options.
 sidebar:
   order: 2.001
 ---

--- a/docs/how-to-guides/networking/create-custom-gateways.mdx
+++ b/docs/how-to-guides/networking/create-custom-gateways.mdx
@@ -1,5 +1,6 @@
 ---
 title: Create a custom gateway
+description: Create a custom Istio gateway alongside the standard UDS Core gateways for separate domain routing, TLS settings, or IP-based access restrictions.
 sidebar:
   order: 2.006
 ---

--- a/docs/how-to-guides/networking/define-network-access.mdx
+++ b/docs/how-to-guides/networking/define-network-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: Define network access for your application
+description: Define inbound, outbound, API server, and external network access rules for your application using the UDS Package CR.
 sidebar:
   order: 2.004
 ---

--- a/docs/how-to-guides/networking/enable-passthrough-gateway.mdx
+++ b/docs/how-to-guides/networking/enable-passthrough-gateway.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enable and use the passthrough gateway
+description: Enable the optional passthrough gateway so Istio routes ingress to an application without performing TLS termination.
 sidebar:
   order: 2.003
 ---

--- a/docs/how-to-guides/networking/expose-apps-on-gateways.mdx
+++ b/docs/how-to-guides/networking/expose-apps-on-gateways.mdx
@@ -1,5 +1,6 @@
 ---
 title: Expose applications on gateways
+description: Expose your application through the UDS Core tenant or admin Istio ingress gateway using the UDS Package CR's expose block.
 sidebar:
   order: 2.002
 ---

--- a/docs/how-to-guides/networking/manage-trust-bundles.mdx
+++ b/docs/how-to-guides/networking/manage-trust-bundles.mdx
@@ -1,5 +1,6 @@
 ---
 title: Manage trust bundles
+description: Distribute custom CA certificates across your cluster using UDS Core's trust bundle so platform components and applications trust private or DoD PKI.
 sidebar:
   order: 2.010
 ---

--- a/docs/how-to-guides/networking/overview.mdx
+++ b/docs/how-to-guides/networking/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Networking
+description: Guides for configuring UDS Core networking: TLS certificates, gateways, ingress, application network access rules, and trust bundles.
 sidebar:
   order: 2.000
 ---

--- a/docs/how-to-guides/networking/overview.mdx
+++ b/docs/how-to-guides/networking/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Networking
-description: Guides for configuring UDS Core networking: TLS certificates, gateways, ingress, application network access rules, and trust bundles.
+description: Guides for configuring UDS Core networking, covering TLS certificates, gateways, ingress, application network access rules, and trust bundles.
 sidebar:
   order: 2.000
 ---

--- a/docs/how-to-guides/overview.mdx
+++ b/docs/how-to-guides/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: How-to Guides
+description: Guides for configuring and operating UDS Core, organized by capability area: HA, networking, identity, logging, monitoring, runtime security, backup, policy, and packaging.
 sidebar:
   order: 0.000
 ---

--- a/docs/how-to-guides/overview.mdx
+++ b/docs/how-to-guides/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: How-to Guides
-description: Guides for configuring and operating UDS Core, organized by capability area: HA, networking, identity, logging, monitoring, runtime security, backup, policy, and packaging.
+description: Guides for configuring and operating UDS Core, organized by capability area including HA, networking, identity, logging, monitoring, runtime security, backup, policy, and packaging.
 sidebar:
   order: 0.000
 ---

--- a/docs/how-to-guides/packaging-applications/create-uds-package.mdx
+++ b/docs/how-to-guides/packaging-applications/create-uds-package.mdx
@@ -1,5 +1,6 @@
 ---
 title: Create a UDS Package
+description: Package an existing Helm chart as a UDS Package with network policies, SSO integration, and monitoring, ready to deploy on UDS Core.
 sidebar:
   order: 9.001
 ---

--- a/docs/how-to-guides/packaging-applications/overview.mdx
+++ b/docs/how-to-guides/packaging-applications/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Packaging Applications
+description: Guides for packaging applications as UDS Packages: creating a Zarf package with UDS Package CR integration and testing strategies.
 sidebar:
   order: 9.000
 ---

--- a/docs/how-to-guides/packaging-applications/overview.mdx
+++ b/docs/how-to-guides/packaging-applications/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Packaging Applications
-description: Guides for packaging applications as UDS Packages: creating a Zarf package with UDS Package CR integration and testing strategies.
+description: Guides for packaging applications as UDS Packages, covering Zarf package creation, UDS Package CR integration, and testing strategies.
 sidebar:
   order: 9.000
 ---

--- a/docs/how-to-guides/packaging-applications/package-testing.mdx
+++ b/docs/how-to-guides/packaging-applications/package-testing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Package Testing
+description: Set up a testing strategy for your UDS Package that validates deployment correctness, UDS Core integration, and upgrade compatibility.
 sidebar:
   order: 9.002
 ---

--- a/docs/how-to-guides/platform-features/build-functional-layer-bundle.mdx
+++ b/docs/how-to-guides/platform-features/build-functional-layer-bundle.mdx
@@ -1,5 +1,6 @@
 ---
 title: Build a functional layer bundle
+description: Build a UDS Bundle that deploys a tailored subset of UDS Core using individual functional layers instead of the full core package.
 sidebar:
   order: 10.003
 ---

--- a/docs/how-to-guides/platform-features/configure-pod-reload.mdx
+++ b/docs/how-to-guides/platform-features/configure-pod-reload.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure automatic pod reload
+description: Configure pods that consume specific Secrets or ConfigMaps to restart automatically when those resources change, eliminating manual rollout restarts.
 sidebar:
   order: 10.001
 ---

--- a/docs/how-to-guides/platform-features/enable-classification-banner.mdx
+++ b/docs/how-to-guides/platform-features/enable-classification-banner.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enable the classification banner
+description: Display a security classification banner on web applications exposed through the Istio service mesh using bundle overrides.
 sidebar:
   order: 10.002
 ---

--- a/docs/how-to-guides/platform-features/overview.mdx
+++ b/docs/how-to-guides/platform-features/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Platform Features
+description: Guides for platform-wide UDS Core features: functional layer bundles, automatic pod reload, and the security classification banner.
 sidebar:
   order: 10.000
 ---

--- a/docs/how-to-guides/platform-features/overview.mdx
+++ b/docs/how-to-guides/platform-features/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Platform Features
-description: Guides for platform-wide UDS Core features: functional layer bundles, automatic pod reload, and the security classification banner.
+description: Guides for platform-wide UDS Core features including functional layer bundles, automatic pod reload, and the security classification banner.
 sidebar:
   order: 10.000
 ---

--- a/docs/how-to-guides/policy-and-compliance/allow-exemptions-all-namespaces.mdx
+++ b/docs/how-to-guides/policy-and-compliance/allow-exemptions-all-namespaces.mdx
@@ -1,5 +1,6 @@
 ---
 title: Allow exemptions in all namespaces
+description: Configure UDS Core to accept Exemption CRs from any namespace instead of only the default uds-policy-exemptions namespace.
 sidebar:
   order: 8.003
 ---

--- a/docs/how-to-guides/policy-and-compliance/audit-security-posture.mdx
+++ b/docs/how-to-guides/policy-and-compliance/audit-security-posture.mdx
@@ -1,5 +1,6 @@
 ---
 title: Audit security posture
+description: Review your cluster's security posture by auditing policy exemptions and inspecting Package CR network rules for overly permissive configurations.
 sidebar:
   order: 8.005
 ---

--- a/docs/how-to-guides/policy-and-compliance/configure-infrastructure-exemptions.mdx
+++ b/docs/how-to-guides/policy-and-compliance/configure-infrastructure-exemptions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure infrastructure exemptions
+description: Configure policy exemptions for infrastructure workloads that legitimately require elevated privileges, such as Istio NodePort services or storage drivers.
 sidebar:
   order: 8.004
 ---

--- a/docs/how-to-guides/policy-and-compliance/create-policy-exemptions.mdx
+++ b/docs/how-to-guides/policy-and-compliance/create-policy-exemptions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Create UDS policy exemptions
+description: Create a UDS Exemption CR to allow a workload to bypass specific UDS admission policies when a code-level fix is not possible.
 sidebar:
   order: 8.001
 ---

--- a/docs/how-to-guides/policy-and-compliance/overview.mdx
+++ b/docs/how-to-guides/policy-and-compliance/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Policy & Compliance
+description: Guides for working with UDS Core's Pepr admission policies: creating exemptions, auditing security posture, and resolving policy violations.
 sidebar:
   order: 8.000
 ---

--- a/docs/how-to-guides/policy-and-compliance/overview.mdx
+++ b/docs/how-to-guides/policy-and-compliance/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Policy & Compliance
-description: Guides for working with UDS Core's Pepr admission policies: creating exemptions, auditing security posture, and resolving policy violations.
+description: Guides for working with UDS Core's Pepr admission policies, covering exemption creation, security posture auditing, and resolving policy violations.
 sidebar:
   order: 8.000
 ---

--- a/docs/how-to-guides/runtime-security/migrate-from-neuvector.mdx
+++ b/docs/how-to-guides/runtime-security/migrate-from-neuvector.mdx
@@ -1,5 +1,6 @@
 ---
 title: Migrate from NeuVector to Falco
+description: Upgrade a UDS Core deployment from the legacy NeuVector runtime security provider to Falco as part of a standard version upgrade.
 sidebar:
   order: 6.004
 ---

--- a/docs/how-to-guides/runtime-security/overview.mdx
+++ b/docs/how-to-guides/runtime-security/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Runtime Security
-description: Guides for UDS Core's Falco-based runtime security: tuning detections, querying events in Grafana, routing alerts, and migrating from NeuVector.
+description: Guides for UDS Core's Falco-based runtime security, covering detection tuning, querying events in Grafana, alert routing, and migration from NeuVector.
 sidebar:
   order: 6.000
 ---

--- a/docs/how-to-guides/runtime-security/overview.mdx
+++ b/docs/how-to-guides/runtime-security/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Runtime Security
+description: Guides for UDS Core's Falco-based runtime security: tuning detections, querying events in Grafana, routing alerts, and migrating from NeuVector.
 sidebar:
   order: 6.000
 ---

--- a/docs/how-to-guides/runtime-security/query-falco-events.mdx
+++ b/docs/how-to-guides/runtime-security/query-falco-events.mdx
@@ -1,5 +1,6 @@
 ---
 title: Query Falco events in Grafana
+description: Query and visualize Falco runtime security events in Grafana using Loki and the built-in Falcosidekick dashboard.
 sidebar:
   order: 6.002
 ---

--- a/docs/how-to-guides/runtime-security/route-runtime-alerts.mdx
+++ b/docs/how-to-guides/runtime-security/route-runtime-alerts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Route runtime alerts to external destinations
+description: Configure Falcosidekick to forward runtime security alerts to Slack, Mattermost, or Microsoft Teams for real-time security operations notifications.
 sidebar:
   order: 6.003
 ---

--- a/docs/how-to-guides/runtime-security/tune-falco-detections.mdx
+++ b/docs/how-to-guides/runtime-security/tune-falco-detections.mdx
@@ -1,5 +1,6 @@
 ---
 title: Tune Falco runtime detections
+description: Customize Falco detection rules (enabling rulesets, disabling noisy rules, adding exceptions, and writing custom rules) all via bundle overrides.
 sidebar:
   order: 6.001
 ---

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: UDS Core
-description: UDS Core is the foundational runtime layer for secure Kubernetes deployments - a curated set of platform capabilities pre-configured for DoD and IC security requirements.
+description: Index of UDS Core documentation: a foundational runtime layer for secure Kubernetes deployments covering installation, concepts, configuration guides, reference, and operations.
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: UDS Core
-description: Index of UDS Core documentation: a foundational runtime layer for secure Kubernetes deployments covering installation, concepts, configuration guides, reference, and operations.
+description: Index of UDS Core documentation, a foundational runtime layer for secure Kubernetes deployments covering installation, concepts, configuration guides, reference, and operations.
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';

--- a/docs/operations/overview.mdx
+++ b/docs/operations/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Operations & Maintenance
-description: Index of Day-2 operations guides for UDS Core: upgrade procedures, troubleshooting runbooks, and release notes.
+description: Index of Day-2 operations guides for UDS Core, covering upgrade procedures, troubleshooting runbooks, and release notes.
 sidebar:
   order: 0.000
 ---

--- a/docs/operations/overview.mdx
+++ b/docs/operations/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Operations & Maintenance
+description: Index of Day-2 operations guides for UDS Core: upgrade procedures, troubleshooting runbooks, and release notes.
 sidebar:
   order: 0.000
 ---

--- a/docs/operations/release-notes/0-60.mdx
+++ b/docs/operations/release-notes/0-60.mdx
@@ -1,6 +1,6 @@
 ---
 title: UDS Core 0.60
-description: UDS Core 0.60 release notes: Istio ambient mode as default for Package CRs, SSO secret field reorganization, and Keycloak logout confirmation changes.
+description: UDS Core 0.60 release notes covering Istio ambient mode as default for Package CRs, SSO secret field reorganization, and Keycloak logout confirmation changes.
 sidebar:
   order: 3.999
 ---

--- a/docs/operations/release-notes/0-60.mdx
+++ b/docs/operations/release-notes/0-60.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Core 0.60
+description: UDS Core 0.60 release notes: Istio ambient mode as default for Package CRs, SSO secret field reorganization, and Keycloak logout confirmation changes.
 sidebar:
   order: 3.999
 ---

--- a/docs/operations/release-notes/0-61.mdx
+++ b/docs/operations/release-notes/0-61.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Core 0.61
+description: UDS Core 0.61 release notes: Blackbox Exporter for uptime monitoring, Keycloak HA improvements, and UDS trust bundle applied to all Core applications.
 sidebar:
   order: 3.998
 ---

--- a/docs/operations/release-notes/0-61.mdx
+++ b/docs/operations/release-notes/0-61.mdx
@@ -1,6 +1,6 @@
 ---
 title: UDS Core 0.61
-description: UDS Core 0.61 release notes: Blackbox Exporter for uptime monitoring, Keycloak HA improvements, and UDS trust bundle applied to all Core applications.
+description: UDS Core 0.61 release notes covering Blackbox Exporter for uptime monitoring, Keycloak HA improvements, and UDS trust bundle support for all Core applications.
 sidebar:
   order: 3.998
 ---

--- a/docs/operations/release-notes/0-62.mdx
+++ b/docs/operations/release-notes/0-62.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Core 0.62
+description: UDS Core 0.62 release notes: uptime probe support for Authservice-protected apps, Falco rule overrides, and Falco Helm chart 8.x upgrade.
 sidebar:
   order: 3.997
 ---

--- a/docs/operations/release-notes/0-62.mdx
+++ b/docs/operations/release-notes/0-62.mdx
@@ -1,6 +1,6 @@
 ---
 title: UDS Core 0.62
-description: UDS Core 0.62 release notes: uptime probe support for Authservice-protected apps, Falco rule overrides, and Falco Helm chart 8.x upgrade.
+description: UDS Core 0.62 release notes covering uptime probe support for Authservice-protected apps, Falco rule overrides, and the Falco Helm chart 8.x upgrade.
 sidebar:
   order: 3.997
 ---

--- a/docs/operations/release-notes/0-63.mdx
+++ b/docs/operations/release-notes/0-63.mdx
@@ -1,6 +1,6 @@
 ---
 title: UDS Core 0.63
-description: UDS Core 0.63 release notes: built-in uptime observability with recording rules, Core Uptime dashboard, and standalone CRDs functional layer.
+description: UDS Core 0.63 release notes covering built-in uptime observability with recording rules, the Core Uptime dashboard, and the standalone CRDs functional layer.
 sidebar:
   order: 3.996
 ---

--- a/docs/operations/release-notes/0-63.mdx
+++ b/docs/operations/release-notes/0-63.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Core 0.63
+description: UDS Core 0.63 release notes: built-in uptime observability with recording rules, Core Uptime dashboard, and standalone CRDs functional layer.
 sidebar:
   order: 3.996
 ---

--- a/docs/operations/release-notes/1-0.mdx
+++ b/docs/operations/release-notes/1-0.mdx
@@ -1,6 +1,6 @@
 ---
 title: UDS Core 1.0
-description: UDS Core 1.0 release notes: formal API stability guarantee, removal of all deprecated features, and the launch of the new documentation site.
+description: UDS Core 1.0 release notes covering the formal API stability guarantee, removal of all deprecated features, and the new documentation site.
 sidebar:
   order: 3.995
 ---

--- a/docs/operations/release-notes/1-0.mdx
+++ b/docs/operations/release-notes/1-0.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Core 1.0
+description: UDS Core 1.0 release notes: formal API stability guarantee, removal of all deprecated features, and the launch of the new documentation site.
 sidebar:
   order: 3.995
 ---

--- a/docs/operations/release-notes/overview.mdx
+++ b/docs/operations/release-notes/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release Notes
+description: Index of UDS Core release notes documenting breaking changes, notable features, and version-specific upgrade considerations.
 sidebar:
   order: 3.000
 ---

--- a/docs/operations/troubleshooting-and-runbooks/exemptions-and-packages.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/exemptions-and-packages.mdx
@@ -1,5 +1,6 @@
 ---
 title: Exemptions & Packages Not Updating
+description: Diagnose and resolve issues where UDS Exemption or Package CRs are not being reconciled by the UDS Operator.
 sidebar:
   order: 1.001
 ---

--- a/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
@@ -1,5 +1,6 @@
 ---
 title: Keycloak Credential Recovery
+description: Recover access to a Keycloak instance when admin credentials are lost or a realm is misconfigured.
 sidebar:
   order: 1.002
 ---

--- a/docs/operations/troubleshooting-and-runbooks/overview.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting & Runbooks
+description: Index of runbooks for diagnosing and resolving common issues on a running UDS Core platform.
 sidebar:
   order: 1.000
 ---

--- a/docs/operations/troubleshooting-and-runbooks/policy-violations.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/policy-violations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Policy Violations
+description: Diagnose and resolve UDS admission policy violations that are blocking Kubernetes resource creation.
 sidebar:
   order: 1.004
 ---

--- a/docs/operations/troubleshooting-and-runbooks/resize-prometheus-pvc.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/resize-prometheus-pvc.mdx
@@ -1,5 +1,6 @@
 ---
 title: Resize Prometheus PVCs
+description: Increase the size of Prometheus PVCs managed by Prometheus Operator in a running UDS Core deployment.
 sidebar:
   order: 1.003
 ---

--- a/docs/operations/upgrades/configuration-changes.mdx
+++ b/docs/operations/upgrades/configuration-changes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration Changes
+description: Apply configuration changes to a running UDS Core deployment by updating bundle overrides and redeploying.
 sidebar:
   order: 2.001
 ---

--- a/docs/operations/upgrades/overview.mdx
+++ b/docs/operations/upgrades/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Upgrades
-description: Guides for upgrading UDS Core: general procedures, checklists, and links to version-specific release notes for breaking changes.
+description: Guides for upgrading UDS Core, covering general procedures, checklists, and version-specific release notes for breaking changes.
 sidebar:
   order: 2.000
 ---

--- a/docs/operations/upgrades/overview.mdx
+++ b/docs/operations/upgrades/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Upgrades
+description: Guides for upgrading UDS Core: general procedures, checklists, and links to version-specific release notes for breaking changes.
 sidebar:
   order: 2.000
 ---

--- a/docs/operations/upgrades/upgrade-keycloak-realm.mdx
+++ b/docs/operations/upgrades/upgrade-keycloak-realm.mdx
@@ -1,5 +1,6 @@
 ---
 title: Upgrade Keycloak realm configuration
+description: Manually apply Keycloak realm configuration changes required by specific UDS Core version upgrades that cannot be handled by automated re-import.
 sidebar:
   order: 2.002
 ---

--- a/docs/reference/configuration/identity-and-authorization.md
+++ b/docs/reference/configuration/identity-and-authorization.md
@@ -1,6 +1,6 @@
 ---
 title: Identity & Authorization
-description: Complete reference for UDS Core identity and authorization configuration: Keycloak Helm values, realmInitEnv variables, theme and plugin settings, and SSO defaults.
+description: Complete reference for UDS Core identity and authorization configuration, covering Keycloak Helm values, realmInitEnv variables, theme and plugin settings, and SSO defaults.
 sidebar:
   order: 3.001
 ---

--- a/docs/reference/configuration/identity-and-authorization.md
+++ b/docs/reference/configuration/identity-and-authorization.md
@@ -1,5 +1,6 @@
 ---
 title: Identity & Authorization
+description: Complete reference for UDS Core identity and authorization configuration: Keycloak Helm values, realmInitEnv variables, theme and plugin settings, and SSO defaults.
 sidebar:
   order: 3.001
 ---

--- a/docs/reference/configuration/monitoring-and-observability.md
+++ b/docs/reference/configuration/monitoring-and-observability.md
@@ -1,5 +1,6 @@
 ---
 title: Monitoring & Observability
+description: Complete reference for UDS Core monitoring configuration surfaces: built-in Grafana dashboards and the Package CR uptime probe fields.
 sidebar:
   order: 3.002
 ---

--- a/docs/reference/configuration/monitoring-and-observability.md
+++ b/docs/reference/configuration/monitoring-and-observability.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring & Observability
-description: Complete reference for UDS Core monitoring configuration surfaces: built-in Grafana dashboards and the Package CR uptime probe fields.
+description: Complete reference for UDS Core monitoring configuration surfaces, covering built-in Grafana dashboards and the Package CR uptime probe fields.
 sidebar:
   order: 3.002
 ---

--- a/docs/reference/configuration/overview.mdx
+++ b/docs/reference/configuration/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Index of configuration surfaces exposed by UDS Core components: Helm values, environment variables, and bundle overrides that control platform behavior.
 sidebar:
   order: 3.000
 ---

--- a/docs/reference/configuration/overview.mdx
+++ b/docs/reference/configuration/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Index of configuration surfaces exposed by UDS Core components: Helm values, environment variables, and bundle overrides that control platform behavior.
+description: Index of configuration surfaces exposed by UDS Core components, including Helm values, environment variables, and bundle overrides that control platform behavior.
 sidebar:
   order: 3.000
 ---

--- a/docs/reference/operator-and-crds/clusterconfig-v1alpha1-cr.md
+++ b/docs/reference/operator-and-crds/clusterconfig-v1alpha1-cr.md
@@ -1,6 +1,5 @@
 ---
 title: Clusterconfig CR (v1alpha1)
-description: Complete reference for the ClusterConfig v1alpha1 custom resource, which holds cluster-wide UDS settings like domains, CA certificates, and networking CIDRs.
 tableOfContents:
   maxHeadingLevel: 6
 sidebar:

--- a/docs/reference/operator-and-crds/clusterconfig-v1alpha1-cr.md
+++ b/docs/reference/operator-and-crds/clusterconfig-v1alpha1-cr.md
@@ -1,5 +1,6 @@
 ---
 title: Clusterconfig CR (v1alpha1)
+description: Complete reference for the ClusterConfig v1alpha1 custom resource, which holds cluster-wide UDS settings like domains, CA certificates, and networking CIDRs.
 tableOfContents:
   maxHeadingLevel: 6
 sidebar:

--- a/docs/reference/operator-and-crds/exemptions-v1alpha1-cr.md
+++ b/docs/reference/operator-and-crds/exemptions-v1alpha1-cr.md
@@ -1,6 +1,5 @@
 ---
 title: Exemptions CR (v1alpha1)
-description: Complete reference for the Exemption v1alpha1 custom resource, which grants workloads permission to bypass named UDS security policies.
 tableOfContents:
   maxHeadingLevel: 6
 sidebar:

--- a/docs/reference/operator-and-crds/exemptions-v1alpha1-cr.md
+++ b/docs/reference/operator-and-crds/exemptions-v1alpha1-cr.md
@@ -1,5 +1,6 @@
 ---
 title: Exemptions CR (v1alpha1)
+description: Complete reference for the Exemption v1alpha1 custom resource, which grants workloads permission to bypass named UDS security policies.
 tableOfContents:
   maxHeadingLevel: 6
 sidebar:

--- a/docs/reference/operator-and-crds/overview.mdx
+++ b/docs/reference/operator-and-crds/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Operator & CRDs
+description: Index of the UDS Operator and the three custom resources it manages: Package, Exemption, and ClusterConfig.
 sidebar:
   order: 1.000
 ---

--- a/docs/reference/operator-and-crds/overview.mdx
+++ b/docs/reference/operator-and-crds/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Operator & CRDs
-description: Index of the UDS Operator and the three custom resources it manages: Package, Exemption, and ClusterConfig.
+description: Index of the UDS Operator and the three custom resources it manages, covering Package, Exemption, and ClusterConfig.
 sidebar:
   order: 1.000
 ---

--- a/docs/reference/operator-and-crds/packages-v1alpha1-cr.md
+++ b/docs/reference/operator-and-crds/packages-v1alpha1-cr.md
@@ -1,5 +1,6 @@
 ---
 title: Packages CR (v1alpha1)
+description: Complete reference for the Package v1alpha1 custom resource, which declares an application's network access, SSO clients, and monitoring configuration.
 tableOfContents:
   maxHeadingLevel: 6
 sidebar:

--- a/docs/reference/operator-and-crds/packages-v1alpha1-cr.md
+++ b/docs/reference/operator-and-crds/packages-v1alpha1-cr.md
@@ -1,6 +1,5 @@
 ---
 title: Packages CR (v1alpha1)
-description: Complete reference for the Package v1alpha1 custom resource, which declares an application's network access, SSO clients, and monitoring configuration.
 tableOfContents:
   maxHeadingLevel: 6
 sidebar:

--- a/docs/reference/operator-and-crds/policy-engine.mdx
+++ b/docs/reference/operator-and-crds/policy-engine.mdx
@@ -1,5 +1,6 @@
 ---
 title: UDS Policies
+description: Complete reference for UDS Core security policies enforced by Pepr admission webhooks, aligned with Kubernetes Pod Security Standards.
 sidebar:
   order: 1.004
 ---

--- a/docs/reference/overview.mdx
+++ b/docs/reference/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference
+description: Index of UDS Core reference material covering CRD schemas, operator behavior, configuration surfaces, and project policies.
 sidebar:
   order: 0.000
 ---

--- a/docs/reference/policies/overview.mdx
+++ b/docs/reference/policies/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Index of UDS Core project policies: versioning, deprecations, and security vulnerability disclosure.
+description: Index of UDS Core project policies covering versioning, deprecations, and security vulnerability disclosure.
 sidebar:
   order: 2.000
 ---

--- a/docs/reference/policies/overview.mdx
+++ b/docs/reference/policies/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Index of UDS Core project policies: versioning, deprecations, and security vulnerability disclosure.
 sidebar:
   order: 2.000
 ---


### PR DESCRIPTION
## Description
Adds `description` frontmatter to all published doc pages, required for accurate llms.txt navigation so AI assistants can route questions to the right page without downloading full content. Adds a top-level `description` field to `docs/docs.config.json` that populates the `## Products` section of llms.txt automatically. Also includes minor improvements to the how-to guide template and contributing guide to document the `description` requirements.

## Related Issue

Fixes [core-425](https://linear.app/defense-unicorns/issue/CORE-425/re-evaluate-the-llms-text-generation)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
