### PR TITLE
fix: remove aggressive whitespace trimming in keycloak statefulset template

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -224,7 +224,7 @@ spec:
           {{- if .Values.autoscaling.enabled }}
           {{- if ne (include "keycloak.postgresql.config" .) "true" -}}
               {{- fail "You must configure PostgreSQL when using Autoscaling (HA Mode)" -}}
-          {{- end -}}
+          {{- end }}
             # Use Infinispan distributes caches
             - name: KC_CACHE
               value: ispn

--- a/src/keycloak/chart/tests/kc_debug_autoscaling_test.yaml
+++ b/src/keycloak/chart/tests/kc_debug_autoscaling_test.yaml
@@ -1,0 +1,56 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - debugMode with autoscaling enabled
+templates:
+  - statefulset.yaml
+  - secret-postgresql.yaml
+  - secret-kc-realm.yaml
+
+tests:
+  - it: should render debug logging env vars alongside autoscaling env vars
+    set:
+      devMode: false
+      debugMode: true
+      autoscaling:
+        enabled: true
+      postgresql:
+        username: "test-user"
+        password: "test-password"
+        database: "test-db"
+        host: "test-host"
+        port: 5432
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_LOG_LEVEL
+            value: DEBUG
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUARKUS_LOG_CATEGORY__ORG_APACHE_HTTP__LEVEL
+            value: DEBUG
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUARKUS_LOG_CATEGORY__ORG_KEYCLOAK_SERVICES_X509__LEVEL
+            value: TRACE
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUARKUS_LOG_CATEGORY__ORG_KEYCLOAK_COMMON_CRYPTO__LEVEL
+            value: TRACE
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUARKUS_LOG_CATEGORY__ORG_KEYCLOAK_CRYPTO__LEVEL
+            value: TRACE
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_CACHE
+            value: ispn


### PR DESCRIPTION
## Description

 When both debugMode and autoscaling were enabled, the {{- end -}} directive on the postgresql validation block trimmed all whitespace between the TRACE env value and the Infinispan comment, producing an invalid Quarkus config value of "TRACE# Use Infinispan distributes caches"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `helm unittest -f tests/kc_debug_autoscaling_test.yaml src/keycloak/chart` (can revert the change to see this test fail too)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
