### PR TITLE
chore: replace use of `uds` with `./uds` in uds tasks

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -33,22 +33,22 @@ tasks:
 
       - description: "Create required namespaces"
         cmd: |
-          uds zarf tools kubectl create ns uds-policy-exemptions
-          uds zarf tools kubectl create ns istio-system
-          uds zarf tools kubectl create ns pepr-system
+          ./uds zarf tools kubectl create ns uds-policy-exemptions
+          ./uds zarf tools kubectl create ns istio-system
+          ./uds zarf tools kubectl create ns pepr-system
 
       - description: "Deploy the UDS CRDs and apply all hack dev manifests"
         cmd: |
-          uds zarf tools kubectl apply -f src/pepr/uds-cluster-crds/templates/
-          uds zarf tools kubectl apply -f hack/dev-manifests/
+          ./uds zarf tools kubectl apply -f src/pepr/uds-cluster-crds/templates/
+          ./uds zarf tools kubectl apply -f hack/dev-manifests/
 
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
-        cmd: "uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --components=${{ .inputs.istio_components }}"
+        cmd: "./uds zarf dev deploy src/istio --flavor upstream --registry-url docker.io --components=${{ .inputs.istio_components }}"
 
       # Note: Since this is a dev deploy without any `--flavor` it only deploys the CRDs (other components are flavored)
       - description: "Deploy the Prometheus-Stack source package with Zarf Dev to only install the CRDs"
-        cmd: "uds zarf dev deploy src/prometheus-stack"
+        cmd: "./uds zarf dev deploy src/prometheus-stack"
 
       - description: "Dev instructions"
         cmd: |
@@ -86,12 +86,12 @@ tasks:
         cmd: "npx pepr deploy --yes"
 
       - description: "Deploy Keycloak + Authservice"
-        cmd: "uds run dev-deploy --set LAYER=identity-authorization --no-progress"
+        cmd: "./uds run dev-deploy --set LAYER=identity-authorization --no-progress"
 
   - name: dev-deploy
     description: "Deploy the given core layer with Zarf Dev"
     actions:
-      - cmd: "uds zarf dev deploy packages/${LAYER} --flavor ${FLAVOR} --components '*'"
+      - cmd: "./uds zarf dev deploy packages/${LAYER} --flavor ${FLAVOR} --components '*'"
 
   - name: setup-cluster
     description: "Create a k3d Cluster and Initialize with Zarf"

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
@@ -40,7 +40,7 @@ tasks:
     description: "Create the K3d-UDS Core Bundle"
     actions:
       - description: "Create the UDS Core Standard Bundle"
-        cmd: uds create bundles/k3d-standard --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
+        cmd: ./uds create bundles/k3d-standard --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
 
   - name: k3d-slim-dev-bundle
     description: "Create the slim dev bundle (Base and Identity)"
@@ -57,7 +57,7 @@ tasks:
           layer: identity-authorization
 
       - description: "Create the slim dev bundle (Base and Identity)"
-        cmd: uds create bundles/k3d-slim-dev --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
+        cmd: ./uds create bundles/k3d-slim-dev --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
 
   - name: checkpoint-dev-package
     description: "Create the K3d + UDS Core Checkpoint Zarf Package"
@@ -65,7 +65,7 @@ tasks:
       - description: "Create build output directory"
         cmd: "mkdir -p build"
       - description: "Create the UDS Core Checkpoint Zarf Package"
-        cmd: "uds zarf package create packages/checkpoint-dev --confirm --skip-sbom"
+        cmd: "./uds zarf package create packages/checkpoint-dev --confirm --skip-sbom"
 
   # This task is a wrapper to support --set LAYER=identity-authorization
   - name: single-layer-callable
@@ -109,7 +109,7 @@ tasks:
           linux: bash
         cmd: |
           if [[ ${{.inputs.shim_bundle}} == "true" ]]; then
-            uds create bundles/base-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
+            ./uds create bundles/base-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
           else
             echo "Skipping base-shim bundle creation."
           fi

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -21,12 +21,12 @@ tasks:
         description: "Extra args for k3d"
     actions:
       - description: "Deploy the UDS Core Standard Bundle"
-        cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set INSECURE_ADMIN_PASSWORD_GENERATION=true --set FALCO_SANDBOX_RULES_ENABLED=true --set FALCO_INCUBATING_RULES_ENABLED=true --set K3D_EXTRA_ARGS="${{ .inputs.K3D_EXTRA_ARGS }}" --confirm --no-progress
+        cmd: ./uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set INSECURE_ADMIN_PASSWORD_GENERATION=true --set FALCO_SANDBOX_RULES_ENABLED=true --set FALCO_INCUBATING_RULES_ENABLED=true --set K3D_EXTRA_ARGS="${{ .inputs.K3D_EXTRA_ARGS }}" --confirm --no-progress
 
   - name: k3d-standard-bundle-ha
     actions:
       - description: "Deploy the UDS Core Standard Bundle"
-        cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+        cmd: ./uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
         env:
           - UDS_CONFIG=bundles/k3d-standard/uds-ha-config.yaml
 
@@ -44,22 +44,22 @@ tasks:
   - name: k3d-standard-bundle-private-pki
     actions:
       - description: "Deploy k3d cluster and init packages"
-        cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages uds-k3d-dev,init --confirm --no-progress
+        cmd: ./uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages uds-k3d-dev,init --confirm --no-progress
 
       - description: "Deploy UDS Core with Private PKI configuration"
-        cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages core --confirm --no-progress
+        cmd: ./uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages core --confirm --no-progress
         env:
           - UDS_CONFIG=build/private-pki/uds-private-pki-config.yaml
 
   - name: k3d-slim-dev-bundle
     actions:
       - description: "Deploy the UDS Core Slim Dev Only Bundle"
-        cmd: uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+        cmd: ./uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
 
   - name: k3d-slim-dev-bundle-ha
     actions:
       - description: "Deploy the UDS Core Slim Dev Bundle with HA configuration"
-        cmd: uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+        cmd: ./uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
         env:
           - UDS_CONFIG=bundles/k3d-slim-dev/uds-ha-config.yaml
 
@@ -79,10 +79,10 @@ tasks:
     actions:
       - description: "Deploy UDS Core Base Layer"
         if: ${{ eq .inputs.layer "base"}}
-        cmd: uds deploy bundles/base-shim/uds-bundle-base-shim-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
+        cmd: ./uds deploy bundles/base-shim/uds-bundle-base-shim-${UDS_ARCH}-${VERSION}.tar.zst --confirm --no-progress
       - description: "Deploy a single UDS Core Layer (must set UDS_LAYER environment variable)"
         if: ${{ ne .inputs.layer "base"}}
-        cmd: uds zarf package deploy build/zarf-package-core-${{ index .inputs "layer" }}-${UDS_ARCH}-${VERSION}.tar.zst --confirm --components '*'
+        cmd: ./uds zarf package deploy build/zarf-package-core-${{ index .inputs "layer" }}-${UDS_ARCH}-${VERSION}.tar.zst --confirm --components '*'
 
   - name: resolve-latest-core-release
     actions:
@@ -100,9 +100,9 @@ tasks:
           fi
 
           if [ -n "${TARGET_VERSION}" ]; then
-            uds zarf tools registry ls ${TARGET_REPO}/core | grep "${FLAVOR}" | grep -E "^${TARGET_VERSION}\\." | sort -V | tail -1
+            ./uds zarf tools registry ls ${TARGET_REPO}/core | grep "${FLAVOR}" | grep -E "^${TARGET_VERSION}\\." | sort -V | tail -1
           else
-            uds zarf tools registry ls ${TARGET_REPO}/core | grep "${FLAVOR}" | sort -V | tail -1
+            ./uds zarf tools registry ls ${TARGET_REPO}/core | grep "${FLAVOR}" | sort -V | tail -1
           fi
         setVariables:
           - name: LATEST_VERSION
@@ -127,19 +127,19 @@ tasks:
           curl -sSL https://raw.githubusercontent.com/defenseunicorns/uds-core/v${LATEST_CORE_TAG}/bundles/k3d-standard/uds-bundle.yaml -o tmp/core-shim/uds-bundle.yaml
 
           # Update the bundle with the latest version using yq
-          uds zarf tools yq e -i "
+          ./uds zarf tools yq e -i "
             del(.packages[] | select(.name == \"core\").path) |
             .packages[] |= (select(.name == \"core\") |
             .repository = \"${TARGET_REPO}/core\" | .ref = \"${LATEST_VERSION}\")" \
             tmp/core-shim/uds-bundle.yaml
 
           # Create and deploy the bundle
-          uds create tmp/core-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
+          ./uds create tmp/core-shim --confirm --no-progress --architecture=${ZARF_ARCHITECTURE}
       - description: "Deploy the latest version from the bundle"
         cmd: |
           # Set UDS_CONFIG for bundle deployment
           export UDS_CONFIG="${{ .inputs.configFile }}"
-          uds deploy tmp/core-shim/uds-bundle-k3d-core-demo-${UDS_ARCH}-${LATEST_CORE_TAG}.tar.zst --confirm --no-progress
+          ./uds deploy tmp/core-shim/uds-bundle-k3d-core-demo-${UDS_ARCH}-${LATEST_CORE_TAG}.tar.zst --confirm --no-progress
       - description: "Clean up temporary files"
         cmd: rm -rf tmp/core-shim
 
@@ -156,7 +156,7 @@ tasks:
           cd tmp/test-shim/uds-core
           git sparse-checkout set src/test tasks
       - description: "Deploy Latest Release Test Resources"
-        cmd: uds run -f src/test/tasks.yaml create-deploy
+        cmd: ./uds run -f src/test/tasks.yaml create-deploy
         dir: tmp/test-shim/uds-core/
       - description: "Clean up temporary files"
         cmd: rm -rf tmp/test-shim
@@ -164,14 +164,14 @@ tasks:
   - name: latest-slim-bundle-release
     actions:
       - description: "Deploy the latest UDS Core package release"
-        cmd: uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-slim-dev:latest --set INSECURE_ADMIN_PASSWORD_GENERATION=true --confirm --no-progress
+        cmd: ./uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-slim-dev:latest --set INSECURE_ADMIN_PASSWORD_GENERATION=true --confirm --no-progress
 
   - name: standard-package
     actions:
       - description: "Deploy the standard UDS Core zarf package"
-        cmd: uds zarf package deploy build/zarf-package-core-${UDS_ARCH}-${VERSION}.tar.zst --confirm --components '*'
+        cmd: ./uds zarf package deploy build/zarf-package-core-${UDS_ARCH}-${VERSION}.tar.zst --confirm --components '*'
 
   - name: checkpoint-package
     actions:
       - description: "Deploy the checkpoint K3d + UDS Core Slim zarf package"
-        cmd: uds zarf package deploy build/zarf-package-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm
+        cmd: ./uds zarf package deploy build/zarf-package-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -37,7 +37,7 @@ tasks:
         default: "bundles/k3d-standard/uds-upgrade-test-config.yaml"
     actions:
       - description: "Deploy UDS Core (core package only, for upgrade testing)"
-        cmd: uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages core --confirm --no-progress
+        cmd: ./uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --packages core --confirm --no-progress
         env:
           - UDS_CONFIG=${{ .inputs.configFile }}
 

--- a/tasks/iac.yaml
+++ b/tasks/iac.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
@@ -32,7 +32,7 @@ tasks:
           ATTEMPTS=${API_WAIT_ATTEMPTS:-60}
           SLEEP=${API_WAIT_SLEEP:-10}
           for i in $(seq 1 $ATTEMPTS); do
-            if uds zarf tools kubectl get --raw="/readyz" >/dev/null 2>&1; then
+            if ./uds zarf tools kubectl get --raw="/readyz" >/dev/null 2>&1; then
               echo "API server ready"
               exit 0
             fi
@@ -41,7 +41,7 @@ tasks:
           done
 
           echo "API server did not become ready in time" >&2
-          uds zarf tools kubectl get --raw="/readyz?verbose"
+          ./uds zarf tools kubectl get --raw="/readyz?verbose"
           exit 1
 
   - name: cluster-ready
@@ -66,7 +66,7 @@ tasks:
           # wait for nodes to be ready
           echo "Waiting for all cluster nodes to be ready...";
           while true; do
-            if [ $(uds zarf tools kubectl get nodes | grep Ready | wc -l) -lt 4 ]; then
+            if [ $(./uds zarf tools kubectl get nodes | grep Ready | wc -l) -lt 4 ]; then
               sleep 5;
             else
               break
@@ -75,7 +75,7 @@ tasks:
           # wait for cluster components
           echo "Waiting for Helm Controller to install cluster components..."
           while true; do
-            if [ $(uds zarf tools kubectl get po -n kube-system -l batch.kubernetes.io/controller-uid --no-headers | egrep -v Completed | wc -l) -gt 0 ]; then
+            if [ $(./uds zarf tools kubectl get po -n kube-system -l batch.kubernetes.io/controller-uid --no-headers | egrep -v Completed | wc -l) -gt 0 ]; then
                sleep 5;
             else
               break
@@ -83,7 +83,7 @@ tasks:
           done
           echo "Waiting for cluster components to be ready...";
           while true; do
-            if [ $(uds zarf tools kubectl get po,job -A --no-headers=true | egrep -v 'Running|Complete' | wc -l) -gt 0 ]; then
+            if [ $(./uds zarf tools kubectl get po,job -A --no-headers=true | egrep -v 'Running|Complete' | wc -l) -gt 0 ]; then
               sleep 5;
             else
               echo "Cluster is ready!"

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
@@ -28,14 +28,14 @@ tasks:
       - description: "Publish amd64/arm64 packages per flavor"
         cmd: |
           echo "Publishing package to ${TARGET_REPO}"
-          uds zarf package publish build/zarf-package-core-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}
-          uds zarf package publish build/zarf-package-core-arm64-${VERSION}.tar.zst oci://${TARGET_REPO}
+          ./uds zarf package publish build/zarf-package-core-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}
+          ./uds zarf package publish build/zarf-package-core-arm64-${VERSION}.tar.zst oci://${TARGET_REPO}
 
       - description: "Tag the latest package (if a snapshot release)"
         cmd: |
           if [ $(echo "${TARGET_REPO}" | grep 'snapshot') ]; then
              pkgPath="${TARGET_REPO}/core"
-             uds zarf tools registry copy ${pkgPath}:${VERSION}-${FLAVOR} ${pkgPath}:latest-${FLAVOR}
+             ./uds zarf tools registry copy ${pkgPath}:${VERSION}-${FLAVOR} ${pkgPath}:latest-${FLAVOR}
           fi
 
   - name: checkpoint-package
@@ -43,7 +43,7 @@ tasks:
     actions:
       - description: "Publish the checkpoint package for the current UDS_ARCH"
         cmd: |
-          uds zarf package publish build/zarf-package-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst oci://ghcr.io/defenseunicorns/dev/uds/checkpoints
+          ./uds zarf package publish build/zarf-package-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst oci://ghcr.io/defenseunicorns/dev/uds/checkpoints
 
   - name: bundles
     description: "Publish UDS Bundles"
@@ -52,18 +52,18 @@ tasks:
       - description: "Publish amd64 and arm64 bundles"
         cmd: |
           echo "Publishing bundles to ${TARGET_REPO}"
-          uds publish bundles/k3d-standard/uds-bundle-k3d-*-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
-          uds publish bundles/k3d-standard/uds-bundle-k3d-*-arm64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
+          ./uds publish bundles/k3d-standard/uds-bundle-k3d-*-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
+          ./uds publish bundles/k3d-standard/uds-bundle-k3d-*-arm64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
 
-          uds publish bundles/k3d-slim-dev/uds-bundle-k3d-*-arm64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
-          uds publish bundles/k3d-slim-dev/uds-bundle-k3d-*-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
+          ./uds publish bundles/k3d-slim-dev/uds-bundle-k3d-*-arm64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
+          ./uds publish bundles/k3d-slim-dev/uds-bundle-k3d-*-amd64-${VERSION}.tar.zst oci://${TARGET_REPO}/bundles --no-progress
 
       - description: "Tag the latest bundles"
         cmd: |
           pkgPath="${TARGET_REPO}/bundles/k3d-core-demo"
-          uds zarf tools registry copy ${pkgPath}:${VERSION} ${pkgPath}:latest
+          ./uds zarf tools registry copy ${pkgPath}:${VERSION} ${pkgPath}:latest
           pkgPath="${TARGET_REPO}/bundles/k3d-core-slim-dev"
-          uds zarf tools registry copy ${pkgPath}:${VERSION} ${pkgPath}:latest
+          ./uds zarf tools registry copy ${pkgPath}:${VERSION} ${pkgPath}:latest
 
   - name: single-layer
     description: "Test and Publish UDS Core layer"
@@ -80,4 +80,4 @@ tasks:
           layer: ${LAYER}
       - task: utils:determine-repo
       - description: "Publish build of layer"
-        cmd: uds zarf package publish build/zarf-package-core-${LAYER}-${UDS_ARCH}-${VERSION}.tar.zst oci://${TARGET_REPO}
+        cmd: ./uds zarf package publish build/zarf-package-core-${LAYER}-${UDS_ARCH}-${VERSION}.tar.zst oci://${TARGET_REPO}

--- a/tasks/scan.yaml
+++ b/tasks/scan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:

--- a/tasks/scan.yaml
+++ b/tasks/scan.yaml
@@ -36,14 +36,14 @@ tasks:
           - name: VERSION
       - description: "Get latest tag version from OCI"
         if: ${{ eq .variables.VERSION "latest" }}
-        cmd: uds zarf tools registry ls ${TARGET_REPO}/${PACKAGE} | grep ${FLAVOR} | sort -V | tail -1
+        cmd: ./uds zarf tools registry ls ${TARGET_REPO}/${PACKAGE} | grep ${FLAVOR} | sort -V | tail -1
         setVariables:
           - name: VERSION
       - description: "Pull the SBOMs from the package"
         cmd: |
           rm -rf cve/sboms/${PACKAGE}
           mkdir -p cve/sboms
-          uds zarf package inspect sbom oci://${TARGET_REPO}/${PACKAGE}:${VERSION} --output cve/sboms
+          ./uds zarf package inspect sbom oci://${TARGET_REPO}/${PACKAGE}:${VERSION} --output cve/sboms
 
   # Note: This task assumes local SBOMs already available for the specified package
   - name: scan-sbom

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -6,7 +6,7 @@ tasks:
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/uds-k3d versioning=docker
-        cmd: "uds zarf package deploy oci://defenseunicorns/uds-k3d:0.19.5-airgap --confirm"
+        cmd: "./uds zarf package deploy oci://defenseunicorns/uds-k3d:0.19.5-airgap --confirm"
 
   - name: k3d-test-cluster
     actions:
@@ -14,7 +14,7 @@ tasks:
 
       - description: "Initialize the cluster with Zarf"
         # renovate: datasource=github-tags depName=zarf-dev/zarf versioning=semver
-        cmd: "uds zarf package deploy oci://ghcr.io/zarf-dev/packages/init:v0.74.0 --confirm"
+        cmd: "./uds zarf package deploy oci://ghcr.io/zarf-dev/packages/init:v0.74.0 --confirm"
 
   - name: ha-postgres
     actions:

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -24,7 +24,7 @@ tasks:
     actions:
       - task: create:pepr-build
       - task: setup:k3d-test-cluster
-      - cmd: uds run -f tasks/test.yaml single-layer --set FLAVOR=${FLAVOR} --set=layer=base
+      - cmd: ./uds run -f tasks/test.yaml single-layer --set FLAVOR=${FLAVOR} --set=layer=base
 
   - name: single-layer
     description: "Build and test a single layer, must set UDS_LAYER environment variable"
@@ -48,13 +48,13 @@ tasks:
     description: "Sets up a k3d cluster and deploys dependencies for the given layer"
     actions:
       - task: setup:k3d-test-cluster
-      - cmd: uds zarf tools yq '.metadata.x-uds-dependencies.[]' packages/${LAYER}/zarf.yaml 2>/dev/null
+      - cmd: ./uds zarf tools yq '.metadata.x-uds-dependencies.[]' packages/${LAYER}/zarf.yaml 2>/dev/null
         mute: true
         setVariables:
           - name: LAYER_DEPS
       - cmd: |
           for dep in $LAYER_DEPS; do
-            uds run -f tasks/test.yaml single-layer --set LAYER=$dep --set FLAVOR=${FLAVOR} --no-progress
+            ./uds run -f tasks/test.yaml single-layer --set LAYER=$dep --set FLAVOR=${FLAVOR} --no-progress
           done
 
   - name: validate-packages
@@ -70,9 +70,9 @@ tasks:
           for package in $(ls src); do
             if [ ! $(echo ${EXCLUDED_PACKAGES} | grep ${package}) ]; then
               if [ ${package} = "istio" ]; then
-                uds run -f src/${package}/tasks.yaml validate --no-progress --with validate_passthrough=${{ .inputs.validate_passthrough }}
+                ./uds run -f src/${package}/tasks.yaml validate --no-progress --with validate_passthrough=${{ .inputs.validate_passthrough }}
               else
-                uds run -f src/${package}/tasks.yaml validate --no-progress
+                ./uds run -f src/${package}/tasks.yaml validate --no-progress
               fi
             fi
           done
@@ -86,7 +86,7 @@ tasks:
         required: true
     actions:
       - cmd: |
-          uds run -f packages/${{ index .inputs "layer" }}/tasks.yaml validate --no-progress
+          ./uds run -f packages/${{ index .inputs "layer" }}/tasks.yaml validate --no-progress
 
   - name: e2e-tests
     description: "E2E Test all packages"
@@ -239,8 +239,8 @@ tasks:
           group: "/UDS Core/Admin"
       - description: "Setup Authservice App for Testing"
         cmd: |
-          uds zarf tools kubectl apply -f src/test/app-ambient-authservice-tenant-package.yaml
-          uds zarf tools kubectl label namespace authservice-ambient-test-app zarf.dev/agent=ignore
-          uds zarf tools kubectl apply -f src/test/app-ambient-authservice-tenant.yaml
+          ./uds zarf tools kubectl apply -f src/test/app-ambient-authservice-tenant-package.yaml
+          ./uds zarf tools kubectl label namespace authservice-ambient-test-app zarf.dev/agent=ignore
+          ./uds zarf tools kubectl apply -f src/test/app-ambient-authservice-tenant.yaml
       - task: private-pki:private-pki-tests
       - task: trust-bundle:trust-bundle-tests

--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -77,7 +77,7 @@ tasks:
       - description: Fetch Admin Gateway IP Address
         cmd: |
           IP_ADDR=$(./uds zarf tools kubectl get service -n istio-admin-gateway admin-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
-          if [ -z $IP_ADDR ]; then
+          if [ -z "$IP_ADDR" ]; then
             HOSTNAME=$(./uds zarf tools kubectl get service -n istio-admin-gateway admin-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
             IP_ADDR=$(dig +short $HOSTNAME | head -n1)
           fi; echo $IP_ADDR
@@ -90,7 +90,7 @@ tasks:
       - description: Fetch Tenant Gateway IP Address
         cmd: |
           IP_ADDR=$(./uds zarf tools kubectl get service -n istio-tenant-gateway tenant-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
-          if [ -z $IP_ADDR ]; then
+          if [ -z "$IP_ADDR" ]; then
             HOSTNAME=$(./uds zarf tools kubectl get service -n istio-tenant-gateway tenant-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
             IP_ADDR=$(dig +short $HOSTNAME | head -n1)
           fi; echo $IP_ADDR

--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 variables:
@@ -34,7 +34,7 @@ tasks:
     actions:
       - description: Setup Custom ConfigMap for Core DNS
         cmd: |
-          uds zarf tools kubectl apply -f - <<EOF
+          ./uds zarf tools kubectl apply -f - <<EOF
           apiVersion: v1
           data:
             uds.override: |
@@ -49,13 +49,13 @@ tasks:
             name: coredns-custom
             namespace: kube-system
           EOF
-          uds zarf tools kubectl -n kube-system rollout restart deployment coredns
+          ./uds zarf tools kubectl -n kube-system rollout restart deployment coredns
 
   - name: eks-storageclass-setup
     actions:
       - description: Setup GP3 Storage Class
         cmd: |
-          uds zarf tools kubectl apply -f - <<EOF
+          ./uds zarf tools kubectl apply -f - <<EOF
             apiVersion: storage.k8s.io/v1
             kind: StorageClass
             metadata:
@@ -76,9 +76,9 @@ tasks:
     actions:
       - description: Fetch Admin Gateway IP Address
         cmd: |
-          IP_ADDR=$(uds zarf tools kubectl get service -n istio-admin-gateway admin-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
+          IP_ADDR=$(./uds zarf tools kubectl get service -n istio-admin-gateway admin-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
           if [ -z $IP_ADDR ]; then
-            HOSTNAME=$(uds zarf tools kubectl get service -n istio-admin-gateway admin-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
+            HOSTNAME=$(./uds zarf tools kubectl get service -n istio-admin-gateway admin-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
             IP_ADDR=$(dig +short $HOSTNAME | head -n1)
           fi; echo $IP_ADDR
         mute: true
@@ -89,9 +89,9 @@ tasks:
     actions:
       - description: Fetch Tenant Gateway IP Address
         cmd: |
-          IP_ADDR=$(uds zarf tools kubectl get service -n istio-tenant-gateway tenant-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
+          IP_ADDR=$(./uds zarf tools kubectl get service -n istio-tenant-gateway tenant-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)
           if [ -z $IP_ADDR ]; then
-            HOSTNAME=$(uds zarf tools kubectl get service -n istio-tenant-gateway tenant-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
+            HOSTNAME=$(./uds zarf tools kubectl get service -n istio-tenant-gateway tenant-ingressgateway -o=jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
             IP_ADDR=$(dig +short $HOSTNAME | head -n1)
           fi; echo $IP_ADDR
         mute: true


### PR DESCRIPTION
## Description

Replaces `uds` with `./uds` in tasks to enable testing/use of different versions of uds cli without having to rename/reinstall difference versions of cli and rely solely on shell path (i.e. keeping multiple copies like uds-cli-v0.29.0)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Steps to Validate
- Run uds tasks with a different version of uds-cli that's been renamed (i.e. `uds-cli-v0.29.0`). To validate the correct binary is being used, you can add an extra `cmd` step to a task to `echo $(./uds version)` and validate the expected version of the calling uds-cli binary is echo'd

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
