### PR TITLE
chore(renovate): add minimumReleaseAge for npm support dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -104,7 +104,6 @@
         "**/package-lock.json"
       ],
       "groupName": "support-deps",
-      "matchDepTypes": ["devDependencies"],
       "commitMessageTopic": "support dependencies",
       "minimumReleaseAge": "5 days"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -100,8 +100,8 @@
       "matchFileNames": [
         "package.json",
         "package-lock.json",
-        "docs/.c4/package.json",
-        "docs/.c4/package-lock.json"
+        "**/package.json",
+        "**/package-lock.json"
       ],
       "groupName": "support-deps",
       "matchDepTypes": ["devDependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "github>defenseunicorns/uds-common//config/renovate.json5",
     ":semanticCommits",
-    ":semanticCommitTypeAll(chore)"
+    ":semanticCommitTypeAll(chore)",
+    "security:minimumReleaseAgeNpm"
   ],
   "ignorePresets": [":ignoreModulesAndTests"],
   "branchConcurrentLimit": 0,

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "extends": [
     "github>defenseunicorns/uds-common//config/renovate.json5",
     ":semanticCommits",
-    ":semanticCommitTypeAll(chore)",
-    "security:minimumReleaseAgeNpm"
+    ":semanticCommitTypeAll(chore)"
   ],
   "ignorePresets": [":ignoreModulesAndTests"],
   "branchConcurrentLimit": 0,
@@ -106,7 +105,8 @@
       ],
       "groupName": "support-deps",
       "matchDepTypes": ["devDependencies"],
-      "commitMessageTopic": "support dependencies"
+      "commitMessageTopic": "support dependencies",
+      "minimumReleaseAge": "5 days"
     },
     {
       "matchFileNames": [


### PR DESCRIPTION
## Description

This adds renovate's [`minimumReleaseAge`](https://docs.renovatebot.com/key-concepts/minimum-release-age/) set to 5 days for all support dependencies on our `package.json`s.

An alternative would be to use the [Renovate preset](https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm) however we'd likely want to override to NOT set that for Pepr/KFC.

Note: We could also evaluate this for github actions if desired.