### PR TITLE
chore(renovate): set min release age for pepr to null

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -119,7 +119,8 @@
         "defenseunicorns/pepr"
       ],
       "groupName": "pepr",
-      "commitMessageTopic": "pepr"
+      "commitMessageTopic": "pepr",
+      "minimumReleaseAge": null
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Description

Noticed in https://github.com/defenseunicorns/uds-core/pull/2540 that the newly added setting is also being set for Pepr itself.