### PR TITLE
feat: add upstream istio network policies

### DIFF
--- a/src/istio/values/base-cni.yaml
+++ b/src/istio/values/base-cni.yaml
@@ -1,7 +1,11 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 profile: ambient
+
+global:
+  networkPolicy:
+    enabled: true
 
 cniConfDir: ###ZARF_VAR_CNI_CONF_DIR###
 cniBinDir: ###ZARF_VAR_CNI_BIN_DIR###

--- a/src/istio/values/base-gateway.yaml
+++ b/src/istio/values/base-gateway.yaml
@@ -1,9 +1,6 @@
-# Copyright 2024-2026 Defense Unicorns
+# Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 global:
   networkPolicy:
     enabled: true
-
-service:
-  type: ClusterIP

--- a/src/istio/values/base-istiod.yaml
+++ b/src/istio/values/base-istiod.yaml
@@ -1,7 +1,11 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 profile: ambient
+
+global:
+  networkPolicy:
+    enabled: true
 
 meshConfig:
   # @lulaStart 98a6ad94-c638-4a31-8519-e823db7457f3

--- a/src/istio/values/base-ztunnel.yaml
+++ b/src/istio/values/base-ztunnel.yaml
@@ -1,5 +1,9 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+global:
+  networkPolicy:
+    enabled: true
 
 # SELinux enforcing environments require the spc_t SELinux type
 seLinuxOptions:

--- a/src/istio/zarf.yaml
+++ b/src/istio/zarf.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 kind: ZarfPackageConfig
@@ -101,6 +101,8 @@ components:
         version: 1.29.1
         releaseName: admin-ingressgateway
         namespace: istio-admin-gateway
+        valuesFiles:
+          - "values/base-gateway.yaml"
       - name: uds-istio-config
         version: 0.2.0
         localPath: charts/uds-istio-config
@@ -116,6 +118,8 @@ components:
         version: 1.29.1
         releaseName: tenant-ingressgateway
         namespace: istio-tenant-gateway
+        valuesFiles:
+          - "values/base-gateway.yaml"
       - name: uds-istio-config
         version: 0.2.0
         localPath: charts/uds-istio-config
@@ -131,6 +135,8 @@ components:
         version: 1.29.1
         releaseName: passthrough-ingressgateway
         namespace: istio-passthrough-gateway
+        valuesFiles:
+          - "values/base-gateway.yaml"
       - name: uds-istio-config
         version: 0.2.0
         localPath: charts/uds-istio-config


### PR DESCRIPTION
## Description

Enables upstream Istio 1.29.1 NetworkPolicies for all Istio components.

**NetworkPolicies added**

  istiod (istio-system)
  - Ingress: webhook (15017), xDS (15010-15012), debug (8080), metrics (15014)
  - Egress: all

  istio-cni (istio-system)
  - Ingress: metrics (15014), readiness (8000)
  - Egress: all

  ztunnel (istio-system)
  - Ingress: readiness (15021), metrics (15020), admin (15000), HBONE (15008), outbound (15001)
  - Egress: all

  admin-ingressgateway (istio-admin-gateway)
  - Ingress: health (15021), metrics (15020, 15090), HTTP (80), HTTPS (443)
  - Egress: all

  tenant-ingressgateway (istio-tenant-gateway)
  - Ingress: health (15021), metrics (15020, 15090), HTTP (80), HTTPS (443)
  - Egress: all

  passthrough-ingressgateway (istio-passthrough-gateway)
  - Ingress: health (15021), metrics (15020, 15090), HTTP (80), HTTPS (443)
  - Egress: all

  egressgateway (istio-egress-gateway)
  - Ingress: health (15021), metrics (15020, 15090), HTTP (80), HTTPS (443)
  - Egress: all

Note: Ambient Egress does not use the upstream helm chart, so not adding a netpol for that (the Authorization Policies created by the operator already lock down).

## Related Issue

Fixes CORE-1

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run test:uds-core-e2e`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
