### PR TITLE
feat: allow annotation/label overrides for keycloak waypoint pod

### DIFF
--- a/src/keycloak/chart/templates/waypoint-config.yaml
+++ b/src/keycloak/chart/templates/waypoint-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 apiVersion: v1

--- a/src/keycloak/chart/templates/waypoint-config.yaml
+++ b/src/keycloak/chart/templates/waypoint-config.yaml
@@ -11,6 +11,17 @@ data:
   deployment: |
     spec:
       template:
+        {{- if or .podAnnotations .podLabels }}
+        metadata:
+          {{- if .podAnnotations }}
+          annotations:
+            {{- toYaml .podAnnotations | nindent 12 }}
+          {{- end }}
+          {{- if .podLabels }}
+          labels:
+            {{- toYaml .podLabels | nindent 12 }}
+          {{- end }}
+        {{- end }}
         spec:
           containers:
           - name: istio-proxy

--- a/src/keycloak/chart/tests/kc_waypoint_config_test.yaml
+++ b/src/keycloak/chart/tests/kc_waypoint_config_test.yaml
@@ -107,6 +107,35 @@ tests:
                       whenUnsatisfiable: DoNotSchedule
                   priorityClassName: most-urgent
 
+  - it: should render deployment with custom pod annotations and labels
+    set:
+      waypoint.deployment.podAnnotations:
+        my-annotation: foo
+      waypoint.deployment.podLabels:
+        my-label: bar
+    template: waypoint-config.yaml
+    asserts:
+      - equal:
+          path: data.deployment
+          value: |
+            spec:
+              template:
+                metadata:
+                  annotations:
+                    my-annotation: foo
+                  labels:
+                    my-label: bar
+                spec:
+                  containers:
+                  - name: istio-proxy
+                    resources:
+                      requests:
+                        cpu: 250m
+                        memory: 256Mi
+                      limits:
+                        cpu: 2
+                        memory: 1Gi
+
   - it: should not render horizontalPodAutoscaler when disabled
     set:
       waypoint.horizontalPodAutoscaler.enabled: false

--- a/src/keycloak/chart/tests/kc_waypoint_config_test.yaml
+++ b/src/keycloak/chart/tests/kc_waypoint_config_test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json

--- a/src/keycloak/chart/tests/kc_waypoint_config_test.yaml
+++ b/src/keycloak/chart/tests/kc_waypoint_config_test.yaml
@@ -107,7 +107,57 @@ tests:
                       whenUnsatisfiable: DoNotSchedule
                   priorityClassName: most-urgent
 
-  - it: should render deployment with custom pod annotations and labels
+  - it: should render deployment with only pod annotations
+    set:
+      waypoint.deployment.podAnnotations:
+        my-annotation: foo
+    template: waypoint-config.yaml
+    asserts:
+      - equal:
+          path: data.deployment
+          value: |
+            spec:
+              template:
+                metadata:
+                  annotations:
+                    my-annotation: foo
+                spec:
+                  containers:
+                  - name: istio-proxy
+                    resources:
+                      requests:
+                        cpu: 250m
+                        memory: 256Mi
+                      limits:
+                        cpu: 2
+                        memory: 1Gi
+
+  - it: should render deployment with only pod labels
+    set:
+      waypoint.deployment.podLabels:
+        my-label: bar
+    template: waypoint-config.yaml
+    asserts:
+      - equal:
+          path: data.deployment
+          value: |
+            spec:
+              template:
+                metadata:
+                  labels:
+                    my-label: bar
+                spec:
+                  containers:
+                  - name: istio-proxy
+                    resources:
+                      requests:
+                        cpu: 250m
+                        memory: 256Mi
+                      limits:
+                        cpu: 2
+                        memory: 1Gi
+
+  - it: should render deployment with both pod annotations and labels
     set:
       waypoint.deployment.podAnnotations:
         my-annotation: foo

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -157,6 +157,12 @@
         "deployment": {
           "type": "object",
           "properties": {
+            "podAnnotations": {
+              "type": "object"
+            },
+            "podLabels": {
+              "type": "object"
+            },
             "requests": {
               "$ref": "#/definitions/resourcesSchema"
             },

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -377,7 +377,9 @@ autoscaling:
 # Istio waypoint configuration
 waypoint:
   deployment:
+    # Additional annotations to add to the waypoint pods
     podAnnotations: {}
+    # Additional labels to add to the waypoint pods
     podLabels: {}
     # Larger requests by default since Keycloak manages all SSO for the cluster
     requests:

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -377,6 +377,8 @@ autoscaling:
 # Istio waypoint configuration
 waypoint:
   deployment:
+    podAnnotations: {}
+    podLabels: {}
     # Larger requests by default since Keycloak manages all SSO for the cluster
     requests:
       cpu: 250m


### PR DESCRIPTION
## Description

Adds pod/label helm values to keycloak waypoint config.

## Related Issue

Fixes CORE-470

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- override slim-dev bundle with:
```yaml
  waypoint:
    deployment:
      podAnnotations:
        test: "true"
      podLabels:
        test: "true"
```
- deploy slim-dev bundle and ensure labels/annotations are present

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
