### PR TITLE
chore(docs): enable release branch versioned docs

### DIFF
--- a/docs/docs.config.json
+++ b/docs/docs.config.json
@@ -3,6 +3,8 @@
   "label": "Core",
   "contentDir": "core",
   "description": "The platform layer deployed onto a Kubernetes cluster. Bundles Istio (service mesh and ingress), Keycloak (identity and SSO), Authservice (SSO proxy for apps without native OIDC), Prometheus + Grafana + Alertmanager (monitoring), Vector + Loki (logging), Falco (runtime security), and Pepr (policy engine and operator framework). Exposes UDS Package, UDS Exemption, and UDS ClusterConfig CRDs for application and platform integration.",
+  "versionSource": "branch",
+  "archiveCount": 3,
   "sidebarOrder": [
     "getting-started",
     "concepts",


### PR DESCRIPTION
## Description
Now that release branches are allowed in the uds-docs we want to utilize this and enable our versioned docs. This is set to `3` so that upon our next release `1.2.0` that new version will be pulled in.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- With `uds-docs` and `uds-core` locally run the following command:
```
cd <uds-docs path>
DOCS_OVERRIDES="<uds-core path>" npm run build && npm run preview
```

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
