### PR TITLE
docs: add keycloak admin handling doc

### DIFF
--- a/docs/dev/keycloak-crl-airgap.md
+++ b/docs/dev/keycloak-crl-airgap.md
@@ -170,7 +170,7 @@ uds run create:k3d-slim-dev-bundle
 UDS_CONFIG=bundles/k3d-slim-dev/uds-config.yaml uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-amd64-*.tar.zst --confirm --no-progress
 
 # Connect Keycloak Admin Portal
-zarf connect keycloak
+uds zarf connect keycloak
 ```
 
 ---

--- a/docs/how-to-guides/identity-and-authorization/build-deploy-custom-image.mdx
+++ b/docs/how-to-guides/identity-and-authorization/build-deploy-custom-image.mdx
@@ -2,7 +2,7 @@
 title: Build a custom Keycloak configuration image
 description: Build a custom uds-identity-config image with your Keycloak theme, plugin, or truststore changes and deploy it via the configImage Helm override.
 sidebar:
-  order: 3.007
+  order: 3.019
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-account-inactivity-disable.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-account-inactivity-disable.mdx
@@ -2,7 +2,7 @@
 title: Configure automatic account inactivity disable
 description: Configure Keycloak to automatically disable non-admin user accounts after a set number of days of inactivity.
 sidebar:
-  order: 3.020
+  order: 3.010
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-account-lockout.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-account-lockout.mdx
@@ -2,7 +2,7 @@
 title: Configure Keycloak account lockout
 description: Configure Keycloak's brute-force protection to set temporary and permanent account lockout thresholds via bundle overrides.
 sidebar:
-  order: 3.011
+  order: 3.009
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-authentication-flows.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-authentication-flows.mdx
@@ -2,7 +2,7 @@
 title: Configure Keycloak authentication methods
 description: Enable or disable Keycloak login methods (including X.509/CAC, WebAuthn, OTP, and social login) using bundle overrides.
 sidebar:
-  order: 3.003
+  order: 3.007
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-device-flow.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-device-flow.mdx
@@ -2,7 +2,7 @@
 title: Configure OAuth 2.0 device flow
 description: Configure a UDS Package to use OAuth 2.0 Device Authorization Grant for CLI tools and headless devices that cannot use browser-based redirects.
 sidebar:
-  order: 3.010
+  order: 3.006
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-google-idp.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-google-idp.mdx
@@ -2,7 +2,7 @@
 title: Configure Google SAML as an identity provider
 description: Connect Google SAML as an external identity provider in Keycloak using bundle overrides, with no Keycloak admin UI configuration required.
 sidebar:
-  order: 3.015
+  order: 3.016
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-http-retries.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-http-retries.mdx
@@ -2,7 +2,7 @@
 title: Configure Keycloak HTTP retries
 description: Enable and tune Keycloak's outbound HTTP retry behavior for requests to external identity providers and services.
 sidebar:
-  order: 3.006
+  order: 3.013
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-login-policies.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-login-policies.mdx
@@ -2,7 +2,7 @@
 title: Configure Keycloak login policies
 description: Configure Keycloak session limits, idle timeouts, and logout confirmation behavior via bundle overrides.
 sidebar:
-  order: 3.005
+  order: 3.008
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-keycloak-notifications-and-alerts.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-keycloak-notifications-and-alerts.mdx
@@ -2,7 +2,7 @@
 title: Configure Keycloak notifications and alerts
 description: Enable Prometheus alerting rules for Keycloak realm and user account changes, routing notifications through Alertmanager.
 sidebar:
-  order: 3.019
+  order: 3.014
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-service-accounts.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-service-accounts.mdx
@@ -2,7 +2,7 @@
 title: Configure service account clients
 description: Configure a Keycloak client with OAuth 2.0 Client Credentials Grant so automated processes can obtain tokens without a user session.
 sidebar:
-  order: 3.009
+  order: 3.005
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-truststore.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-truststore.mdx
@@ -2,7 +2,7 @@
 title: Configure the CA truststore
 description: Replace the default DoD CA bundle in the uds-identity-config image with a custom CA bundle for X.509/CAC certificate validation.
 sidebar:
-  order: 3.008
+  order: 3.017
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-user-account-settings.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-user-account-settings.mdx
@@ -2,7 +2,7 @@
 title: Configure user accounts and security policies
 description: Configure Keycloak user account behavior (password policy, email verification, username format, and security allow lists) via bundle overrides.
 sidebar:
-  order: 3.013
+  order: 3.011
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/configure-x509-crl-airgap.mdx
+++ b/docs/how-to-guides/identity-and-authorization/configure-x509-crl-airgap.mdx
@@ -2,7 +2,7 @@
 title: Configure Keycloak Airgap CRLs
 description: Configure Keycloak to validate X.509/CAC certificates against locally loaded CRLs in an airgapped environment where OCSP is unreachable.
 sidebar:
-  order: 3.017
+  order: 3.018
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/connect-azure-ad-idp.mdx
+++ b/docs/how-to-guides/identity-and-authorization/connect-azure-ad-idp.mdx
@@ -2,7 +2,7 @@
 title: Connect Azure AD as an identity provider
 description: Configure Azure Entra ID as a SAML identity provider in Keycloak so users authenticate via Azure instead of local Keycloak accounts.
 sidebar:
-  order: 3.004
+  order: 3.015
 ---
 
 import { Steps } from '@astrojs/starlight/components';
@@ -74,7 +74,7 @@ You will configure two App Registrations in Azure (one per Keycloak realm) and t
    Log in to the Keycloak admin UI at `keycloak.<admin_domain>`.
 
    > [!NOTE]
-   > If UDS Core was deployed with `INSECURE_ADMIN_PASSWORD_GENERATION`, the username is `admin` and the password is in the `keycloak-admin-password` Kubernetes secret. Otherwise, register an admin user via `zarf connect keycloak`.
+   > If UDS Core was deployed with `INSECURE_ADMIN_PASSWORD_GENERATION`, the username is `admin` and the password is in the `keycloak-admin-password` Kubernetes secret. Otherwise, register an admin user via `uds zarf connect keycloak`.
 
    **Disable required actions** so Azure-federated users are not prompted to configure local credentials:
    1. Go to **Authentication** → **Required actions**

--- a/docs/how-to-guides/identity-and-authorization/enforce-group-based-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/enforce-group-based-access.mdx
@@ -2,7 +2,7 @@
 title: Enforce group-based access controls
 description: Restrict a UDS application to only users in specific Keycloak groups, denying access to all others even with valid accounts.
 sidebar:
-  order: 3.002
+  order: 3.004
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
@@ -9,7 +9,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## What you'll accomplish
 
-You'll create, use, and remove a Keycloak admin account in the master realm as a just-in-time credential. UDS Core ships without a default admin, so you must bootstrap one before you can access the admin console at `https://keycloak.<admin_domain>/`. This guide covers the two supported bootstrap methods and the recommended lifecycle for keeping admin credentials out of the cluster.
+You'll create, use, and remove a Keycloak admin account in the master realm. UDS Core ships without a default admin, so you must bootstrap one before you can access the admin console at `https://keycloak.<admin_domain>/`. This guide covers the two supported bootstrap methods and the recommended lifecycle for keeping admin credentials out of the cluster.
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ You'll create, use, and remove a Keycloak admin account in the master realm as a
 
 UDS Core does not create a default admin user in any realm. You must create the first admin in the **master realm** (Keycloak's built-in admin realm) before you can manage the `uds` realm or any of its clients. Two bootstrap methods are supported:
 
-- `uds zarf connect keycloak` opens a port-forward to the Keycloak HTTP service so you can register an admin through the browser-based first-run form. This is the preferred method for all interactive installs.
+- `uds zarf connect keycloak` opens a port-forward to the Keycloak HTTP service so you can register an admin through the browser-based Welcome Page. This is the preferred method for all interactive installs.
 - `insecureAdminPasswordGeneration` is a Helm value that provisions an admin user from a Kubernetes Secret at chart install time. Use this method only when you cannot run the interactive flow (for example, fully automated installs with no browser access).
 
 Treat every admin account as a break-glass credential. The goal is to have no standing admin user when administrative work is not in progress:
@@ -60,7 +60,7 @@ Treat every admin account as a break-glass credential. The goal is to have no st
    2026-04-16 17:11:00 INF Tunnel established, waiting for user to interrupt (ctrl-c to end) urls=http://127.0.0.1:56641
    ```
 
-   Open the URL shown next to `urls=` in a browser to reach Keycloak's first-run admin form. Fill in every field (**Username**, **Password**, **Email**, **First name**, **Last name**) and submit to create the master realm admin user. Leave the terminal running until you have submitted the form; pressing **Ctrl-C** closes the tunnel.
+   Open the URL shown next to `urls=` in a browser to reach Keycloak's Welcome Page. Fill in every field (**Username**, **Password**, **Email**, **First name**, **Last name**) and submit to create the master realm admin user. Leave the terminal running until you have submitted the form; pressing **Ctrl-C** closes the tunnel.
 
    > [!TIP]
    > Use a username tied to the individual performing the work (for example, `firstname.lastname`). Avoid generic names like `admin` or `root` so the account cannot be reused as a shared credential and so audit logs clearly attribute actions.
@@ -131,9 +131,9 @@ Log in at `https://keycloak.<admin_domain>/` with your admin credentials and con
 
 ## Troubleshooting
 
-### Problem: `uds zarf connect keycloak` does not show the first-run form
+### Problem: `uds zarf connect keycloak` does not show the Welcome Page
 
-**Symptom:** The tunnel URL loads the Keycloak sign-in page rather than the "Create administrative user" first-run form.
+**Symptom:** The tunnel URL loads the Keycloak sign-in page rather than the "Create administrative user" Welcome Page.
 
 **Solution:** A master realm admin already exists or did previously. Log in with those credentials, or follow the [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) runbook to bootstrap a temporary admin.
 

--- a/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
@@ -15,7 +15,7 @@ You'll create, use, and remove a Keycloak admin account in the master realm as a
 
 - UDS Core deployed
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
-- Access to a Kubernetes cluster with `kubectl` permissions in the `keycloak` namespace
+- Access to a Kubernetes cluster with permissions in the `keycloak` namespace
 - For the headless option, familiarity with bundle overrides
 
 ## Before you begin

--- a/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
@@ -113,9 +113,9 @@ Treat every admin account as a break-glass credential. The goal is to have no st
    > [!IMPORTANT]
    > Deleting the Secret does not remove or alter the admin user in Keycloak. It only clears the plaintext copy of the initial password from the cluster. The `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` environment variables are only read on first startup, so deleting the Secret has no runtime effect after the initial bootstrap.
 
-3. **Delete the admin user when the work is complete**
+3. **(Optional) Delete the admin user when the work is complete**
 
-   After you finish the administrative task, remove the account so that no standing admin credential exists. Bootstrap a fresh one the next time you need admin access.
+   Removing the account after you finish the administrative task is recommended for security: no standing admin credential exists, and you bootstrap a fresh one the next time you need admin access. This step is optional; retain the account if your operational model requires a persistent master realm admin.
 
    1. In the Keycloak admin console, click the menu icon in the top-left and select **Users**.
    2. Select the admin user you created, click the three-dot menu, and choose **Delete**.

--- a/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
@@ -34,6 +34,9 @@ Treat every admin account as a break-glass credential. The goal is to have no st
 > [!CAUTION]
 > A standing admin account or a leftover `keycloak-admin-password` Secret is equivalent to a cluster-wide superuser credential that anyone with `get secret` access in the `keycloak` namespace can read. Remove both as soon as your administrative task is complete.
 
+> [!NOTE]
+> Use this guide only to bootstrap the **first** master realm admin on a cluster. Once an admin has existed, the `uds zarf connect keycloak` first-run form will not reappear and `insecureAdminPasswordGeneration` only fires on the initial install. To bootstrap a replacement admin later, follow the [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) runbook, which walks through `kc.sh bootstrap-admin` to create a temporary admin.
+
 ## Steps
 
 <Steps>
@@ -119,9 +122,6 @@ Treat every admin account as a break-glass credential. The goal is to have no st
 
    1. In the Keycloak admin console, click the menu icon in the top-left and select **Users**.
    2. Select the admin user you created, click the three-dot menu, and choose **Delete**.
-
-   > [!NOTE]
-   > Once a master realm admin has existed, the `uds zarf connect keycloak` first-run form will not reappear and `insecureAdminPasswordGeneration` only fires on the initial install. To bootstrap a replacement admin later, follow the [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) runbook, which walks through `kc.sh bootstrap-admin` to create a temporary admin.
 
 </Steps>
 

--- a/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
@@ -35,7 +35,7 @@ Treat every admin account as a break-glass credential. The goal is to have no st
 > A standing admin account or a leftover `keycloak-admin-password` Secret is equivalent to a cluster-wide superuser credential that anyone with `get secret` access in the `keycloak` namespace can read. Remove both as soon as your administrative task is complete.
 
 > [!NOTE]
-> Use this guide only to bootstrap the **first** master realm admin on a cluster. Once an admin has existed, the `uds zarf connect keycloak` first-run form will not reappear and `insecureAdminPasswordGeneration` only fires on the initial install. To bootstrap a replacement admin later, follow the [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) runbook, which walks through `kc.sh bootstrap-admin` to create a temporary admin.
+> Use this guide only to bootstrap the **first** master realm admin on a cluster. Once an admin has existed (even if later deleted) you must bootstrap a replacement admin following the [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) runbook, which walks through `kc.sh bootstrap-admin`.
 
 ## Steps
 

--- a/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-admin-access.mdx
@@ -1,0 +1,149 @@
+---
+title: Manage Keycloak admin access
+description: Create, rotate, and remove the Keycloak master realm admin account using `uds zarf connect keycloak` or the headless `insecureAdminPasswordGeneration` bundle override.
+sidebar:
+  order: 3.001
+---
+
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+## What you'll accomplish
+
+You'll create, use, and remove a Keycloak admin account in the master realm as a just-in-time credential. UDS Core ships without a default admin, so you must bootstrap one before you can access the admin console at `https://keycloak.<admin_domain>/`. This guide covers the two supported bootstrap methods and the recommended lifecycle for keeping admin credentials out of the cluster.
+
+## Prerequisites
+
+- UDS Core deployed
+- [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- Access to a Kubernetes cluster with `kubectl` permissions in the `keycloak` namespace
+- For the headless option, familiarity with bundle overrides
+
+## Before you begin
+
+UDS Core does not create a default admin user in any realm. You must create the first admin in the **master realm** (Keycloak's built-in admin realm) before you can manage the `uds` realm or any of its clients. Two bootstrap methods are supported:
+
+- `uds zarf connect keycloak` opens a port-forward to the Keycloak HTTP service so you can register an admin through the browser-based first-run form. This is the preferred method for all interactive installs.
+- `insecureAdminPasswordGeneration` is a Helm value that provisions an admin user from a Kubernetes Secret at chart install time. Use this method only when you cannot run the interactive flow (for example, fully automated installs with no browser access).
+
+Treat every admin account as a break-glass credential. The goal is to have no standing admin user when administrative work is not in progress:
+
+- **Do not keep a long-lived admin.** Create an account for a specific change window, delete it when the work is complete, and bootstrap a fresh one the next time you need admin access.
+- **Do not share** admin credentials across users. Each operator should create their own individually-named account so that audit logs clearly attribute actions.
+- **Do not leave credentials in the cluster.** The `keycloak-admin-password` Secret created by the headless option is an initial bootstrap only. Rotate the password and delete the Secret as soon as you have logged in.
+
+> [!CAUTION]
+> A standing admin account or a leftover `keycloak-admin-password` Secret is equivalent to a cluster-wide superuser credential that anyone with `get secret` access in the `keycloak` namespace can read. Remove both as soon as your administrative task is complete.
+
+## Steps
+
+<Steps>
+
+1. **Bootstrap an admin user for the task at hand**
+
+   Pick one of the following methods. Run this step only when you have administrative work to do, and plan to delete the account once the work is complete.
+
+   <Tabs>
+   <TabItem label="Interactive (zarf connect)">
+
+   Run `uds zarf connect keycloak` from a machine with browser access. The command opens a port-forward to the Keycloak HTTP service (labeled `zarf.dev/connect-name: keycloak`) and prints a local tunnel URL:
+
+   ```bash
+   uds zarf connect keycloak
+   ```
+
+   Example output:
+
+   ```console
+   2026-04-16 17:11:00 INF Tunnel established, waiting for user to interrupt (ctrl-c to end) urls=http://127.0.0.1:56641
+   ```
+
+   Open the URL shown next to `urls=` in a browser to reach Keycloak's first-run admin form. Fill in every field (**Username**, **Password**, **Email**, **First name**, **Last name**) and submit to create the master realm admin user. Leave the terminal running until you have submitted the form; pressing **Ctrl-C** closes the tunnel.
+
+   > [!TIP]
+   > Use a username tied to the individual performing the work (for example, `firstname.lastname`). Avoid generic names like `admin` or `root` so the account cannot be reused as a shared credential and so audit logs clearly attribute actions.
+
+   </TabItem>
+   <TabItem label="Headless (bundle override)">
+
+   Enable `insecureAdminPasswordGeneration` in your bundle when the cluster has no route to the Keycloak UI. The chart generates a 32-character random password at install time and stores it in the `keycloak-admin-password` Secret in the `keycloak` namespace. Keycloak reads `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` from that Secret as bootstrap environment variables on first startup.
+
+   ```yaml title="uds-bundle.yaml"
+   packages:
+     - name: core
+       repository: registry.defenseunicorns.com/public/core
+       ref: x.x.x-upstream
+       overrides:
+         keycloak:
+           keycloak:
+             values:
+               # Generates the master realm admin from a cluster Secret.
+               # Intended for headless installs only; rotate the password and delete the Secret immediately after first login.
+               - path: insecureAdminPasswordGeneration.enabled
+                 value: true
+               # Optional: override the generated username. Defaults to `admin`.
+               - path: insecureAdminPasswordGeneration.username
+                 value: admin
+   ```
+
+   After deploy, retrieve the generated password:
+
+   ```bash
+   uds zarf tools kubectl get secret -n keycloak keycloak-admin-password -o go-template='{{ .data.password | base64decode }}'
+   ```
+
+   > [!WARNING]
+   > The generated password is stored in a cluster Secret. Anyone with `get secret` access in the `keycloak` namespace can read it. Rotate the password and delete the Secret as soon as you have logged in once.
+   </TabItem>
+   </Tabs>
+
+2. **Rotate the bootstrap password and clear the in-cluster Secret if needed**
+
+   Log in to `https://keycloak.<admin_domain>/` with the bootstrap credentials, then change the password immediately:
+
+   1. Keycloak opens in the **master** realm by default. Click the menu icon in the top-left and select **Users**.
+   2. Select your admin user, then open the **Credentials** tab.
+   3. Click **Reset password** and set a new strong password. Clear the **Temporary** toggle if you want the new password to persist.
+
+   If you used the headless method, the rotated password is known only to you; the `keycloak-admin-password` Secret still holds the original generated value and should now be treated as stale. Delete it so that old credentials are not left behind in the cluster:
+
+   ```bash
+   uds zarf tools kubectl delete secret -n keycloak keycloak-admin-password
+   ```
+
+   > [!IMPORTANT]
+   > Deleting the Secret does not remove or alter the admin user in Keycloak. It only clears the plaintext copy of the initial password from the cluster. The `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` environment variables are only read on first startup, so deleting the Secret has no runtime effect after the initial bootstrap.
+
+3. **Delete the admin user when the work is complete**
+
+   After you finish the administrative task, remove the account so that no standing admin credential exists. Bootstrap a fresh one the next time you need admin access.
+
+   1. In the Keycloak admin console, click the menu icon in the top-left and select **Users**.
+   2. Select the admin user you created, click the three-dot menu, and choose **Delete**.
+
+   > [!NOTE]
+   > Once a master realm admin has existed, the `uds zarf connect keycloak` first-run form will not reappear and `insecureAdminPasswordGeneration` only fires on the initial install. To bootstrap a replacement admin later, follow the [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) runbook, which walks through `kc.sh bootstrap-admin` to create a temporary admin.
+
+</Steps>
+
+## Verification
+
+Log in at `https://keycloak.<admin_domain>/` with your admin credentials and confirm you can view **Users**, **Clients**, and **Realm settings** in the master realm.
+
+## Troubleshooting
+
+### Problem: `uds zarf connect keycloak` does not show the first-run form
+
+**Symptom:** The tunnel URL loads the Keycloak sign-in page rather than the "Create administrative user" first-run form.
+
+**Solution:** A master realm admin already exists or did previously. Log in with those credentials, or follow the [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) runbook to bootstrap a temporary admin.
+
+### Problem: `keycloak-admin-password` Secret is missing
+
+**Symptom:** The Secret does not exist in the `keycloak` namespace.
+
+**Solution:** The chart only generates the Secret on initial install when `insecureAdminPasswordGeneration.enabled: true` is set in the bundle. Enabling the override on an existing deployment does not create it retroactively. If you did not set the override at install time, use the interactive `uds zarf connect keycloak` method to create the admin instead.
+
+## Related documentation
+
+- [Keycloak Credential Recovery](/operations/troubleshooting-and-runbooks/keycloak-credential-recovery/) - Recover access when admin credentials are lost.
+- [Keycloak Admin bootstrap and recovery](https://www.keycloak.org/server/bootstrap-admin-recovery) - Upstream reference for the `kc.sh bootstrap-admin` command.

--- a/docs/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu.mdx
+++ b/docs/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu.mdx
@@ -2,7 +2,7 @@
 title: Manage Keycloak with OpenTofu
 description: Use the uds-opentofu-client and OpenTofu Keycloak provider to programmatically manage Keycloak groups, clients, and identity providers.
 sidebar:
-  order: 3.014
+  order: 3.021
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/overview.mdx
+++ b/docs/how-to-guides/identity-and-authorization/overview.mdx
@@ -15,6 +15,16 @@ For background on how Keycloak, Authservice, and SSO work together, see [Identit
 
 <CardGrid>
   <LinkCard
+    title="Manage Keycloak admin access"
+    description="Bootstrap a temporary Keycloak admin user, then remove it when the work is complete."
+    href="/how-to-guides/identity-and-authorization/manage-admin-access/"
+  />
+  <LinkCard
+    title="Register and customize SSO clients"
+    description="Register native OIDC or SAML clients, customize secrets, add protocol mappers, and configure client attributes."
+    href="/how-to-guides/identity-and-authorization/register-and-customize-sso-clients/"
+  />
+  <LinkCard
     title="Protect non-OIDC apps with SSO"
     description="Add SSO protection to applications that have no native OIDC support."
     href="/how-to-guides/identity-and-authorization/protect-apps-with-authservice/"
@@ -23,36 +33,6 @@ For background on how Keycloak, Authservice, and SSO work together, see [Identit
     title="Enforce group-based access controls"
     description="Restrict application access to users in specific Keycloak groups using the `Package` CR."
     href="/how-to-guides/identity-and-authorization/enforce-group-based-access/"
-  />
-  <LinkCard
-    title="Configure Keycloak authentication methods"
-    description="Enable or disable username/password, X.509/CAC, WebAuthn, OTP, and social login via bundle overrides."
-    href="/how-to-guides/identity-and-authorization/configure-authentication-flows/"
-  />
-  <LinkCard
-    title="Connect Azure AD as an identity provider"
-    description="Configure Azure Entra ID as a SAML IdP so users authenticate via Azure instead of local Keycloak accounts."
-    href="/how-to-guides/identity-and-authorization/connect-azure-ad-idp/"
-  />
-  <LinkCard
-    title="Configure Google SAML as an identity provider"
-    description="Connect Google SAML using realmInitEnv bundle overrides, with no admin UI required."
-    href="/how-to-guides/identity-and-authorization/configure-google-idp/"
-  />
-  <LinkCard
-    title="Configure Keycloak login policies"
-    description="Set session timeouts, concurrent session limits, and logout behavior via bundle overrides."
-    href="/how-to-guides/identity-and-authorization/configure-keycloak-login-policies/"
-  />
-  <LinkCard
-    title="Configure Keycloak HTTP retries"
-    description="Enable and tune retry behavior for Keycloak outbound HTTP requests to external services."
-    href="/how-to-guides/identity-and-authorization/configure-keycloak-http-retries/"
-  />
-  <LinkCard
-    title="Configure the CA truststore"
-    description="Replace the default DoD CA bundle with a custom certificate authority for X.509/CAC authentication."
-    href="/how-to-guides/identity-and-authorization/configure-truststore/"
   />
   <LinkCard
     title="Configure service account clients"
@@ -65,6 +45,16 @@ For background on how Keycloak, Authservice, and SSO work together, see [Identit
     href="/how-to-guides/identity-and-authorization/configure-device-flow/"
   />
   <LinkCard
+    title="Configure Keycloak authentication methods"
+    description="Enable or disable username/password, X.509/CAC, WebAuthn, OTP, and social login via bundle overrides."
+    href="/how-to-guides/identity-and-authorization/configure-authentication-flows/"
+  />
+  <LinkCard
+    title="Configure Keycloak login policies"
+    description="Set session timeouts, concurrent session limits, and logout behavior via bundle overrides."
+    href="/how-to-guides/identity-and-authorization/configure-keycloak-login-policies/"
+  />
+  <LinkCard
     title="Configure Keycloak account lockout"
     description="Set temporary and permanent lockout thresholds for brute-force protection."
     href="/how-to-guides/identity-and-authorization/configure-account-lockout/"
@@ -75,29 +65,39 @@ For background on how Keycloak, Authservice, and SSO work together, see [Identit
     href="/how-to-guides/identity-and-authorization/configure-account-inactivity-disable/"
   />
   <LinkCard
-    title="Customize Keycloak login page branding"
-    description="Replace the default logos, background, and Terms & Conditions content via bundle overrides and ConfigMaps."
-    href="/how-to-guides/identity-and-authorization/customize-branding/"
-  />
-  <LinkCard
-    title="Build a custom Keycloak configuration image"
-    description="Build, publish, and deploy a custom configuration image to UDS Core for theme or truststore changes."
-    href="/how-to-guides/identity-and-authorization/build-deploy-custom-image/"
-  />
-  <LinkCard
     title="Configure user accounts and security policies"
     description="Set password complexity, enable email verification, and extend security hardening allow lists via bundle overrides."
     href="/how-to-guides/identity-and-authorization/configure-user-account-settings/"
   />
   <LinkCard
-    title="Manage Keycloak with OpenTofu"
-    description="Enable the built-in OpenTofu client and use it to programmatically manage Keycloak resources."
-    href="/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu/"
+    title="Customize Keycloak login page branding"
+    description="Replace the default logos, background, and Terms & Conditions content via bundle overrides and ConfigMaps."
+    href="/how-to-guides/identity-and-authorization/customize-branding/"
   />
   <LinkCard
-    title="Upgrade to FIPS 140-2 mode"
-    description="Migrate an existing non-FIPS deployment to FIPS 140-2 Strict Mode before upgrading UDS Core."
-    href="/how-to-guides/identity-and-authorization/upgrade-to-fips-mode/"
+    title="Configure Keycloak HTTP retries"
+    description="Enable and tune retry behavior for Keycloak outbound HTTP requests to external services."
+    href="/how-to-guides/identity-and-authorization/configure-keycloak-http-retries/"
+  />
+  <LinkCard
+    title="Configure Keycloak notifications and alerts"
+    description="Enable Prometheus alerting rules so Keycloak realm, user, and admin changes trigger Alertmanager notifications."
+    href="/how-to-guides/identity-and-authorization/configure-keycloak-notifications-and-alerts/"
+  />
+  <LinkCard
+    title="Connect Azure AD as an identity provider"
+    description="Configure Azure Entra ID as a SAML IdP so users authenticate via Azure instead of local Keycloak accounts."
+    href="/how-to-guides/identity-and-authorization/connect-azure-ad-idp/"
+  />
+  <LinkCard
+    title="Configure Google SAML as an identity provider"
+    description="Connect Google SAML using realmInitEnv bundle overrides, with no admin UI required."
+    href="/how-to-guides/identity-and-authorization/configure-google-idp/"
+  />
+  <LinkCard
+    title="Configure the CA truststore"
+    description="Replace the default DoD CA bundle with a custom certificate authority for X.509/CAC authentication."
+    href="/how-to-guides/identity-and-authorization/configure-truststore/"
   />
   <LinkCard
     title="Configure CRL-based certificate revocation in an airgap"
@@ -105,13 +105,18 @@ For background on how Keycloak, Authservice, and SSO work together, see [Identit
     href="/how-to-guides/identity-and-authorization/configure-x509-crl-airgap/"
   />
   <LinkCard
-    title="Register and customize SSO clients"
-    description="Register native OIDC or SAML clients, customize secrets, add protocol mappers, and configure client attributes."
-    href="/how-to-guides/identity-and-authorization/register-and-customize-sso-clients/"
+    title="Build a custom Keycloak configuration image"
+    description="Build, publish, and deploy a custom configuration image to UDS Core for theme or truststore changes."
+    href="/how-to-guides/identity-and-authorization/build-deploy-custom-image/"
   />
   <LinkCard
-    title="Configure Keycloak notifications and alerts"
-    description="Enable Prometheus alerting rules so Keycloak realm, user, and admin changes trigger Alertmanager notifications."
-    href="/how-to-guides/identity-and-authorization/configure-keycloak-notifications-and-alerts/"
+    title="Upgrade to FIPS 140-2 mode"
+    description="Migrate an existing non-FIPS deployment to FIPS 140-2 Strict Mode before upgrading UDS Core."
+    href="/how-to-guides/identity-and-authorization/upgrade-to-fips-mode/"
+  />
+  <LinkCard
+    title="Manage Keycloak with OpenTofu"
+    description="Enable the built-in OpenTofu client and use it to programmatically manage Keycloak resources."
+    href="/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu/"
   />
 </CardGrid>

--- a/docs/how-to-guides/identity-and-authorization/protect-apps-with-authservice.mdx
+++ b/docs/how-to-guides/identity-and-authorization/protect-apps-with-authservice.mdx
@@ -2,7 +2,7 @@
 title: Protect non-OIDC apps with SSO
 description: Add SSO protection to applications without native OIDC support by configuring Authservice to intercept requests and handle the auth flow.
 sidebar:
-  order: 3.001
+  order: 3.003
 ---
 
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/register-and-customize-sso-clients.mdx
+++ b/docs/how-to-guides/identity-and-authorization/register-and-customize-sso-clients.mdx
@@ -2,7 +2,7 @@
 title: Register and customize SSO clients
 description: Register a native OIDC or SAML SSO client in Keycloak, customize the generated Kubernetes secret, and add protocol mappers for custom token claims.
 sidebar:
-  order: 3.018
+  order: 3.002
 ---
 
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/how-to-guides/identity-and-authorization/upgrade-to-fips-mode.mdx
+++ b/docs/how-to-guides/identity-and-authorization/upgrade-to-fips-mode.mdx
@@ -2,7 +2,7 @@
 title: Upgrade to FIPS 140-2 mode
 description: Prepare an existing Keycloak deployment for upgrade to FIPS 140-2 Strict Mode by migrating password hashing and resetting incompatible credentials.
 sidebar:
-  order: 3.016
+  order: 3.020
 ---
 
 import { Steps } from '@astrojs/starlight/components';

--- a/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
@@ -86,7 +86,7 @@ This runbook uses the Keycloak [Admin bootstrap and recovery](https://www.keyclo
    Use whichever case applies:
 
    - **Reset the password on an existing admin user:** Navigate to the **Users** tab, select the admin user, go to the **Credentials** tab, and click **Reset Password**. Set a new password for the account.
-   - **Create a new admin user** (for example, the previous break-glass admin was deleted): Navigate to the **Users** tab, click **Add user**, and create an account. Open the **Role mapping** tab, click **Assign role**, and assign the `admin` role from the master realm.
+   - **Create a new admin user** (for example, the previous break-glass admin was deleted): Navigate to the **Users** tab, click **Add user**, and create an account. Open the **Role mapping** tab, click **Assign role**, **Realm roles**, and check the box for the `admin` role then **Assign**.
 
 4. **Delete the temporary admin user**
 

--- a/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
@@ -81,9 +81,12 @@ This runbook uses the Keycloak [Admin bootstrap and recovery](https://www.keyclo
 
    Navigate to `https://keycloak.<admin_domain>/` and log in with the `temp-admin` user and the password you set in the previous step.
 
-3. **Reset the admin password**
+3. **Restore a permanent admin user**
 
-   Once logged in, navigate to the **Users** tab, select the **admin** user, go to the **Credentials** tab, and click **Reset Password**. Set a new password for the admin account.
+   Use whichever case applies:
+
+   - **Reset the password on an existing admin user:** Navigate to the **Users** tab, select the admin user, go to the **Credentials** tab, and click **Reset Password**. Set a new password for the account.
+   - **Create a new admin user** (for example, the previous break-glass admin was deleted): Navigate to the **Users** tab, click **Add user**, and create an account. Open the **Role mapping** tab, click **Assign role**, and assign the `admin` role from the master realm.
 
 4. **Delete the temporary admin user**
 

--- a/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
@@ -81,7 +81,7 @@ This runbook uses the Keycloak [Admin bootstrap and recovery](https://www.keyclo
 
    Navigate to `https://keycloak.<admin_domain>/` and log in with the `temp-admin` user and the password you set in the previous step.
 
-3. **Restore a permanent admin user**
+3. **Restore admin access**
 
    Use whichever case applies:
 

--- a/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
@@ -14,6 +14,8 @@ Use this runbook when:
 - You cannot log into the Keycloak admin console at `https://keycloak.<admin_domain>/`
 - Admin credentials are unknown, lost, or were changed without updating records
 - Your account is locked out after a FIPS migration or upgrade
+- No admin user exists because the previous break-glass admin was deleted after completing an administrative task
+- `uds zarf connect keycloak` no longer shows the first-run "Create administrative user" form
 
 ## Overview
 
@@ -22,6 +24,7 @@ This is typically caused by one of the following:
 1. **Admin password lost or forgotten:** the original admin password was not recorded or has been misplaced
 2. **Credentials rotated without updating records:** a scheduled or manual rotation changed the password but the new value was not stored
 3. **Account locked after FIPS migration or upgrade:** FIPS mode can invalidate existing credential hashes, locking out the admin account
+4. **Break-glass admin deleted:** the prior admin was intentionally removed after completing an administrative task (see [Manage Keycloak admin access](/how-to-guides/identity-and-authorization/manage-admin-access/)) and a new one must be bootstrapped
 
 This runbook uses the Keycloak [Admin bootstrap and recovery](https://www.keycloak.org/server/bootstrap-admin-recovery) feature to create a temporary admin user, then reset the original admin credentials.
 


### PR DESCRIPTION
## Description

Adds a new doc around managing initial admin access. Also:
- updates order of all identity docs to be a bit more intuitive (basic -> advanced)
- changes `zarf connect keycloak` -> `uds zarf connect keycloak`
- updates credential recovery runbook with new symptoms/causes