### PR TITLE
fix: restore original loki write service account name

### DIFF
--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # Sets the global DNS service to the service created in this chart
@@ -221,6 +221,10 @@ read:
 write:
   # Remove default anti-affinity to support single node
   affinity: null
+  # Use shared loki SA instead of creating a write-specific one
+  # https://github.com/grafana-community/helm-charts/issues/390
+  serviceAccount:
+    create: false
 
 backend:
   # Remove default anti-affinity to support single node


### PR DESCRIPTION
## Description

Restores the Loki service account name used by the write pods to `loki`. Upstream unexpectedly changed this and can fail deployments that reference this service account by name for object storage auth (i.e. IRSA).  See upstream issue: https://github.com/grafana-community/helm-charts/issues/390

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run` & check `loki` service account is used by write pods

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
