### PR TITLE
fix: re-add keycloak client registration authpol

### DIFF
--- a/src/keycloak/chart/templates/istio-authpol-admin.yaml
+++ b/src/keycloak/chart/templates/istio-authpol-admin.yaml
@@ -41,7 +41,7 @@ spec:
             ports:
               - "8080"
             paths:
-              # Block client registration on the public (tenant) API
+              # Block client registration API access. Users can use Admin API via admin gateway instead.
               - "/realms/{{ .Values.realm }}/clients-registrations/*"
     - to:
         - operation:

--- a/src/keycloak/chart/templates/istio-authpol-admin.yaml
+++ b/src/keycloak/chart/templates/istio-authpol-admin.yaml
@@ -41,6 +41,13 @@ spec:
             ports:
               - "8080"
             paths:
+              # Block client registration on the public (tenant) API
+              - "/realms/{{ .Values.realm }}/clients-registrations/*"
+    - to:
+        - operation:
+            ports:
+              - "8080"
+            paths:
               - "/admin/realms/{{ .Values.realm }}/clients"
       from:
         - source:


### PR DESCRIPTION
## Description

As a defense in depth measure this re-adds protections to prevent client registrations via the "public" (tenant) client registration endpoint for the uds realm.