### PR TITLE
fix: handle apply properly for keycloak client secret

### DIFF
--- a/src/pepr/operator/controllers/keycloak/client-secret-sync.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/client-secret-sync.spec.ts
@@ -1,14 +1,16 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2025-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
 import { describe, expect, it, vi } from "vitest";
 
+const applyMock = vi.fn().mockResolvedValue(undefined);
+
 // Mock pepr K8s API
 vi.mock("pepr", () => ({
   K8s: () => ({
-    Apply: vi.fn().mockResolvedValue(undefined),
+    Apply: applyMock,
   }),
   kind: {
     Secret: "Secret",
@@ -34,6 +36,7 @@ interface Config {
   metadata: {
     name: string;
     namespace: string;
+    managedFields?: unknown[];
   };
   data: {
     [key: string]: string;
@@ -69,6 +72,7 @@ describe("updateKeycloakClientsSecret Tests", () => {
   });
 
   it("should not generate a new secret if KEYCLOAK_CLIENT_SECRET_KEY exists and forceRotation is false", async () => {
+    applyMock.mockClear();
     const config = createConfig({
       [KEYCLOAK_CLIENT_SECRET_KEY]: "existing-secret",
     });
@@ -76,5 +80,36 @@ describe("updateKeycloakClientsSecret Tests", () => {
     await updateKeycloakClientsSecret(config);
 
     expect(config.data[KEYCLOAK_CLIENT_SECRET_KEY]).toBe("existing-secret");
+    expect(applyMock).not.toHaveBeenCalled();
+  });
+
+  it("should handle config with undefined data", async () => {
+    const config: Config = {
+      metadata: {
+        name: KEYCLOAK_CLIENTS_SECRET_NAME,
+        namespace: KEYCLOAK_CLIENTS_SECRET_NAMESPACE,
+      },
+    } as Config;
+
+    await updateKeycloakClientsSecret(config);
+
+    expect(config.data).toBeDefined();
+    expect(config.data[KEYCLOAK_CLIENT_SECRET_KEY]).toBeTruthy();
+  });
+
+  it("should not pass metadata.managedFields through to Apply", async () => {
+    applyMock.mockClear();
+    const config = createConfig();
+    config.metadata.managedFields = [
+      { manager: "kubectl", operation: "Update", apiVersion: "v1" },
+    ];
+
+    await updateKeycloakClientsSecret(config, true);
+
+    expect(applyMock).toHaveBeenCalledTimes(1);
+    const applied = applyMock.mock.calls[0][0];
+    expect(applied.metadata.managedFields).toBeUndefined();
+    expect(applied.metadata.name).toBe(KEYCLOAK_CLIENTS_SECRET_NAME);
+    expect(applied.metadata.namespace).toBe(KEYCLOAK_CLIENTS_SECRET_NAMESPACE);
   });
 });

--- a/src/pepr/operator/controllers/keycloak/client-secret-sync.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/client-secret-sync.spec.ts
@@ -100,9 +100,7 @@ describe("updateKeycloakClientsSecret Tests", () => {
   it("should not pass metadata.managedFields through to Apply", async () => {
     applyMock.mockClear();
     const config = createConfig();
-    config.metadata.managedFields = [
-      { manager: "kubectl", operation: "Update", apiVersion: "v1" },
-    ];
+    config.metadata.managedFields = [{ manager: "kubectl", operation: "Update", apiVersion: "v1" }];
 
     await updateKeycloakClientsSecret(config, true);
 

--- a/src/pepr/operator/controllers/keycloak/client-secret-sync.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/client-secret-sync.spec.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
+import { V1ManagedFieldsEntry } from "@kubernetes/client-node";
 import { describe, expect, it, vi } from "vitest";
 
 const applyMock = vi.fn().mockResolvedValue(undefined);
@@ -36,7 +37,7 @@ interface Config {
   metadata: {
     name: string;
     namespace: string;
-    managedFields?: unknown[];
+    managedFields?: V1ManagedFieldsEntry[];
   };
   data: {
     [key: string]: string;

--- a/src/pepr/operator/controllers/keycloak/client-secret-sync.ts
+++ b/src/pepr/operator/controllers/keycloak/client-secret-sync.ts
@@ -26,11 +26,20 @@ export async function updateKeycloakClientsSecret(
   config: kind.Secret,
   forceRotation: boolean = false,
 ) {
-  config.data = config.data || {};
+  let data = config.data || {};
 
-  if (!config.data[KEYCLOAK_CLIENT_SECRET_KEY] || forceRotation) {
+  if (!data[KEYCLOAK_CLIENT_SECRET_KEY] || forceRotation) {
     log.info("Generating new Keycloak client secret");
-    config.data[KEYCLOAK_CLIENT_SECRET_KEY] = Buffer.from(uuidv4()).toString("base64");
-    await K8s(kind.Secret).Apply(config, { force: true });
+    data[KEYCLOAK_CLIENT_SECRET_KEY] = Buffer.from(uuidv4()).toString("base64");
+    await K8s(kind.Secret).Apply(
+      {
+        metadata: {
+          name: config.metadata!.name,
+          namespace: config.metadata!.namespace,
+        },
+        data: data,
+      },
+      { force: true },
+    );
   }
 }

--- a/src/pepr/operator/controllers/keycloak/client-secret-sync.ts
+++ b/src/pepr/operator/controllers/keycloak/client-secret-sync.ts
@@ -26,7 +26,7 @@ export async function updateKeycloakClientsSecret(
   config: kind.Secret,
   forceRotation: boolean = false,
 ) {
-  let data = config.data || {};
+  const data = config.data || {};
 
   if (!data[KEYCLOAK_CLIENT_SECRET_KEY] || forceRotation) {
     log.info("Generating new Keycloak client secret");

--- a/src/pepr/operator/controllers/keycloak/client-secret-sync.ts
+++ b/src/pepr/operator/controllers/keycloak/client-secret-sync.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2025-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -26,18 +26,18 @@ export async function updateKeycloakClientsSecret(
   config: kind.Secret,
   forceRotation: boolean = false,
 ) {
-  const data = config.data || {};
+  config.data = config.data || {};
 
-  if (!data[KEYCLOAK_CLIENT_SECRET_KEY] || forceRotation) {
+  if (!config.data[KEYCLOAK_CLIENT_SECRET_KEY] || forceRotation) {
     log.info("Generating new Keycloak client secret");
-    data[KEYCLOAK_CLIENT_SECRET_KEY] = Buffer.from(uuidv4()).toString("base64");
+    config.data[KEYCLOAK_CLIENT_SECRET_KEY] = Buffer.from(uuidv4()).toString("base64");
     await K8s(kind.Secret).Apply(
       {
         metadata: {
           name: config.metadata!.name,
           namespace: config.metadata!.namespace,
         },
-        data: data,
+        data: config.data,
       },
       { force: true },
     );


### PR DESCRIPTION
## Description

Updates the apply to properly use a new secret object rather than trying to re-apply in place. Re-applying in place leads to errors when the secret is rotated:
```
{"level":50,"time":"2026-04-27T21:12:30.190Z","pid":15,"hostname":"pepr-uds-core-watcher-7f4dfbc54c-4t24s","data":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"metadata.managedFields must be nil","reason":"BadRequest","code":400},"ok":false,"status":400,"statusText":"Bad Request","headers":{},"msg":"Error executing watch callback"}

# In short:
# metadata.managedFields must be nil
```

Previously this was handled a different way: https://github.com/defenseunicorns/uds-core/blob/231fa5cf6b9c0c1e06a9c43b0dcaa56d624d7c1c/src/pepr/operator/controllers/keycloak/client-secret-sync.ts#L31-L32

Either approach will work, however this makes the object being applied more explicit.