### PR TITLE
Evaluate v1beta1 migration

### DIFF
--- a/packages/standard/zarf.yaml
+++ b/packages/standard/zarf.yaml
@@ -2,16 +2,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # @lulaStart babb60a4-d745-426c-ab8e-9527fda629d6
+apiVersion: zarf.dev/v1beta1
 kind: ZarfPackageConfig
 metadata:
   name: core
   description: "UDS Core is a collection of several individual applications combined into a single Zarf Package, that establishes a secure baseline for secure cloud-native systems."
   # @lulaEnd babb60a4-d745-426c-ab8e-9527fda629d6
-  authors: "Defense Unicorns - Product"
   # x-release-please-start-version
   version: "1.3.0"
   # x-release-please-end
   annotations:
+    authors: "Defense Unicorns - Product"
     dev.uds.title: UDS Core
     dev.uds.tagline: Collection of packages that enable a secure baseline for cloud-native systems
     dev.uds.categories: UDS-Core
@@ -20,111 +21,92 @@ metadata:
 
 components:
   - name: uds-crds
-    required: true
     import:
-      path: ../base
+      path: ../../src/pepr/uds-crds.yaml
 
   - name: prometheus-operator-crds
-    required: true
     import:
-      path: ../base
+      path: ../../src/prometheus-stack/prometheus-operator-crds.yaml
 
   - name: uds-operator-config
-    required: true
     import:
-      path: ../base
+      path: ../../src/pepr/uds-operator-config.yaml
 
   - name: pepr-uds-core
-    required: true
     import:
-      path: ../base
+      path: ../../src/pepr/pepr-uds-core.yaml
 
   - name: uds-exemptions
-    required: true
     import:
-      path: ../base
+      path: ../../src/pepr/uds-exemptions.yaml
 
   - name: istio-controlplane
-    required: true
     import:
-      path: ../base
+      path: ../../src/istio/istio-controlplane.yaml
 
   - name: gateway-api-crds
-    required: true
     import:
-      path: ../../src/istio/common
+      path: ../../src/istio/gateway-api-crds.yaml
 
   - name: istio-admin-gateway
-    required: true
     import:
-      path: ../base
+      path: ../../src/istio/istio-admin-gateway.yaml
 
   - name: istio-tenant-gateway
-    required: true
     import:
-      path: ../base
+      path: ../../src/istio/istio-tenant-gateway.yaml
 
   - name: istio-passthrough-gateway
-    required: false
+    optional: true
     import:
-      path: ../base
+      path: ../../src/istio/istio-passthrough-gateway.yaml
 
   - name: istio-egress-ambient
-    required: true
     import:
-      path: ../base
+      path: ../../src/istio/istio-egress-ambient.yaml
 
   - name: istio-egress-gateway
-    required: false
+    optional: true
     import:
-      path: ../base
+      path: ../../src/istio/istio-egress-gateway.yaml
 
   - name: metrics-server
-    required: false
+    optional: true
     import:
-      path: ../metrics-server
+      path: ../../src/metrics-server/metrics-server.yaml
 
   - name: keycloak
-    required: true
     import:
-      path: ../identity-authorization
+      path: ../../src/keycloak/keycloak.yaml
 
   - name: falco
-    required: true
     import:
-      path: ../runtime-security
+      path: ../../src/falco/falco.yaml
 
   - name: loki
-    required: true
     import:
-      path: ../logging
+      path: ../../src/loki/loki.yaml
 
   - name: kube-prometheus-stack
-    required: true
     import:
-      path: ../monitoring
+      path: ../../src/prometheus-stack/kube-prometheus-stack.yaml
 
   - name: prometheus-blackbox-exporter
-    required: true
     import:
-      path: ../monitoring
+      path: ../../src/prometheus-stack/prometheus-blackbox-exporter.yaml
 
   - name: vector
-    required: true
     import:
-      path: ../logging
+      path: ../../src/vector/vector.yaml
 
   - name: grafana
-    required: true
     import:
-      path: ../monitoring
+      path: ../../src/grafana/grafana.yaml
 
   - name: authservice
-    required: true
     import:
-      path: ../identity-authorization
+      path: ../../src/authservice/authservice.yaml
 
   - name: velero
-    required: true
     import:
-      path: ../backup-restore
+      path: ../../src/velero/velero.yaml

--- a/src/authservice/authservice.yaml
+++ b/src/authservice/authservice.yaml
@@ -1,0 +1,40 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: authservice
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-authservice.yaml
+    charts:
+      - name: authservice
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: ghcr.io/istio-ecosystem/authservice/authservice:1.1.5
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-authservice.yaml
+    charts:
+      - name: authservice
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/istio-ecosystem/authservice:1.1.5-fips
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-authservice.yaml
+    charts:
+      - name: authservice
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/istio-ecosystem/authservice:1.1.5-jammy-scratch-fips-rfcurated

--- a/src/authservice/common-authservice.yaml
+++ b/src/authservice/common-authservice.yaml
@@ -1,0 +1,14 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: authservice
+  description: "Common content shared across all flavors of authservice"
+component:
+  charts:
+    - name: authservice
+      namespace: authservice
+      local:
+        path: chart

--- a/src/falco/common-falco.yaml
+++ b/src/falco/common-falco.yaml
@@ -1,0 +1,52 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: falco
+  description: "Common content shared across all flavors of falco"
+variables:
+  - name: CLEANUP_LEGACY_NEUVECTOR
+    description: "Automatically cleanup previous Neuvector resources on upgrade"
+    default: "false"
+component:
+  charts:
+    - name: uds-falco-config
+      namespace: falco
+      local:
+        path: chart
+      valuesFiles:
+        - chart/values.yaml
+    - name: falco
+      namespace: falco
+      helmRepository:
+        url: https://falcosecurity.github.io/charts
+        name: falco
+        version: 8.0.0
+      valuesFiles:
+        - values/values.yaml
+  actions:
+    onDeploy:
+      before:
+        - description: "Optionally remove legacy NeuVector namespace (opt-in)"
+          cmd: |
+            if [ "${ZARF_VAR_CLEANUP_LEGACY_NEUVECTOR}" = "true" ]; then
+              echo "[cleanup] Removing legacy NeuVector namespace if present..."
+              ./zarf tools kubectl delete namespace neuvector --ignore-not-found
+            else
+              echo "[cleanup] Skipping NeuVector namespace cleanup (CLEANUP_LEGACY_NEUVECTOR=false)"
+            fi
+        - description: "Optionally remove legacy NeuVector CRDs (opt-in)"
+          cmd: |
+            if [ "${ZARF_VAR_CLEANUP_LEGACY_NEUVECTOR}" = "true" ]; then
+              echo "[cleanup] Removing legacy NeuVector CRDs if present..."
+              NV_CRDS="$(./zarf tools kubectl get crd -o name | grep -E '\.neuvector\.com$' || true)"
+              if [ -n "$NV_CRDS" ]; then
+                echo "$NV_CRDS" | xargs -r ./zarf tools kubectl delete
+              else
+                echo "[cleanup] No NeuVector CRDs found"
+              fi
+            else
+              echo "[cleanup] Skipping NeuVector CRD cleanup (CLEANUP_LEGACY_NEUVECTOR=false)"
+            fi

--- a/src/falco/falco.yaml
+++ b/src/falco/falco.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: falco
+  description: "Deploy Falco"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-falco.yaml
+    charts:
+      - name: falco
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: docker.io/falcosecurity/falco:0.43.0
+      - name: docker.io/falcosecurity/falcosidekick:2.32.0
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-falco.yaml
+    charts:
+      - name: falco
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/falcosecurity/falco:0.43.0
+      - name: registry1.dso.mil/ironbank/opensource/falcosecurity/falcosidekick:2.32.0
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-falco.yaml
+    charts:
+      - name: falco
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/falcosecurity/falco:0.43.0-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/falcosecurity/falcosidekick:2.32.0-jammy-scratch-fips-rfcurated

--- a/src/grafana/common-grafana.yaml
+++ b/src/grafana/common-grafana.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: grafana
+  description: "Common content shared across all flavors of grafana"
+component:
+  charts:
+    - name: uds-grafana-config
+      namespace: grafana
+      local:
+        path: chart
+      valuesFiles:
+        - chart/values.yaml
+    - name: grafana
+      namespace: grafana
+      helmRepository:
+        url: https://grafana-community.github.io/helm-charts
+        name: grafana
+        version: 11.6.0
+      valuesFiles:
+        - values/values.yaml

--- a/src/grafana/grafana-component-base.yaml
+++ b/src/grafana/grafana-component-base.yaml
@@ -1,6 +1,10 @@
 # Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
+# This is an implementation of the  "Variants Extend Base Component" alternative 
+# specified here  https://github.com/zarf-dev/proposals/pull/52/changes#diff-bcbe12162bddd5b89598d5a1633ff4a6c41fa16712fba247c2c2fa6c657f72adR636
+# This is the only file required for that alternative
+
 apiVersion: zarf.dev/v1beta1
 kind: ZarfComponentConfig
 metadata:

--- a/src/grafana/grafana-component-base.yaml
+++ b/src/grafana/grafana-component-base.yaml
@@ -1,0 +1,65 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: grafana
+  description: "UDS Core Grafana"
+variables:
+  - name: DOMAIN
+    description: "Cluster domain"
+    default: "uds.dev"
+  - name: ADMIN_DOMAIN
+    description: "Domain for admin services, defaults to `admin.DOMAIN`"
+component:
+  charts:
+    - name: uds-grafana-config
+      namespace: grafana
+      local:
+        path: chart
+      valuesFiles:
+        - chart/values.yaml
+    - name: grafana
+      namespace: grafana
+      helmRepository:
+        url: https://grafana-community.github.io/helm-charts
+        name: grafana
+        version: 11.6.0
+      valuesFiles:
+        - values/values.yaml
+variants:
+  - target:
+      flavor: upstream
+    charts:
+      - name: grafana
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: docker.io/grafana/grafana:12.4.2
+      - name: docker.io/curlimages/curl:8.19.0
+      - name: docker.io/library/busybox:1.37.0
+      - name: ghcr.io/kiwigrid/k8s-sidecar:2.5.0
+
+  - target:
+      flavor: registry1
+    charts:
+      - name: grafana
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/grafana/grafana:12.4.2
+      - name: registry1.dso.mil/ironbank/redhat/ubi/ubi9-minimal:9.7
+      - name: registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:2.5.0
+
+  - target:
+      flavor: unicorn
+    charts:
+      - name: grafana
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/grafana:12.4.2-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/busybox:1.37.0-musl-rf.1-fips-rfcurated
+      - name: quay.io/rfcurated/curl:8.19.0-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/kiwigrid/k8s-sidecar:2.5.0-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/grafana/grafana.yaml
+++ b/src/grafana/grafana.yaml
@@ -1,0 +1,55 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: grafana
+  description: "UDS Core Grafana"
+variables:
+  - name: DOMAIN
+    description: "Cluster domain"
+    default: "uds.dev"
+  - name: ADMIN_DOMAIN
+    description: "Domain for admin services, defaults to `admin.DOMAIN`"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-grafana.yaml
+    charts:
+      - name: grafana
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: docker.io/grafana/grafana:12.4.2
+      - name: docker.io/curlimages/curl:8.19.0
+      - name: docker.io/library/busybox:1.37.0
+      - name: ghcr.io/kiwigrid/k8s-sidecar:2.5.0
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-grafana.yaml
+    charts:
+      - name: grafana
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/grafana/grafana:12.4.2
+      - name: registry1.dso.mil/ironbank/redhat/ubi/ubi9-minimal:9.7
+      - name: registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:2.5.0
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-grafana.yaml
+    charts:
+      - name: grafana
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/grafana:12.4.2-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/busybox:1.37.0-musl-rf.1-fips-rfcurated
+      - name: quay.io/rfcurated/curl:8.19.0-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/kiwigrid/k8s-sidecar:2.5.0-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/istio/common-istio-controlplane.yaml
+++ b/src/istio/common-istio-controlplane.yaml
@@ -1,0 +1,100 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: istio-controlplane
+  description: "Common content shared across all flavors of the istio control plane"
+variables:
+  - name: CNI_CONF_DIR
+    description: "CNI configuration directory"
+    default: ""
+  - name: CNI_BIN_DIR
+    description: "CNI binary directory"
+    default: ""
+component:
+  charts:
+    - name: base
+      namespace: istio-system
+      # Istio's webhooks currently will cause SSA conflicts - https://github.com/istio/istio/issues/59487
+      # This should be fixed in a future Istio version
+      serverSideApply: false
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: base
+        version: 1.29.2
+    - name: istiod
+      namespace: istio-system
+      # Istio's webhooks currently will cause SSA conflicts - https://github.com/istio/istio/issues/59487
+      # This should be fixed in a future Istio version
+      serverSideApply: false
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: istiod
+        version: 1.29.2
+      valuesFiles:
+        - values/base-istiod.yaml
+    - name: uds-global-istio-config
+      namespace: istio-system
+      local:
+        path: common/chart
+      valuesFiles:
+        - common/chart/values.yaml
+    - name: cni
+      namespace: istio-system
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: cni
+        version: 1.29.2
+      valuesFiles:
+        - values/base-cni.yaml
+    - name: ztunnel
+      namespace: istio-system
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: ztunnel
+        version: 1.29.2
+      valuesFiles:
+        - values/base-ztunnel.yaml
+  actions:
+    onDeploy:
+      before:
+        - description: "Add helm ownership if necessary for clean helm upgrade"
+          mute: true
+          cmd: |
+            ./zarf tools kubectl annotate exemption istio -n uds-policy-exemptions "meta.helm.sh/release-name=uds-global-istio-config" --overwrite || true
+        - description: "Ensure CNI_CONF_DIR is set"
+          cmd: |
+            if [ \"${ZARF_VAR_CNI_CONF_DIR}\" = \"\" ]; then
+              if ./zarf tools kubectl version -o json 2>/dev/null | ./zarf tools yq '.serverVersion.gitVersion' 2>/dev/null | grep -q "k3s"; then
+                echo "/var/lib/rancher/k3s/agent/etc/cni/net.d"
+              else
+                echo "/etc/cni/net.d"
+              fi
+            else
+              echo "${ZARF_VAR_CNI_CONF_DIR}"
+            fi
+          setVariables:
+            - name: CNI_CONF_DIR
+        - description: "Ensure CNI_BIN_DIR is set"
+          cmd: |
+            if [ \"${ZARF_VAR_CNI_BIN_DIR}\" = \"\" ]; then
+              if ./zarf tools kubectl version -o json 2>/dev/null | ./zarf tools yq '.serverVersion.gitVersion' 2>/dev/null | grep -q "k3s"; then
+                echo "/var/lib/rancher/k3s/data/cni"
+              else
+                echo "/opt/cni/bin"
+              fi
+            else
+              echo "${ZARF_VAR_CNI_BIN_DIR}"
+            fi
+          setVariables:
+            - name: CNI_BIN_DIR
+      after:
+        - description: "Ensure Istio Ambient is enabled for Pepr"
+          cmd: |
+            echo "Setting Ambient mode for pepr-system..."
+            ./zarf tools kubectl label namespace pepr-system "istio.io/dataplane-mode"="ambient" --overwrite
+
+            echo "Disabling istio-injection on pepr-system..."
+            ./zarf tools kubectl label namespace pepr-system istio-injection=disabled --overwrite

--- a/src/istio/gateway-api-crds.yaml
+++ b/src/istio/gateway-api-crds.yaml
@@ -1,0 +1,12 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: gateway-api-crds
+component:
+  manifests:
+    - name: gateway-api-crds
+      files:
+        - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml

--- a/src/istio/istio-admin-gateway.yaml
+++ b/src/istio/istio-admin-gateway.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: istio-admin-gateway
+component:
+  charts:
+    - name: gateway
+      releaseName: admin-ingressgateway
+      namespace: istio-admin-gateway
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: gateway
+        version: 1.29.2
+      valuesFiles:
+        - values/base-gateway.yaml
+    - name: uds-istio-config
+      namespace: istio-admin-gateway
+      local:
+        path: charts/uds-istio-config
+      valuesFiles:
+        - values/config-admin.yaml

--- a/src/istio/istio-controlplane.yaml
+++ b/src/istio/istio-controlplane.yaml
@@ -1,0 +1,74 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: istio-controlplane
+  description: "UDS Core Istio package deploys Istio with admin, tenant and passthrough gateways."
+variables:
+  - name: DOMAIN
+    description: "Cluster domain"
+    default: "uds.dev"
+  - name: ADMIN_DOMAIN
+    description: "Domain for admin services, defaults to `admin.DOMAIN`"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-istio-controlplane.yaml
+    charts:
+      - name: istiod
+        valuesFiles:
+          - values/upstream/istiod.yaml
+      - name: cni
+        valuesFiles:
+          - values/upstream/cni.yaml
+      - name: ztunnel
+        valuesFiles:
+          - values/upstream/ztunnel.yaml
+    images:
+      - name: docker.io/istio/pilot:1.29.2-distroless
+      - name: docker.io/istio/proxyv2:1.29.2-distroless
+      - name: docker.io/istio/install-cni:1.29.2-distroless
+      - name: docker.io/istio/ztunnel:1.29.2-distroless
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-istio-controlplane.yaml
+    charts:
+      - name: istiod
+        valuesFiles:
+          - values/registry1/istiod.yaml
+      - name: cni
+        valuesFiles:
+          - values/registry1/cni.yaml
+      - name: ztunnel
+        valuesFiles:
+          - values/registry1/ztunnel.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/tetrate/istio/proxyv2:1.29.2-fips
+      - name: registry1.dso.mil/ironbank/tetrate/istio/pilot:1.29.2-fips
+      - name: registry1.dso.mil/ironbank/tetrate/istio/install-cni:1.29.2-fips
+      - name: registry1.dso.mil/ironbank/tetrate/istio/ztunnel:1.29.2-fips
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-istio-controlplane.yaml
+    charts:
+      - name: istiod
+        valuesFiles:
+          - values/unicorn/istiod.yaml
+      - name: cni
+        valuesFiles:
+          - values/unicorn/cni.yaml
+      - name: ztunnel
+        valuesFiles:
+          - values/unicorn/ztunnel.yaml
+    images:
+      - name: quay.io/rfcurated/istio/pilot:1.29.2-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/istio/proxyv2:1.29.2-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/istio/install-cni:1.29.2-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/istio/ztunnel:1.29.2-jammy-scratch-fips-rfcurated

--- a/src/istio/istio-egress-ambient.yaml
+++ b/src/istio/istio-egress-ambient.yaml
@@ -1,0 +1,13 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: istio-egress-ambient
+component:
+  charts:
+    - name: uds-istio-egress-config
+      namespace: istio-egress-ambient
+      local:
+        path: charts/uds-istio-egress-config

--- a/src/istio/istio-egress-gateway.yaml
+++ b/src/istio/istio-egress-gateway.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: istio-egress-gateway
+component:
+  charts:
+    - name: gateway
+      releaseName: egressgateway
+      namespace: istio-egress-gateway
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: gateway
+        version: 1.29.2
+      valuesFiles:
+        - values/base-egress.yaml

--- a/src/istio/istio-passthrough-gateway.yaml
+++ b/src/istio/istio-passthrough-gateway.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: istio-passthrough-gateway
+component:
+  charts:
+    - name: gateway
+      releaseName: passthrough-ingressgateway
+      namespace: istio-passthrough-gateway
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: gateway
+        version: 1.29.2
+      valuesFiles:
+        - values/base-gateway.yaml
+    - name: uds-istio-config
+      namespace: istio-passthrough-gateway
+      local:
+        path: charts/uds-istio-config
+      valuesFiles:
+        - values/config-passthrough.yaml

--- a/src/istio/istio-tenant-gateway.yaml
+++ b/src/istio/istio-tenant-gateway.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: istio-tenant-gateway
+component:
+  charts:
+    - name: gateway
+      releaseName: tenant-ingressgateway
+      namespace: istio-tenant-gateway
+      helmRepository:
+        url: https://istio-release.storage.googleapis.com/charts
+        name: gateway
+        version: 1.29.2
+      valuesFiles:
+        - values/base-gateway.yaml
+    - name: uds-istio-config
+      namespace: istio-tenant-gateway
+      local:
+        path: charts/uds-istio-config
+      valuesFiles:
+        - values/config-tenant.yaml

--- a/src/keycloak/common-keycloak.yaml
+++ b/src/keycloak/common-keycloak.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: keycloak
+  description: "Common content shared across all flavors of keycloak"
+component:
+  charts:
+    - name: keycloak
+      namespace: keycloak
+      local:
+        path: chart
+      valuesFiles:
+        - chart/values.yaml
+  actions:
+    onDeploy:
+      before:
+        - description: Re-create Keycloak StatefulSet
+          mute: false
+          cmd: |
+            set +e
+
+            echo "Checking if Keycloak StatefulSet should be deleted"
+            KEYCLOAK_INSTALLED=$(./zarf tools kubectl get sts -n keycloak keycloak > /dev/null 2>&1; echo $?)
+            if [ "${KEYCLOAK_INSTALLED}" -eq 0 ]; then
+              echo "Keycloak has been previously installed. Checking the podManagementPolicy..."
+              POD_MGMT_POLICY=$(./zarf tools kubectl get sts -n keycloak keycloak -o jsonpath='{.spec.podManagementPolicy}' 2>/dev/null || true)
+              echo "Detected podManagementPolicy: ${POD_MGMT_POLICY:-<none>}"
+              if [ -n "${POD_MGMT_POLICY}" ] && [ "${POD_MGMT_POLICY}" != "OrderedReady" ]; then
+                echo "podManagementPolicy is '${POD_MGMT_POLICY}', deleting StatefulSet (cascade=orphan) to allow re-create with OrderedReady"
+               ./zarf tools kubectl delete sts -n keycloak keycloak --cascade=orphan
+              else
+                echo "podManagementPolicy is correct. Skipping..."
+              fi
+            else
+              echo "Keycloak has not been installed. Skipping..."
+            fi
+      after:
+        - description: Validate Keycloak Pods
+          wait:
+            cluster:
+              kind: Pod
+              name: app.kubernetes.io/name=keycloak
+              condition: Ready
+              namespace: keycloak

--- a/src/keycloak/keycloak.yaml
+++ b/src/keycloak/keycloak.yaml
@@ -1,0 +1,49 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: keycloak
+variables:
+  - name: DOMAIN
+    description: "Cluster domain"
+    default: "uds.dev"
+  - name: ADMIN_DOMAIN
+    description: "Domain for admin services, defaults to `admin.DOMAIN`"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-keycloak.yaml
+    charts:
+      - name: keycloak
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: quay.io/keycloak/keycloak:26.5.7
+      - name: ghcr.io/defenseunicorns/uds/identity-config:0.26.1
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-keycloak.yaml
+    charts:
+      - name: keycloak
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.5.7-fips
+      - name: registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.26.1
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-keycloak.yaml
+    charts:
+      - name: keycloak
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/keycloak:26.5.7-jammy-fips-rfcurated
+      - name: ghcr.io/defenseunicorns/uds/identity-config:0.26.1

--- a/src/loki/common-loki.yaml
+++ b/src/loki/common-loki.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: loki
+  description: "Common content shared across all flavors of loki"
+component:
+  charts:
+    - name: uds-loki-config
+      namespace: loki
+      local:
+        path: chart
+    - name: loki
+      namespace: loki
+      helmRepository:
+        url: https://grafana-community.github.io/helm-charts/
+        name: loki
+        version: 11.6.4
+      valuesFiles:
+        - values/values.yaml

--- a/src/loki/loki.yaml
+++ b/src/loki/loki.yaml
@@ -1,0 +1,50 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: loki
+  description: "UDS Core Loki"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-loki.yaml
+    charts:
+      - name: loki
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: docker.io/grafana/loki:3.7.1
+      - name: docker.io/nginxinc/nginx-unprivileged:1.29-alpine
+      - name: docker.io/memcached:1.6.41-alpine
+      - name: ghcr.io/kiwigrid/k8s-sidecar:2.5.0
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-loki.yaml
+    charts:
+      - name: loki
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/grafana/loki:3.7.1
+      - name: registry1.dso.mil/ironbank/opensource/nginx/nginx-alpine:1.29.7
+      - name: registry1.dso.mil/ironbank/opensource/memcached/memcached:1.6.41
+      - name: registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:2.5.0
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-loki.yaml
+    charts:
+      - name: loki
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/grafana/loki:3.7.1-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/nginx:1.29.7-slim-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/memcached:1.6.41-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/kiwigrid/k8s-sidecar:2.5.0-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/metrics-server/common-metrics-server.yaml
+++ b/src/metrics-server/common-metrics-server.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: metrics-server
+  description: "Common content shared across all flavors of metrics-server"
+component:
+  charts:
+    - name: uds-metrics-server-config
+      namespace: metrics-server
+      local:
+        path: chart
+    - name: metrics-server
+      namespace: metrics-server
+      helmRepository:
+        url: https://kubernetes-sigs.github.io/metrics-server
+        name: metrics-server
+        version: 3.13.0
+      valuesFiles:
+        - values/values.yaml

--- a/src/metrics-server/metrics-server.yaml
+++ b/src/metrics-server/metrics-server.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: metrics-server
+  description: "UDS Metrics Server"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-metrics-server.yaml
+    charts:
+      - name: metrics-server
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: registry.k8s.io/metrics-server/metrics-server:v0.8.1
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-metrics-server.yaml
+    charts:
+      - name: metrics-server
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/kubernetes-sigs/metrics-server:v0.8.1
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-metrics-server.yaml
+    charts:
+      - name: metrics-server
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/metrics-server:0.8.1-jammy-scratch-fips-rfcurated-rfhardened

--- a/src/pepr/pepr-uds-core.yaml
+++ b/src/pepr/pepr-uds-core.yaml
@@ -1,0 +1,51 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: pepr-uds-core
+variables:
+  - name: DOMAIN
+    description: "Cluster domain"
+    default: "uds.dev"
+  - name: ADMIN_DOMAIN
+    description: "Domain for admin services, defaults to `admin.DOMAIN`"
+  - name: CA_BUNDLE_CERTS
+    description: "Base64 encoded CA certs (bundle) in PEM format that UDS Core will inherently trust. At a minimum this must at least include your Domain CA Cert if using Private PKI for your UDS Core Deployment"
+    default: ""
+  - name: CA_BUNDLE_INCLUDE_DOD_CERTS
+    description: "Whether to include DoD root and intermediate certificates in the cluster CA bundle"
+    default: "false"
+  - name: CA_BUNDLE_INCLUDE_PUBLIC_CERTS
+    description: "Whether to include public root and intermediate certificates in the cluster CA bundle"
+    default: "false"
+  - name: UDS_LOG_LEVEL
+    description: "UDS Operator log level"
+    default: "debug"
+  - name: AUTHSERVICE_REDIS_URI
+    description: "UDS Authservice Redis URI"
+    default: ""
+  - name: PEPR_SERVICE_MONITORS
+    description: "Enables Service Monitors for Pepr services (watcher, admission)"
+    default: "true"
+  - name: ALLOW_ALL_NS_EXEMPTIONS
+    description: "Whether to allow exemptions to be created in all namespaces"
+    default: "false"
+component:
+  import:
+    path: ../../dist/module.yaml
+  charts:
+    - name: module
+      valuesFiles:
+        - values.yaml
+  actions:
+    onDeploy:
+      after:
+        - description: Validate ClusterConfig
+          maxTotalSeconds: 60
+          wait:
+            cluster:
+              kind: ClusterConfig
+              name: uds-cluster-config
+              condition: "'{.status.phase}'=Ready"

--- a/src/pepr/uds-crds.yaml
+++ b/src/pepr/uds-crds.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: uds-crds
+component:
+  charts:
+    - name: uds-cluster-crds
+      namespace: pepr-system
+      local:
+        path: uds-cluster-crds
+  actions:
+    onDeploy:
+      before:
+        - description: Handle Helm ownership metadata change on upgrade
+          cmd: |
+            # Update Helm ownership metadata for existing Packages and Exemptions CRDs
+            CRDS="packages.uds.dev exemptions.uds.dev"
+
+            for crd in $CRDS; do
+              if ./zarf tools kubectl get crd "$crd" >/dev/null 2>&1; then
+                ./zarf tools kubectl label crd "$crd" \
+                  app.kubernetes.io/managed-by=Helm --overwrite
+
+                ./zarf tools kubectl annotate crd "$crd" \
+                  meta.helm.sh/release-name="uds-cluster-crds" \
+                  meta.helm.sh/release-namespace="pepr-system" \
+                  --overwrite
+              fi
+            done

--- a/src/pepr/uds-exemptions.yaml
+++ b/src/pepr/uds-exemptions.yaml
@@ -1,0 +1,15 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: uds-exemptions
+component:
+  charts:
+    - name: uds-exemptions
+      namespace: uds-policy-exemptions
+      local:
+        path: uds-exemptions
+      valuesFiles:
+        - uds-exemptions/values.yaml

--- a/src/pepr/uds-operator-config.yaml
+++ b/src/pepr/uds-operator-config.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: uds-operator-config
+component:
+  charts:
+    - name: uds-operator-config
+      namespace: pepr-system
+      local:
+        path: uds-operator-config
+      valuesFiles:
+        - uds-operator-config/values.yaml
+  actions:
+    onDeploy:
+      after:
+        - description: "Ensure Istio Ambient is enabled for Pepr"
+          cmd: |
+            echo "Setting Ambient mode for pepr-system..."
+            ./zarf tools kubectl label namespace pepr-system "istio.io/dataplane-mode"="ambient" --overwrite
+
+            echo "Disabling istio-injection on pepr-system..."
+            ./zarf tools kubectl label namespace pepr-system istio-injection=disabled --overwrite

--- a/src/prometheus-stack/common-kube-prometheus-stack.yaml
+++ b/src/prometheus-stack/common-kube-prometheus-stack.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: kube-prometheus-stack
+  description: "Common content shared across all flavors of kube-prometheus-stack"
+component:
+  charts:
+    - name: uds-prometheus-config
+      namespace: monitoring
+      local:
+        path: chart
+    - name: kube-prometheus-stack
+      namespace: monitoring
+      helmRepository:
+        url: https://prometheus-community.github.io/helm-charts
+        name: kube-prometheus-stack
+        version: 84.0.0
+      valuesFiles:
+        - values/kube-prometheus-stack-values.yaml

--- a/src/prometheus-stack/common-prometheus-blackbox-exporter.yaml
+++ b/src/prometheus-stack/common-prometheus-blackbox-exporter.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: prometheus-blackbox-exporter
+  description: "Common content shared across all flavors of prometheus-blackbox-exporter"
+component:
+  charts:
+    - name: prometheus-blackbox-exporter
+      namespace: monitoring
+      helmRepository:
+        url: https://prometheus-community.github.io/helm-charts
+        name: prometheus-blackbox-exporter
+        version: 11.9.1
+      valuesFiles:
+        - values/blackbox-exporter-values.yaml

--- a/src/prometheus-stack/kube-prometheus-stack.yaml
+++ b/src/prometheus-stack/kube-prometheus-stack.yaml
@@ -1,0 +1,59 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: kube-prometheus-stack
+  description: "Install kube-prometheus-stack using the helm chart https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-kube-prometheus-stack.yaml
+    charts:
+      - name: kube-prometheus-stack
+        valuesFiles:
+          - values/upstream/kube-prometheus-stack.yaml
+    images:
+      - name: quay.io/prometheus/node-exporter:v1.11.1
+      - name: quay.io/prometheus-operator/prometheus-operator:v0.90.1
+      - name: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
+      - name: quay.io/prometheus/alertmanager:v0.32.0
+      - name: quay.io/prometheus-operator/prometheus-config-reloader:v0.90.1
+      - name: quay.io/prometheus/prometheus:v3.11.2
+      - name: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.9
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-kube-prometheus-stack.yaml
+    charts:
+      - name: kube-prometheus-stack
+        valuesFiles:
+          - values/registry1/kube-prometheus-stack.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/prometheus/node-exporter:v1.11.1
+      - name: registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-operator:v0.90.1
+      - name: registry1.dso.mil/ironbank/opensource/kubernetes/kube-state-metrics:v2.18.0
+      - name: registry1.dso.mil/ironbank/opensource/prometheus/alertmanager:v0.32.0
+      - name: registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-config-reloader:v0.90.1
+      - name: registry1.dso.mil/ironbank/opensource/prometheus/prometheus:v3.11.2
+      - name: registry1.dso.mil/ironbank/opensource/ingress-nginx/kube-webhook-certgen:v1.6.9
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-kube-prometheus-stack.yaml
+    charts:
+      - name: kube-prometheus-stack
+        valuesFiles:
+          - values/unicorn/kube-prometheus-stack.yaml
+    images:
+      - name: quay.io/rfcurated/prometheus/node-exporter:1.11.1-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/prometheus-operator:0.90.1-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/kube-state-metrics:2.18.0-jammy-scratch-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/prometheus/alertmanager:0.32.0-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/prometheus-operator/prometheus-config-reloader:0.90.1-jammy-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/prometheus:3.11.2-jammy-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/ingress-nginx/kube-webhook-certgen:1.6.9-jammy-fips-rfcurated-rfhardened

--- a/src/prometheus-stack/prometheus-blackbox-exporter.yaml
+++ b/src/prometheus-stack/prometheus-blackbox-exporter.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: prometheus-blackbox-exporter
+  description: "UDS Core Prometheus Blackbox Exporter"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-prometheus-blackbox-exporter.yaml
+    charts:
+      - name: prometheus-blackbox-exporter
+        valuesFiles:
+          - values/upstream/blackbox-exporter.yaml
+    images:
+      - name: quay.io/prometheus/blackbox-exporter:v0.28.0
+      - name: quay.io/prometheus-operator/prometheus-config-reloader:v0.90.1
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-prometheus-blackbox-exporter.yaml
+    charts:
+      - name: prometheus-blackbox-exporter
+        valuesFiles:
+          - values/registry1/blackbox-exporter.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/prometheus/blackbox_exporter:v0.28.0
+      - name: registry1.dso.mil/ironbank/opensource/prometheus-operator/prometheus-config-reloader:v0.90.1
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-prometheus-blackbox-exporter.yaml
+    charts:
+      - name: prometheus-blackbox-exporter
+        valuesFiles:
+          - values/unicorn/blackbox-exporter.yaml
+    images:
+      - name: quay.io/rfcurated/prometheus/blackbox-exporter:0.28.0-jammy-scratch-fips-rfcurated-rfhardened
+      - name: quay.io/rfcurated/prometheus-operator/prometheus-config-reloader:0.90.1-jammy-scratch-fips-rfcurated

--- a/src/prometheus-stack/prometheus-operator-crds.yaml
+++ b/src/prometheus-stack/prometheus-operator-crds.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: prometheus-operator-crds
+  description: "Install kube-prometheus-stack operator crds using the helm chart https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-operator-crds"
+component:
+  charts:
+    - name: prometheus-operator-crds
+      namespace: uds-crds
+      helmRepository:
+        url: https://prometheus-community.github.io/helm-charts
+        name: prometheus-operator-crds
+        version: 28.0.1
+      valuesFiles:
+        - values/crd-values.yaml

--- a/src/test/egress-app.yaml
+++ b/src/test/egress-app.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: egress-app
+component:
+  manifests:
+    - name: egress-pkg
+      files:
+        - app-egress-sidecar-package.yaml
+    - name: egress-app
+      files:
+        - app-egress-sidecar.yaml
+  images:
+    - name: curlimages/curl:latest

--- a/src/test/loki-test.yaml
+++ b/src/test/loki-test.yaml
@@ -1,0 +1,12 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: loki-test
+component:
+  manifests:
+    - name: loki-ruler-test-configmap
+      files:
+        - loki-ruler-test-configmap.yaml

--- a/src/test/podinfo.yaml
+++ b/src/test/podinfo.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: podinfo
+component:
+  charts:
+    - name: uds-podinfo-config
+      namespace: podinfo
+      local:
+        path: ./chart
+    - name: podinfo
+      namespace: podinfo
+      git:
+        url: https://github.com/stefanprodan/podinfo.git@6.11.2
+        path: charts/podinfo
+      valuesFiles:
+        - ./podinfo-values.yaml
+  images:
+    - name: ghcr.io/stefanprodan/podinfo:6.11.2

--- a/src/test/test-app-packages.yaml
+++ b/src/test/test-app-packages.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: test-app-packages
+component:
+  manifests:
+    - name: test-app-packages
+      files:
+        - app-admin-package.yaml
+        - app-sidecar-authservice-tenant-package.yaml
+        - app-tenant-package.yaml
+        - app-ambient-authservice-tenant-package.yaml
+        - app-curl-packages.yaml
+        - app-egress-ambient-package.yaml

--- a/src/test/test-apps.yaml
+++ b/src/test/test-apps.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: test-apps
+component:
+  manifests:
+    - name: app-admin
+      files:
+        - app-admin.yaml
+    - name: app-tenant
+      files:
+        - app-tenant.yaml
+    - name: app-sidecar-authservice-tenant
+      files:
+        - app-sidecar-authservice-tenant.yaml
+    - name: app-ambient-authservice-tenant
+      files:
+        - app-ambient-authservice-tenant.yaml
+    - name: curl-test
+      files:
+        - app-curl.yaml
+    - name: egress-ambient-test
+      files:
+        - app-egress-ambient.yaml
+  images:
+    - name: docker.io/kong/httpbin:0.2.3
+    - name: hashicorp/http-echo:latest
+    - name: curlimages/curl:latest

--- a/src/vector/common-vector.yaml
+++ b/src/vector/common-vector.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: vector
+  description: "Common content shared across all flavors of vector"
+component:
+  charts:
+    - name: uds-vector-config
+      namespace: vector
+      local:
+        path: chart
+    - name: vector
+      namespace: vector
+      git:
+        url: https://helm.vector.dev@0.51.0
+        path: charts/vector
+      valuesFiles:
+        - values/values.yaml

--- a/src/vector/vector.yaml
+++ b/src/vector/vector.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: vector
+  description: "Deploy Vector"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-vector.yaml
+    charts:
+      - name: vector
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: timberio/vector:0.54.0-distroless-static
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-vector.yaml
+    charts:
+      - name: vector
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/timberio/vector:0.54.0
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-vector.yaml
+    charts:
+      - name: vector
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/vector:0.54.0-jammy-fips-rfcurated-rfhardened

--- a/src/velero/common-velero.yaml
+++ b/src/velero/common-velero.yaml
@@ -1,0 +1,56 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: velero
+  description: "Common content shared across all flavors of velero"
+variables:
+  - name: VELERO_BUCKET_PROVIDER_URL
+    description: "S3 compatible object storage service for use with Velero"
+    default: "http://minio.uds-dev-stack.svc.cluster.local:9000"
+  - name: VELERO_BUCKET
+    description: "S3 compatible object storage bucket for use with Velero"
+    default: "uds"
+  - name: VELERO_BUCKET_REGION
+    description: "Region of the bucket for use with Velero"
+    default: "uds-dev-stack"
+  - name: VELERO_BUCKET_KEY
+    description: "Key to use when connecting to the Velero bucket"
+    default: "uds"
+  - name: VELERO_BUCKET_KEY_SECRET
+    sensitive: true
+    description: "Key secret to use when connecting to the Velero bucket"
+    default: "uds-secret"
+  - name: VELERO_BUCKET_CREDENTIAL_NAME
+    default: "velero-bucket-credentials"
+  - name: VELERO_BUCKET_CREDENTIAL_KEY
+    default: "cloud"
+component:
+  charts:
+    - name: uds-velero-config
+      namespace: velero
+      local:
+        path: chart
+    - name: velero
+      namespace: velero
+      releaseName: velero
+      helmRepository:
+        url: https://vmware-tanzu.github.io/helm-charts
+        name: velero
+        version: 12.0.1
+      valuesFiles:
+        - values/values.yaml
+  actions:
+    onDeploy:
+      before:
+        - description: Handle Helm ownership metadata change on upgrade
+          cmd: |
+            # Update Helm ownership metadata for existing Velero CRDs
+            for crd_name in $(./zarf tools kubectl get crd -l 'component=velero' -o jsonpath='{.items[*].metadata.name}'); do
+              echo "Updating metadata for $crd_name"
+              ./zarf tools kubectl label crd "$crd_name" app.kubernetes.io/managed-by=Helm --overwrite
+              ./zarf tools kubectl annotate crd "$crd_name" meta.helm.sh/release-name="uds-velero-config" --overwrite
+              ./zarf tools kubectl annotate crd "$crd_name" meta.helm.sh/release-namespace="velero" --overwrite
+            done

--- a/src/velero/velero.yaml
+++ b/src/velero/velero.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024-2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: zarf.dev/v1beta1
+kind: ZarfComponentConfig
+metadata:
+  name: velero
+  description: "UDS Core Velero"
+variants:
+  - target:
+      flavor: upstream
+    import:
+      path: common-velero.yaml
+    charts:
+      - name: velero
+        valuesFiles:
+          - values/upstream-values.yaml
+    images:
+      - name: velero/velero:v1.18.0
+      - name: velero/velero-plugin-for-aws:v1.14.0
+      - name: velero/velero-plugin-for-microsoft-azure:v1.14.0
+
+  - target:
+      flavor: registry1
+    import:
+      path: common-velero.yaml
+    charts:
+      - name: velero
+        valuesFiles:
+          - values/registry1-values.yaml
+    images:
+      - name: registry1.dso.mil/ironbank/opensource/velero/velero:v1.18.0
+      - name: registry1.dso.mil/ironbank/opensource/velero/velero-plugin-for-aws:v1.14.0
+      - name: registry1.dso.mil/ironbank/opensource/velero/velero-plugin-for-microsoft-azure:v1.14.0
+
+  - target:
+      flavor: unicorn
+    import:
+      path: common-velero.yaml
+    charts:
+      - name: velero
+        valuesFiles:
+          - values/unicorn-values.yaml
+    images:
+      - name: quay.io/rfcurated/velero/velero:1.18.0-noble-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/velero/velero-plugin-for-aws:1.14.0-noble-scratch-fips-rfcurated
+      - name: quay.io/rfcurated/velero/velero-plugin-for-microsoft-azure:1.14.0-noble-scratch-fips-rfcurated


### PR DESCRIPTION
## Description

Using this to evalute the changes in https://github.com/zarf-dev/proposals/pull/52. No intention to merge. 

Seeing this in action points to a few holes: 

- UDS core uses an import strategy wherein they point standard to base, then point to base to the relevant zarf.yaml files. It's probably not a huge lift to ask them to change this, but this system does reduce duplication in the event that folder names change. 
- There is an implicit ordering in a zarf.yaml file, the first component in a list is installed, then the second and so forth. By asking users to break apart their zarf.yaml files into Zarf Component Config files, they may lose this implicit ordering, and it could be more confusing to determine the order of components. The istio example in this PR is a fair example. 
