### PR TITLE
ci: ensure velero task renovate datasource matches chart

### DIFF
--- a/src/velero/tasks.yaml
+++ b/src/velero/tasks.yaml
@@ -6,7 +6,7 @@ includes:
 
 variables:
   - name: VELERO_CRD_VERSION
-    # renovate: datasource=helm depName=velero versioning=semver registryUrl=https://vmware-tanzu.github.io/helm-charts
+    # renovate: datasource=helm depName=velero versioning=helm registryUrl=https://vmware-tanzu.github.io/helm-charts
     default: "12.0.0"  # Helm chart version, not app version
 
 tasks:

--- a/src/velero/tasks.yaml
+++ b/src/velero/tasks.yaml
@@ -6,7 +6,7 @@ includes:
 
 variables:
   - name: VELERO_CRD_VERSION
-    # renovate: datasource=github-tags depName=vmware-tanzu/helm-charts versioning=semver extractVersion=^velero-(?<version>.*)$
+    # renovate: datasource=helm depName=velero versioning=semver registryUrl=https://vmware-tanzu.github.io/helm-charts
     default: "12.0.0"  # Helm chart version, not app version
 
 tasks:


### PR DESCRIPTION
## Description

Noted in https://github.com/defenseunicorns/uds-core/pull/2635 and https://github.com/defenseunicorns/uds-core/pull/2613 that Velero's chart is updating at a different cadence than the task (which controls CRDs).

This updates the renovate comment to use the identical datasource as the chart reference (helm) in order to ensure these should always update in the same PR.