### PR TITLE
fix: ensure prometheus operator can manage endpoints for migration to slices

### DIFF
--- a/src/prometheus-stack/values/kube-prometheus-stack-values.yaml
+++ b/src/prometheus-stack/values/kube-prometheus-stack-values.yaml
@@ -74,7 +74,7 @@ prometheus-node-exporter:
   podAnnotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 prometheusOperator:
-  kubeletEndpointsEnabled: false
+  kubeletEndpointsEnabled: true
   kubeletEndpointSliceEnabled: true
   # Kubelet healthprobes on FIPS nodes fail when this is set to 1.3
   tls:


### PR DESCRIPTION
## Description

Per https://prometheus-operator.dev/docs/platform/troubleshooting/#v1-endpoints-is-deprecated-in-v133--warning-in-the-operators-logs this is the recommended migration path when switching from endpoints to endpointslices.