### PR TITLE
docs: clarity on 1.3 release notes

### DIFF
--- a/docs/operations/release-notes/1-3.mdx
+++ b/docs/operations/release-notes/1-3.mdx
@@ -36,13 +36,13 @@ UDS Core 1.3 introduces opt-in support for public Keycloak clients (PKCE-enforce
 
 ### Identity Config updates (0.26.1)
 
-UDS Core 1.3.0 includes UDS Identity Config [0.26.1](https://github.com/defenseunicorns/uds-identity-config/releases/tag/v0.26.1), which was also included in the 1.2.2 patch release. No breaking changes or manual realm steps are required.
+UDS Core 1.3 includes UDS Identity Config [0.26.1](https://github.com/defenseunicorns/uds-identity-config/releases/tag/v0.26.1), which was also included in the 1.2.2 patch release. No breaking changes or manual realm steps are required.
 
 ## Related documentation
 
 - [Upgrade Overview](/operations/upgrades/overview/) - general upgrade procedures and checklists
 - [Configure automatic account inactivity disable](/how-to-guides/identity-and-authorization/configure-account-inactivity-disable/) - configure and verify inactive account disable behavior
-- [UDS Core 1.3.0 Changelog](https://github.com/defenseunicorns/uds-core/blob/main/CHANGELOG.md#130-2026-04-28) - full changelog
+- [UDS Core 1.3.0 Changelog](https://github.com/defenseunicorns/uds-core/blob/main/CHANGELOG.md#130-2026-04-28) - full changelog for 1.3.0
 - [UDS Identity Config 0.26.0 Changelog](https://github.com/defenseunicorns/uds-identity-config/blob/main/CHANGELOG.md#0260-2026-04-13) - full changelog
 - [UDS Identity Config 0.26.1 Changelog](https://github.com/defenseunicorns/uds-identity-config/blob/main/CHANGELOG.md#0261-2026-04-27) - full changelog
 - [Full diff (1.2.2...1.3.1)](https://github.com/defenseunicorns/uds-core/compare/v1.2.2...v1.3.1) - all changes between versions


### PR DESCRIPTION
## Description

Switched release callout to mention `1.3` instead of `1.3.0`. This was feedback [here](https://github.com/defenseunicorns/uds-core/pull/2651#discussion_r3195453674) on the backport PR to the release branch.

`1.3` mirrors other callouts in this same doc and other release notes, for example `UDS Core 1.3 introduces...`.