### PR TITLE
chore(docs): add legacy upgrade notes and local demo deploy warning

### DIFF
--- a/docs/getting-started/local-demo/install-and-deploy-uds.mdx
+++ b/docs/getting-started/local-demo/install-and-deploy-uds.mdx
@@ -35,6 +35,19 @@ import { Steps } from '@astrojs/starlight/components';
 
 ## Deploy UDS Core
 
+> [!IMPORTANT]
+> Before deploying, confirm your Kubernetes context is not pointing at a real cluster such as AKS, EKS, or GKE:
+>
+> ```bash
+> uds zarf tools kubectl config current-context
+> ```
+>
+> The `k3d-core-demo` bundle creates and targets a local k3d cluster. If your active context points somewhere unexpected, stop and switch context before continuing. If you are redeploying to an existing cluster or using a locally built demo bundle, also confirm the bundle architecture matches your node architecture:
+>
+> ```bash
+> uds zarf tools kubectl get nodes -o custom-columns=NAME:.metadata.name,ARCH:.status.nodeInfo.architecture
+> ```
+
 <Steps>
 
 1. **Deploy the [`k3d-core-demo`](https://github.com/defenseunicorns/uds-core/blob/main/bundles/k3d-standard/README.md) bundle**
@@ -45,7 +58,7 @@ import { Steps } from '@astrojs/starlight/components';
    uds deploy k3d-core-demo:latest
    ```
 
-   Confirm with `y` when prompted. The first run takes approximately **10–15 minutes** while images are pulled.
+   Confirm with `y` when prompted. The first run takes approximately **10 to 15 minutes** while images are pulled.
 
    > [!NOTE]
    > To deploy a specific version, replace `latest` with a version tag. See all versions on the [package registry](https://github.com/defenseunicorns/uds-core/pkgs/container/packages%2Fuds%2Fbundles%2Fk3d-core-demo).
@@ -96,4 +109,3 @@ Delete the local k3d cluster:
 ```bash
 k3d cluster delete uds
 ```
-

--- a/docs/getting-started/local-demo/install-and-deploy-uds.mdx
+++ b/docs/getting-started/local-demo/install-and-deploy-uds.mdx
@@ -58,7 +58,7 @@ import { Steps } from '@astrojs/starlight/components';
    uds deploy k3d-core-demo:latest
    ```
 
-   Confirm with `y` when prompted. The first run takes approximately **10 to 15 minutes** while images are pulled.
+   Confirm with `y` when prompted. The first run takes approximately **10-15 minutes** while images are pulled.
 
    > [!NOTE]
    > To deploy a specific version, replace `latest` with a version tag. See all versions on the [package registry](https://github.com/defenseunicorns/uds-core/pkgs/container/packages%2Fuds%2Fbundles%2Fk3d-core-demo).

--- a/docs/operations/release-notes/overview.mdx
+++ b/docs/operations/release-notes/overview.mdx
@@ -11,6 +11,8 @@ Release notes for UDS Core document what changed in each version, including brea
 
 This page shows the latest 3 supported minor versions. Older release notes are available in the sidebar or on [GitHub Releases](https://github.com/defenseunicorns/uds-core/releases).
 
+If you support a deployment older than the release notes covered here, see [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) for preserved manual upgrade steps.
+
 {/* Maintainer note: Keep only the latest 3 supported minor versions below.
     When adding a new release notes page, add a LinkCard for the new version
     and remove the oldest one. This matches the 3-version support policy. */}

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-10.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-10.mdx
@@ -1,0 +1,44 @@
+---
+title: Identity Config 0.10.0+
+description: Legacy manual upgrade notes for UDS Identity Config 0.10.0+, covering SAML mapper property changes after the Keycloak 26.1.0 upgrade.
+sidebar:
+  order: 2.009
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## SAML mapper properties
+
+UDS Identity Config v0.10.0 upgraded Keycloak to 26.1.0. That release added case sensitivity to Client SAML mappers, which could break SAML authentication flows if identity provider data no longer mapped into applications such as SonarQube or GitLab.
+
+To update affected SAML mappers:
+
+<Steps>
+
+1. Go to **Client scopes**.
+2. For each affected mapper, select the mapper and open the **Mappers** tab.
+3. Select the available mapper.
+4. Update the **Property** field to the exact lower-case or camel-case value.
+5. Click **Save** after each update.
+
+</Steps>
+
+Use these property mappings:
+
+| Mapper | Previous value | Required value |
+|---|---|---|
+| `mapper-saml-email-email` | `Email` | `email` |
+| `mapper-saml-firstname-first_name` | `FirstName` | `firstName` |
+| `mapper-saml-lastname-last_name` | `LastName` | `lastName` |
+| `mapper-saml-username-login` | `Username` | `username` |
+| `mapper-saml-username-name` | `Username` | `username` |
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/) - current guidance for manual Keycloak realm changes

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-11.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-11.mdx
@@ -1,0 +1,199 @@
+---
+title: Identity Config 0.11.0
+description: Legacy manual upgrade notes for UDS Identity Config 0.11.0, covering client credentials, UDS client policy, MFA, and IDP redirector changes.
+sidebar:
+  order: 2.008
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## Client credentials grant
+
+UDS Identity Config v0.11.0 introduced Client Credentials Grant support for the UDS Operator. This replaced Dynamic Client Registration, improved reliability, and removed the need to store registration tokens in the Pepr Store.
+
+### Create the `uds-operator` client
+
+Create a Keycloak client for the UDS Operator:
+
+<Steps>
+
+1. Navigate to the `uds` realm.
+2. Go to **Clients** > **Create**.
+3. Set **Client type** to `openid-connect`.
+4. Set **Client ID** to `uds-operator`.
+5. Set **Client name** to `uds-operator`.
+6. Click **Next**.
+7. Enable **Client authentication**.
+8. Disable all authentication flows except **Service account roles**.
+9. Click **Next**.
+10. Click **Save**.
+
+</Steps>
+
+Configure the client authenticator:
+
+<Steps>
+
+1. Go to **Clients** > **uds-operator** > **Credentials**.
+2. Set **Client authenticator** to **Client Id and Kubernetes Secret**.
+3. Click **Save**.
+
+</Steps>
+
+Configure service account roles:
+
+<Steps>
+
+1. Go to **Clients** > **uds-operator** > **Service account roles**.
+2. If `default-roles-uds` is assigned, open the row action menu and click **Unassign** > **Remove**.
+3. Click **Assign role**.
+4. Set the filter to **Filter by clients**.
+5. Select `realm-management: manage-clients`.
+6. Click **Assign**.
+
+</Steps>
+
+### Configure the UDS client policy
+
+The UDS client policy applies the UDS client profile to clients created for UDS packages.
+
+Create the client profile:
+
+<Steps>
+
+1. Go to **Realm settings** > **Client policies** > **Profiles**.
+2. Click **Create client profile**.
+3. Set **Name** to `uds-client-profile`.
+4. Set **Description** to `UDS Client Profile`.
+5. Click **Save**.
+6. Click **Add executor**.
+7. Select **uds-operator-permissions**.
+8. Click **Add**.
+
+</Steps>
+
+Create the client policy:
+
+<Steps>
+
+1. Go to **Realm settings** > **Client policies** > **Policies**.
+2. Click **Create client policy**.
+3. Set **Name** to `uds-client-policy`.
+4. Set **Description** to `UDS Client Policy`.
+5. Click **Save**.
+6. Click **Add condition**.
+7. Select **any-client**.
+8. Click **Add**.
+9. Click **Add client profile**.
+10. Select `uds-client-profile`.
+11. Click **Add**.
+
+</Steps>
+
+> [!NOTE]
+> Some older Keycloak UI versions appeared to select every client profile during this flow. Only the selected profile was applied.
+
+### Configure the client credentials authentication flow
+
+Create and bind the authentication flow:
+
+<Steps>
+
+1. Go to **Authentication** > **Flows**.
+2. Select the `clients` flow.
+3. Click **Actions** > **Duplicate**.
+4. Set **Name** to `UDS Client Credentials`.
+5. Set **Description** to `UDS Client Credentials`.
+6. Click **Duplicate**.
+7. Go to **Authentication** > **UDS Client Credentials**.
+8. Click **Add step** on pre-v0.40.0 UDS Core deployments, or **Add execution** on v0.40.0 and later.
+9. Select **Client Id and Kubernetes Secret**.
+10. Click **Add**.
+11. Set **Requirement** to **Alternative**.
+12. In the row action menu for **UDS Client Credentials**, select **Bind flows**.
+13. Select **Client authentication flow**.
+14. Click **Save**.
+
+</Steps>
+
+### Verify client credentials configuration
+
+Deploy or update a UDS package, then check the UDS Operator logs.
+
+Use this command to verify that the UDS Operator uses the client credentials flow:
+
+```bash
+uds zarf tools kubectl logs deploy/pepr-uds-core-watcher -n pepr-system | grep "Client Credentials Keycloak Client is available"
+```
+
+After applying these changes, confirm every `Package` reconciles and that the UDS Operator logs show no errors.
+
+> [!TIP]
+> If the UDS Operator logs `The client doesn't have the created-by=uds-operator attribute. Rejecting request`, temporarily disable the `UDS client policy`, wait for package reconciliation, then re-enable it. Some older deployments needed to disable `UDS client policy`, restart the Pepr watcher pod to force all `Package` resources to reconcile, wait for all packages to become ready, and then re-enable `UDS client policy`.
+
+If you need to allow additional protocol mappers or client scopes, see [Identity and authorization configuration](/reference/configuration/identity-and-authorization/#client-policy-enforcement).
+
+## MFA changes
+
+UDS Identity Config v0.11.0 also introduced MFA changes. Previous versions did not support MFA on the X.509 authentication flow. This version added support for X.509 MFA and WebAuthn MFA. Both options were disabled by default.
+
+If you need OTP and WebAuthn MFA everywhere, update required actions first:
+
+<Steps>
+
+1. Go to **Authentication** > **Required actions**.
+2. Enable these required actions, but do not set them as default actions:
+   - **Configure OTP**
+   - **Webauthn Register**
+   - **Delete Credential**
+3. Disable **WebAuthn Register Passwordless**. Do not disable **Webauthn Register**.
+
+</Steps>
+
+> [!CAUTION]
+> Authentication flow changes can break login. Confirm you have a tested administrator recovery path before changing the `UDS Authentication` flow.
+
+To update the `UDS Authentication` flow for X.509 MFA:
+
+<Steps>
+
+1. Go to **Authentication** > **Flows**.
+2. Select **UDS Authentication**.
+3. In the top-level **Authentication** sub-flow, add a sub-flow named `X509 Authentication`.
+4. Drag `X509 Authentication` directly below **Cookie** and **IDP Redirector**.
+5. Set `X509 Authentication` to **Alternative**.
+6. In `X509 Authentication`, add a sub-flow named `X509 Conditional OTP`.
+7. Set `X509 Conditional OTP` to **Required**.
+8. Add **Condition - user configured** to `X509 Conditional OTP` and set it to **Required**.
+9. Add **OTP Form** to `X509 Conditional OTP` and set it to **Required**.
+10. Add **WebAuthn Authenticator** to `X509 Conditional OTP`.
+11. Drag the existing **X509/Validate Username Form** step into the `X509 Authentication` sub-flow above `X509 Conditional OTP`.
+12. Set **X509/Validate Username Form** to **Required**.
+
+</Steps>
+
+## IDP redirector
+
+To add an IDP redirector option to `UDS Authentication`:
+
+<Steps>
+
+1. Go to **Authentication** > **Flows**.
+2. Select **UDS Authentication**.
+3. Under the **Authentication** sub-flow, add a new sub-flow named `idp redirector`.
+4. Drag `idp redirector` directly below **Cookie**.
+5. Set `idp redirector` to **Alternative**.
+6. Add **Identity Provider Redirector** to `idp redirector`.
+7. Set **Identity Provider Redirector** to **Required**.
+
+</Steps>
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Identity and authorization configuration](/reference/configuration/identity-and-authorization/) - current Identity Config configuration reference

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-11.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-11.mdx
@@ -136,7 +136,7 @@ After applying these changes, confirm every `Package` reconciles and that the UD
 > [!TIP]
 > If the UDS Operator logs `The client doesn't have the created-by=uds-operator attribute. Rejecting request`, temporarily disable the `UDS client policy`, wait for package reconciliation, then re-enable it. Some older deployments needed to disable `UDS client policy`, restart the Pepr watcher pod to force all `Package` resources to reconcile, wait for all packages to become ready, and then re-enable `UDS client policy`.
 
-If you need to allow additional protocol mappers or client scopes, see [Identity and authorization configuration](/reference/configuration/identity-and-authorization/#client-policy-enforcement).
+If you need to allow additional protocol mappers or client scopes, see [Identity and authorization configuration](/reference/configuration/identity-and-authorization/#security-hardening).
 
 ## MFA changes
 

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-14.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-14.mdx
@@ -1,0 +1,95 @@
+---
+title: Identity Config 0.14.0 to 0.14.1
+description: Legacy manual upgrade notes for UDS Identity Config 0.14.0 to 0.14.1, covering ambient mode SSL settings, Dynamic Client Registration removal, and FIPS preparation.
+sidebar:
+  order: 2.007
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## v0.14.1+: ambient mode SSL setting
+
+UDS Core v0.42.0 switched Keycloak to ambient mode. In AWS environments that use shared address space from [RFC 6598](https://www.rfc-editor.org/rfc/rfc6598), this could cause HTTP 403 responses unless the realm's **Require SSL** option was set to **None**.
+
+To update **Require SSL** manually:
+
+<Steps>
+
+1. Navigate to the `uds` realm.
+2. Go to **Realm settings** > **General**.
+3. Set **Require SSL** to **None**.
+
+</Steps>
+
+## v0.14.0+: Dynamic Client Registration removal
+
+UDS Identity Config v0.14.0 removed Dynamic Client Registration. Existing deployments needed to remove old trusted hosts and add a `max-clients` policy that blocks authenticated client registration.
+
+To remove old trusted hosts:
+
+<Steps>
+
+1. Navigate to the `uds` realm.
+2. Go to **Clients** > **Client registration** > **Trusted hosts**.
+3. Remove these trusted hosts:
+   - `*.keycloak.svc.cluster.local`
+   - `*.pepr-uds-core-watcher.pepr-system.svc.cluster.local`
+   - `127.0.0.6`
+4. Click **Save**.
+
+</Steps>
+
+To add the `max-clients` policy:
+
+<Steps>
+
+1. Go to **Clients** > **Client registration**.
+2. Click **Create client policy**.
+3. Select **max-clients**.
+4. Set **Name** to `max number of clients`.
+5. Set **Max Clients Per Realm** to `0`.
+6. Click **Save**.
+
+</Steps>
+
+## FIPS preparation
+
+UDS Core v0.41.0 fixed a critical FIPS mode issue in Keycloak. Earlier deployments could start Keycloak without FIPS restrictions because Bouncy Castle FIPS libraries were missing. Enabling FIPS mode changes password and hashing behavior:
+
+- Passwords must be at least 14 characters long, including database credentials and user passwords.
+- The `argon2` hashing algorithm is not available in FIPS mode.
+- Existing systems must migrate user credentials to `pbkdf2-sha512` before enabling FIPS mode in the `master` realm.
+
+> [!CAUTION]
+> If you enable FIPS mode before migrating the administrator credential hashing algorithm, you can lock the administrator account.
+
+To prepare the administrator account for FIPS mode:
+
+<Steps>
+
+1. Log in to Keycloak with the administrator account. If needed, use `uds zarf connect keycloak`.
+2. In the `master` realm, go to **Authentication** > **Policies** > **Password policy**.
+3. Click **Add policy**.
+4. Select **Hashing algorithm** and set it to `pbkdf2-sha512`.
+5. Click **Save**.
+6. Go to **Users** and select the administrator account.
+7. Open the **Credentials** tab and click **Reset password**.
+8. Enter a password of at least 14 characters. You can reuse the existing password if it meets the policy.
+9. Set **Temporary** to **Off**.
+10. Click **Save**.
+11. Return to the user's **Credentials** tab and click **Show data**.
+12. Confirm `algorithm` is set to `pbkdf2-sha512`.
+
+</Steps>
+
+For FIPS limitations, see [Keycloak FIPS 140-2 support](https://www.keycloak.org/server/fips).
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade to FIPS 140-2 mode](/how-to-guides/identity-and-authorization/upgrade-to-fips-mode/) - current FIPS upgrade guidance

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-17.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-17.mdx
@@ -1,0 +1,39 @@
+---
+title: Identity Config 0.17.0
+description: Legacy manual upgrade notes for UDS Identity Config 0.17.0, covering OpenTofu client support and concurrent SSO session limits.
+sidebar:
+  order: 2.006
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## OpenTofu client
+
+UDS Identity Config introduced the `uds-opentofu-client` for managing Keycloak with OpenTofu. New realm imports include this client automatically. If you cannot reinitialize Keycloak, manually configure the client by following [Manage Keycloak with OpenTofu](/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu/).
+
+## SSO session limits
+
+UDS Core v0.51.0 also introduced per-user concurrent SSO session limits in the `uds` realm.
+
+To configure the session limiter manually:
+
+<Steps>
+
+1. Navigate to the `uds` realm.
+2. Go to **Authentication** > **Flows** > **UDS Authentication**.
+3. Click **Add execution**.
+4. Select **User Session Count Limiter**.
+5. Open the settings for the new **User Session Count Limiter** execution.
+6. Set **Maximum concurrent sessions for each user within this realm** to the same value as `SSO_SESSION_MAX_PER_USER` in `realmInitEnv`.
+
+</Steps>
+
+## Related documentation
+
+- [Manage Keycloak with OpenTofu](/how-to-guides/identity-and-authorization/manage-keycloak-with-opentofu/) - current OpenTofu configuration guide
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-19.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-19.mdx
@@ -1,0 +1,41 @@
+---
+title: Identity Config 0.19.0+
+description: Legacy manual upgrade notes for UDS Identity Config 0.19.0+, covering the Keycloak view-system role required by older OpenTofu workflows.
+sidebar:
+  order: 2.005
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## ServerInfo permissions
+
+Keycloak 26.4.0 changed the `ServerInfo` endpoint. Without additional permissions, OpenTofu can fail with a `Malformed version` error when using the Keycloak Terraform provider. See [Keycloak Terraform Provider #1342](https://github.com/keycloak/terraform-provider-keycloak/issues/1342#issuecomment-3398650912) for upstream context.
+
+To add the required `view-system` role:
+
+<Steps>
+
+1. Navigate to the `uds` realm.
+2. Go to **Clients** > **realm-management** > **Client roles** > **Roles**.
+3. Click **Create role**.
+4. Set **Role name** to `view-system`.
+5. Set **Description** to `Enables displaying SystemInfo through the ServerInfo endpoint`.
+6. Click **Save**.
+7. Return to the `realm-management` roles by clicking the **Client details** breadcrumb.
+8. Select the `realm-admin` role.
+9. Open the **Associated roles** tab.
+10. Click **Assign role** > **Client roles**.
+11. Select the `view-system` role.
+12. Click **Assign**.
+
+</Steps>
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/) - current guidance for manual Keycloak realm changes

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-23.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-23.mdx
@@ -1,0 +1,34 @@
+---
+title: Identity Config 0.23.0+
+description: Legacy manual upgrade notes for UDS Identity Config 0.23.0+, covering logout confirmation for built-in Keycloak clients.
+sidebar:
+  order: 2.004
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## Logout confirmation
+
+Keycloak 26.5.0 introduced logout confirmation for built-in clients. Newer installs enable this by default. Existing deployments can update the default Keycloak clients manually.
+
+To enable logout confirmation:
+
+<Steps>
+
+1. Navigate to the `uds` realm.
+2. Go to **Clients** > **account**.
+3. Set **Logout confirmation** to **On**.
+4. Click **Save**.
+5. Repeat these steps for the `account-console` and `security-admin-console` clients.
+
+</Steps>
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/) - current guidance for manual Keycloak realm changes

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-0.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-0.mdx
@@ -1,0 +1,52 @@
+---
+title: Identity Config 0.5.0
+description: Legacy manual upgrade notes for UDS Identity Config 0.5.0, covering group authorization authentication flow changes.
+sidebar:
+  order: 2.013
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## Group authorization
+
+UDS Identity Config v0.5.0 added a new authentication flow for group authorization.
+
+To add group authorization to browser flows:
+
+<Steps>
+
+1. In the Keycloak admin portal, navigate to the `uds` realm.
+2. Go to **Authentication**.
+3. Add **UDS Operator Group Authentication Validation** at the base level and bottom of these flows:
+   - **UDS Authentication**
+   - **UDS Registration**
+   - **UDS Reset Credentials**
+
+</Steps>
+
+If you use a SAML identity provider, create a dedicated `Authorization` flow:
+
+<Steps>
+
+1. Go to **Authentication**.
+2. Click **Create flow**.
+3. Set **Name** to `Authorization`.
+4. Set **Description** to `UDS Operator Group Authentication Validation`.
+5. Select **Basic flow**.
+6. Click **Create**.
+7. Click **Add execution**.
+8. Add **UDS Operator Group Authentication Validation**.
+9. Go to **Identity providers** and select the SAML provider.
+10. In **Advanced settings**, set **Post login flow** to `Authorization`.
+
+</Steps>
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/) - current guidance for manual Keycloak realm changes

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-1.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-1.mdx
@@ -1,0 +1,44 @@
+---
+title: Identity Config 0.5.1
+description: Legacy manual upgrade notes for UDS Identity Config 0.5.1, covering User Managed Attributes and STIG password rule changes.
+sidebar:
+  order: 2.012
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## User managed attributes
+
+UDS Identity Config v0.5.1 used Keycloak User Managed Attributes, which require Keycloak 24 or later.
+
+To update user managed attributes manually:
+
+<Steps>
+
+1. In **Realm settings** > **General**, turn **User-managed access** off.
+2. Set **Unmanaged attributes** to **Only administrators can write**.
+3. Go to **User profile**.
+4. Select the **JSON editor** tab.
+5. Copy the user attribute definition from the [v0.5.1 realm.json](https://github.com/defenseunicorns/uds-identity-config/blob/v0.5.1/src/realm.json#L1884-L1895).
+6. Click **Save**.
+
+</Steps>
+
+## STIG password and session rules
+
+This version also incorporated STIG password and session rules based on the Elasticsearch 8.0 hardening guides:
+
+- Passwords expire after 60 days.
+- Password complexity requires 2 special characters, 1 digit, 1 lowercase character, 1 uppercase character, and 15 characters minimum.
+- IDP session idle timeout is 10 minutes.
+- Maximum login attempts is 3.
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/) - current guidance for manual Keycloak realm changes

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-2.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-2.mdx
@@ -1,0 +1,64 @@
+---
+title: Identity Config 0.5.2
+description: Legacy manual upgrade notes for UDS Identity Config 0.5.2, covering Keycloak event listeners and the bare-groups client scope.
+sidebar:
+  order: 2.011
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## Event listeners
+
+UDS Identity Config v0.5.2 added a custom JSON Keycloak event logger, renamed the custom registration event listener, and added the `bare-groups` client scope.
+
+To enable the JSON event logger in the `uds` realm:
+
+<Steps>
+
+1. Go to **Realm settings** > **Events**.
+2. Add `jsonlog-event-listener`.
+3. Remove the built-in `jboss-logging` event listener.
+4. Click **Save**.
+
+</Steps>
+
+To update the renamed registration event listener in the `uds` realm:
+
+<Steps>
+
+1. Go to **Realm settings** > **Events**.
+2. Add `registration-event-listener`.
+3. Remove `custom-registration-listener`.
+4. Click **Save**.
+
+</Steps>
+
+## `bare-groups` client scope
+
+To add the `bare-groups` client scope:
+
+<Steps>
+
+1. Go to **Client scopes** > **Create client scope**.
+2. Set **Name** to `bare-groups`.
+3. Set **Type** to **Optional**.
+4. Set **Include in token scope** to **On**.
+5. Click **Save**.
+6. Open **Mappers** and click **Create a new mapper**.
+7. Select **Custom Group Path Mapper**.
+8. Set **Name** to `bare groups`.
+9. To allow clients to use this scope as a default client scope, go to **Clients** > **Client registration** > **Allowed client scopes**.
+10. Add `bare-groups`.
+11. Click **Save**.
+
+</Steps>
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/) - current guidance for manual Keycloak realm changes

--- a/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-9-to-0-10.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/identity-config-0-9-to-0-10.mdx
@@ -1,0 +1,51 @@
+---
+title: Identity Config 0.9.1 to 0.10.0
+description: Legacy manual upgrade notes for UDS Identity Config 0.9.1 to 0.10.0, covering ambient mesh trusted hosts and reset credential flow behavior.
+sidebar:
+  order: 2.010
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+These notes preserve manual upgrade steps from older UDS Identity Config versions. Use them when supporting an older UDS Core deployment that may have skipped a historical Keycloak realm change.
+
+> [!NOTE]
+> These notes are not the source of truth for current supported releases. For current upgrade procedures, start with the [Upgrade Overview](/operations/upgrades/overview/), then review [Release Notes](/operations/release-notes/overview/) and [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/).
+
+## Ambient mesh trusted hosts
+
+When running Istio ambient mesh, existing deployments needed two additional trusted hosts for client registration.
+
+To add ambient mesh trusted hosts:
+
+<Steps>
+
+1. Go to **Clients** > **Client registration** > **Client details**.
+2. Add these hosts to **Trusted hosts**:
+   - `*.pepr-uds-core-watcher.pepr-system.svc.cluster.local`
+   - `*.keycloak.svc.cluster.local`
+3. Click **Save**.
+
+</Steps>
+
+## Reset credential flow
+
+Keycloak 26.1.1 also added an option to force re-login after resetting credentials. New deployments enabled this by default.
+
+To enable forced login after credential reset:
+
+<Steps>
+
+1. Go to **Authentication** > **UDS Reset Credentials**.
+2. Find the **Send Reset Email** step.
+3. Click **Settings**.
+4. Enter an alias, for example `reset-credentials-email`.
+5. Enable **Force login after reset**.
+6. Click **Save**.
+
+</Steps>
+
+## Related documentation
+
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions
+- [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/) - current guidance for manual Keycloak realm changes

--- a/docs/operations/upgrades/legacy-upgrade-notes/overview.mdx
+++ b/docs/operations/upgrades/legacy-upgrade-notes/overview.mdx
@@ -1,0 +1,66 @@
+---
+title: Legacy upgrade notes
+description: Preserved manual upgrade notes for older UDS Core and UDS Identity Config deployments that may still need support during version jumps.
+sidebar:
+  order: 2.003
+---
+
+import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Legacy upgrade notes preserve manual steps that applied to older UDS Core and UDS Identity Config releases. Use these pages when supporting deployments that skipped historical manual Keycloak realm changes or are upgrading from versions older than the current release notes cover.
+
+> [!NOTE]
+> These notes are preserved for support cases on older deployments. For current upgrade guidance, use the [Upgrade Overview](/operations/upgrades/overview/), [Upgrade Keycloak realm configuration](/operations/upgrades/upgrade-keycloak-realm/), and [Release Notes](/operations/release-notes/overview/).
+
+<CardGrid>
+  <LinkCard
+    title="Identity Config 0.23.0+"
+    description="Enable logout confirmation for built-in Keycloak clients."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-23/"
+  />
+  <LinkCard
+    title="Identity Config 0.19.0+"
+    description="Add the view-system role required by older OpenTofu workflows."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-19/"
+  />
+  <LinkCard
+    title="Identity Config 0.17.0"
+    description="Configure OpenTofu client support and SSO session limits."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-17/"
+  />
+  <LinkCard
+    title="Identity Config 0.14.0 to 0.14.1"
+    description="Apply legacy Dynamic Client Registration and FIPS preparation steps."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-14/"
+  />
+  <LinkCard
+    title="Identity Config 0.11.0"
+    description="Configure client credentials, UDS client policy, MFA, and IDP redirector changes."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-11/"
+  />
+  <LinkCard
+    title="Identity Config 0.10.0"
+    description="Update SAML mapper properties for Keycloak 26.1.0."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-10/"
+  />
+  <LinkCard
+    title="Identity Config 0.9.1 to 0.10.0"
+    description="Add ambient mesh trusted hosts and reset credential flow behavior."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-9-to-0-10/"
+  />
+  <LinkCard
+    title="Identity Config 0.5.2"
+    description="Apply event listener and bare-groups client scope changes."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-2/"
+  />
+  <LinkCard
+    title="Identity Config 0.5.1"
+    description="Apply user managed attributes and STIG password rule changes."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-1/"
+  />
+  <LinkCard
+    title="Identity Config 0.5.0"
+    description="Create and apply group authorization authentication flows."
+    href="/operations/upgrades/legacy-upgrade-notes/identity-config-0-5-0/"
+  />
+</CardGrid>

--- a/docs/operations/upgrades/overview.mdx
+++ b/docs/operations/upgrades/overview.mdx
@@ -168,14 +168,19 @@ Rather than attempting a rollback, use the following approaches:
 
 <CardGrid>
   <LinkCard
-    title="Configuration Changes"
+    title="Configuration changes"
     description="Apply config changes to bundle overrides on a running platform."
     href="/operations/upgrades/configuration-changes/"
   />
   <LinkCard
-    title="Keycloak Realm Upgrades"
+    title="Keycloak realm upgrades"
     description="Version-specific steps for Keycloak realm configuration changes."
     href="/operations/upgrades/upgrade-keycloak-realm/"
+  />
+  <LinkCard
+    title="Legacy upgrade notes"
+    description="Preserved manual upgrade steps for older UDS Core and Identity Config deployments."
+    href="/operations/upgrades/legacy-upgrade-notes/overview/"
   />
   <LinkCard
     title="Release Notes"

--- a/docs/operations/upgrades/overview.mdx
+++ b/docs/operations/upgrades/overview.mdx
@@ -168,17 +168,17 @@ Rather than attempting a rollback, use the following approaches:
 
 <CardGrid>
   <LinkCard
-    title="Configuration changes"
+    title="Configuration Changes"
     description="Apply config changes to bundle overrides on a running platform."
     href="/operations/upgrades/configuration-changes/"
   />
   <LinkCard
-    title="Keycloak realm upgrades"
+    title="Keycloak Realm Upgrades"
     description="Version-specific steps for Keycloak realm configuration changes."
     href="/operations/upgrades/upgrade-keycloak-realm/"
   />
   <LinkCard
-    title="Legacy upgrade notes"
+    title="Legacy Upgrades"
     description="Preserved manual upgrade steps for older UDS Core and Identity Config deployments."
     href="/operations/upgrades/legacy-upgrade-notes/overview/"
   />

--- a/docs/operations/upgrades/upgrade-keycloak-realm.mdx
+++ b/docs/operations/upgrades/upgrade-keycloak-realm.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2.002
 ---
 
-Some UDS Identity Config upgrades require manual changes to an existing Keycloak realm. For example, when a full realm re-import is not possible and upstream Keycloak changes require manual intervention on a running instance.
+Some UDS Identity Config upgrades require manual changes to an existing Keycloak realm. For example, when a full realm re-import isn't possible and upstream Keycloak changes require manual intervention on a running instance.
 
 When manual realm changes are required, the [release notes](/operations/release-notes/overview/) for the corresponding UDS Core version document the specific steps under the **Identity Config updates** section.
 

--- a/docs/operations/upgrades/upgrade-keycloak-realm.mdx
+++ b/docs/operations/upgrades/upgrade-keycloak-realm.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2.002
 ---
 
-Some UDS Identity Config upgrades require manual changes to an existing Keycloak realm. For example, when a full realm re-import isn't possible and upstream Keycloak changes require manual intervention on a running instance.
+Some UDS Identity Config upgrades require manual changes to an existing Keycloak realm. For example, when a full realm re-import is not possible and upstream Keycloak changes require manual intervention on a running instance.
 
 When manual realm changes are required, the [release notes](/operations/release-notes/overview/) for the corresponding UDS Core version document the specific steps under the **Identity Config updates** section.
 
@@ -21,3 +21,4 @@ Manual realm changes are typically required when:
 
 - [Release Notes](/operations/release-notes/overview/) - version-specific changes including identity-config migration steps
 - [Upgrade Overview](/operations/upgrades/overview/) - general upgrade procedures and checklists
+- [Legacy upgrade notes](/operations/upgrades/legacy-upgrade-notes/overview/) - preserved manual steps for older Identity Config versions


### PR DESCRIPTION
## Description
Bring in legacy identity config upgrade notes as well as local demo kubectl context warning. These docs are essentially the same as [the legacy docs](https://uds.defenseunicorns.com/reference/uds-core/idam/upgrading-versions/), just with our new design and language changes. 

## Related Issue

Fixes [Core-519](https://linear.app/defense-unicorns/issue/CORE-519/add-legacy-upgrade-notes-to-new-docs-site)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
