### PR TITLE
chore(ci): add test to verify loki able to flush to s3

### DIFF
--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -105,6 +105,9 @@ jobs:
       - name: Test UDS Core
         run: uds run -f tasks/test.yaml uds-core-non-k3d
 
+      - name: Validate Loki chunks S3 writes
+        run: uds run -f src/loki/tasks.yaml validate-object-storage-writes --no-progress --with provider=aws --with iac_dir=.github/test-infra/aws/eks
+
       - name: Debug Output
         if: ${{ always() }}
         uses: ./.github/actions/debug-output

--- a/.github/workflows/test-iac.yaml
+++ b/.github/workflows/test-iac.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 name: Filter IaC
@@ -77,6 +77,7 @@ jobs:
               - ".github/workflows/test-rke2.yaml"
             eks:
               - "tasks/iac.yaml"
+              - "src/loki/tasks.yaml"
               - ".github/bundles/eks/**"
               - ".github/test-infra/aws/eks/**"
               - ".github/workflows/test-eks.yaml"

--- a/src/loki/tasks.yaml
+++ b/src/loki/tasks.yaml
@@ -216,21 +216,23 @@ tasks:
           ATTEMPT=1
           while [ "$(date +%s)" -lt "${END_TIME}" ]; do
             REMAINING_SECONDS=$(( END_TIME - $(date +%s) ))
-            echo "Attempt ${ATTEMPT}: checking for Loki chunks object written after ${LOKI_OBJECT_STORAGE_TEST_START} (${REMAINING_SECONDS}s remaining)..."
+            echo "Attempt ${ATTEMPT}: checking for Loki chunk objects under fake/ written after ${LOKI_OBJECT_STORAGE_TEST_START} (${REMAINING_SECONDS}s remaining)..."
 
-            RECENT_OBJECT_KEY="$(aws s3api list-objects-v2 \
+            # auth_enabled is false, so Loki writes tenant chunk objects under fake/.
+            RECENT_CHUNK_OBJECT_COUNT="$(aws s3api list-objects-v2 \
               --bucket "${LOKI_CHUNKS_OBJECT_STORAGE_BUCKET}" \
-              --query "Contents[?LastModified>=\`${LOKI_OBJECT_STORAGE_TEST_START}\`].Key | [0]" \
+              --prefix "fake/" \
+              --query "length(Contents[?LastModified>=\`${LOKI_OBJECT_STORAGE_TEST_START}\`])" \
               --output text 2>"${S3_LIST_ERROR}" || true)"
 
-            if [ -n "${RECENT_OBJECT_KEY}" ] && [ "${RECENT_OBJECT_KEY}" != "None" ]; then
-              echo "Validated Loki wrote a recent object to configured chunks object storage."
+            if [ -n "${RECENT_CHUNK_OBJECT_COUNT}" ] && [ "${RECENT_CHUNK_OBJECT_COUNT}" -gt 0 ] 2>/dev/null; then
+              echo "Validated Loki wrote recent chunk objects to configured object storage."
               exit 0
             fi
 
-            echo "No recent Loki chunks object found yet; waiting ${{ .inputs.poll_interval }}s before retrying."
+            echo "No recent Loki chunk objects found under fake/ yet; waiting ${{ .inputs.poll_interval }}s before retrying."
             ATTEMPT=$(( ATTEMPT + 1 ))
             sleep "${{ .inputs.poll_interval }}"
           done
 
-          fail "Timed out waiting for a recent Loki object to appear in chunks object storage."
+          fail "Timed out waiting for recent Loki chunk objects under fake/ in object storage."

--- a/src/loki/tasks.yaml
+++ b/src/loki/tasks.yaml
@@ -219,11 +219,13 @@ tasks:
             echo "Attempt ${ATTEMPT}: checking for Loki chunk objects under fake/ written after ${LOKI_OBJECT_STORAGE_TEST_START} (${REMAINING_SECONDS}s remaining)..."
 
             # auth_enabled is false, so Loki writes tenant chunk objects under fake/.
+            : > "${S3_LIST_ERROR}"
             RECENT_CHUNK_OBJECT_COUNT="$(aws s3api list-objects-v2 \
               --bucket "${LOKI_CHUNKS_OBJECT_STORAGE_BUCKET}" \
               --prefix "fake/" \
-              --query "length(Contents[?LastModified>=\`${LOKI_OBJECT_STORAGE_TEST_START}\`])" \
-              --output text 2>"${S3_LIST_ERROR}" || true)"
+              --output json 2>"${S3_LIST_ERROR}" \
+              | jq --arg start "${LOKI_OBJECT_STORAGE_TEST_START}" '[.Contents[]? | select(.LastModified >= $start)] | length' \
+              || true)"
 
             if [ -n "${RECENT_CHUNK_OBJECT_COUNT}" ] && [ "${RECENT_CHUNK_OBJECT_COUNT}" -gt 0 ] 2>/dev/null; then
               echo "Validated Loki wrote recent chunk objects to configured object storage."

--- a/src/loki/tasks.yaml
+++ b/src/loki/tasks.yaml
@@ -1,5 +1,9 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+variables:
+  - name: LOKI_CHUNKS_OBJECT_STORAGE_BUCKET
+    sensitive: true
 
 tasks:
   - name: validate
@@ -31,3 +35,178 @@ tasks:
         cmd: |
           npm ci && npx vitest run "loki" --exclude "**/*integration*"
         dir: test/vitest
+
+  - name: validate-object-storage-writes
+    description: Validate Loki writes log chunks to configured object storage
+    inputs:
+      provider:
+        description: Object storage provider to validate. (Currently only 'aws' is supported)
+        required: true
+      iac_dir:
+        description: Directory containing IaC outputs for the object storage backend
+        default: .github/test-infra/aws/eks
+      poll_timeout:
+        description: Maximum seconds to wait for Loki objects to appear in object storage
+        default: "300"
+      poll_interval:
+        description: Seconds between object storage polling attempts
+        default: "10"
+    actions:
+      - description: Validate object storage provider configuration
+        cmd: |
+          set -euo pipefail
+
+          case "${{ .inputs.provider }}" in
+            aws)
+              command -v aws >/dev/null 2>&1 || { echo "ERROR: aws CLI is required"; exit 1; }
+              command -v tofu >/dev/null 2>&1 || { echo "ERROR: tofu is required"; exit 1; }
+              command -v curl >/dev/null 2>&1 || { echo "ERROR: curl is required"; exit 1; }
+              command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required"; exit 1; }
+              ;;
+            *)
+              echo "ERROR: Unsupported Loki object storage provider '${{ .inputs.provider }}'. Supported providers: aws."
+              exit 1
+              ;;
+          esac
+
+          if [ ! -d "${{ .inputs.iac_dir }}" ]; then
+            echo "ERROR: IaC directory '${{ .inputs.iac_dir }}' does not exist."
+            exit 1
+          fi
+
+      - description: Resolve Loki chunks S3 bucket
+        cmd: tofu output -raw loki_s3_bucket
+        dir: ${{ .inputs.iac_dir }}
+        mute: true
+        setVariables:
+          - name: LOKI_CHUNKS_OBJECT_STORAGE_BUCKET
+
+      - description: Set object storage validation start time
+        cmd: date -u +'%Y-%m-%dT%H:%M:%S+00:00'
+        mute: true
+        setVariables:
+          - name: LOKI_OBJECT_STORAGE_TEST_START
+
+      - description: Push a test log and flush Loki chunks
+        cmd: |
+          set -euo pipefail
+
+          LOKI_PORT="3100"
+          PORT_FORWARD_PID=""
+          PORT_FORWARD_LOG="$(mktemp)"
+
+          cleanup() {
+            if [ -n "${PORT_FORWARD_PID}" ] && kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
+              kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+              wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+            fi
+            rm -f "${PORT_FORWARD_LOG}"
+          }
+
+          diagnostics() {
+            echo "Loki push and flush diagnostics:"
+            echo "Loki write pods:"
+            uds zarf tools kubectl get pods -n loki -l app.kubernetes.io/component=write || true
+            echo "Port-forward output is available at ${PORT_FORWARD_LOG} during task execution."
+          }
+
+          fail() {
+            echo "ERROR: $*" >&2
+            diagnostics
+            exit 1
+          }
+
+          trap cleanup EXIT
+
+          uds zarf tools kubectl port-forward -n loki svc/loki-write "${LOKI_PORT}:3100" >"${PORT_FORWARD_LOG}" 2>&1 &
+          PORT_FORWARD_PID="$!"
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS "http://127.0.0.1:${LOKI_PORT}/ready" >/dev/null 2>&1; then
+              break
+            fi
+            if ! kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
+              fail "Loki write port-forward exited before becoming ready."
+            fi
+            if [ "${attempt}" -eq 30 ]; then
+              fail "Timed out waiting for Loki write port-forward to become ready."
+            fi
+            sleep 2
+          done
+
+          TEST_ID="$(date +%s)-$$"
+          LOG_MESSAGE="loki-object-storage-ci-${TEST_ID}"
+          TIMESTAMP="$(date +%s)000000000"
+          PAYLOAD="$(jq -n \
+            --arg timestamp "${TIMESTAMP}" \
+            --arg log_message "${LOG_MESSAGE}" \
+            --arg test_id "${TEST_ID}" \
+            '{
+              streams: [
+                {
+                  stream: {
+                    job: "loki-object-storage-ci",
+                    test_id: $test_id
+                  },
+                  values: [
+                    [$timestamp, $log_message]
+                  ]
+                }
+              ]
+            }')"
+
+          curl -fsS \
+            -H "Content-Type: application/json" \
+            -X POST \
+            --data-raw "${PAYLOAD}" \
+            "http://127.0.0.1:${LOKI_PORT}/loki/api/v1/push" \
+            || fail "Failed to push test log to Loki write endpoint."
+
+          curl -fsS -X POST "http://127.0.0.1:${LOKI_PORT}/flush" >/dev/null \
+            || fail "Failed to flush Loki write endpoint."
+
+          echo "Pushed test log and flushed Loki chunks."
+
+      - description: Verify Loki chunks object write
+        cmd: |
+          set -euo pipefail
+
+          S3_LIST_ERROR="$(mktemp)"
+
+          cleanup() {
+            rm -f "${S3_LIST_ERROR}"
+          }
+
+          diagnostics() {
+            if [ -s "${S3_LIST_ERROR}" ]; then
+              echo "Last S3 list error:"
+              while IFS= read -r line; do
+                echo "  ${line//${LOKI_CHUNKS_OBJECT_STORAGE_BUCKET}/<loki-chunks-bucket>}"
+              done < "${S3_LIST_ERROR}"
+            fi
+          }
+
+          fail() {
+            echo "ERROR: $*" >&2
+            diagnostics
+            exit 1
+          }
+
+          trap cleanup EXIT
+
+          END_TIME=$(( $(date +%s) + ${{ .inputs.poll_timeout }} ))
+          while [ "$(date +%s)" -lt "${END_TIME}" ]; do
+            RECENT_OBJECT_KEY="$(aws s3api list-objects-v2 \
+              --bucket "${LOKI_CHUNKS_OBJECT_STORAGE_BUCKET}" \
+              --query "Contents[?LastModified>=\`${LOKI_OBJECT_STORAGE_TEST_START}\`].Key | [0]" \
+              --output text 2>"${S3_LIST_ERROR}" || true)"
+
+            if [ -n "${RECENT_OBJECT_KEY}" ] && [ "${RECENT_OBJECT_KEY}" != "None" ]; then
+              echo "Validated Loki wrote a recent object to configured chunks object storage."
+              exit 0
+            fi
+
+            sleep "${{ .inputs.poll_interval }}"
+          done
+
+          fail "Timed out waiting for a recent Loki object to appear in chunks object storage."

--- a/src/loki/tasks.yaml
+++ b/src/loki/tasks.yaml
@@ -135,7 +135,9 @@ tasks:
           PORT_FORWARD_PID="$!"
 
           for attempt in $(seq 1 30); do
+            echo "Attempt ${attempt}/30: checking Loki write port-forward readiness..."
             if curl -fsS "http://127.0.0.1:${LOKI_PORT}/ready" >/dev/null 2>&1; then
+              echo "Loki write port-forward is ready."
               break
             fi
             if ! kill -0 "${PORT_FORWARD_PID}" >/dev/null 2>&1; then
@@ -211,7 +213,11 @@ tasks:
           trap cleanup EXIT
 
           END_TIME=$(( $(date +%s) + ${{ .inputs.poll_timeout }} ))
+          ATTEMPT=1
           while [ "$(date +%s)" -lt "${END_TIME}" ]; do
+            REMAINING_SECONDS=$(( END_TIME - $(date +%s) ))
+            echo "Attempt ${ATTEMPT}: checking for Loki chunks object written after ${LOKI_OBJECT_STORAGE_TEST_START} (${REMAINING_SECONDS}s remaining)..."
+
             RECENT_OBJECT_KEY="$(aws s3api list-objects-v2 \
               --bucket "${LOKI_CHUNKS_OBJECT_STORAGE_BUCKET}" \
               --query "Contents[?LastModified>=\`${LOKI_OBJECT_STORAGE_TEST_START}\`].Key | [0]" \
@@ -222,6 +228,8 @@ tasks:
               exit 0
             fi
 
+            echo "No recent Loki chunks object found yet; waiting ${{ .inputs.poll_interval }}s before retrying."
+            ATTEMPT=$(( ATTEMPT + 1 ))
             sleep "${{ .inputs.poll_interval }}"
           done
 

--- a/src/loki/tasks.yaml
+++ b/src/loki/tasks.yaml
@@ -53,6 +53,9 @@ tasks:
         default: "10"
     actions:
       - description: Validate object storage provider configuration
+        shell:
+          darwin: bash
+          linux: bash
         cmd: |
           set -euo pipefail
 
@@ -88,6 +91,9 @@ tasks:
           - name: LOKI_OBJECT_STORAGE_TEST_START
 
       - description: Push a test log and flush Loki chunks
+        shell:
+          darwin: bash
+          linux: bash
         cmd: |
           set -euo pipefail
 
@@ -107,7 +113,14 @@ tasks:
             echo "Loki push and flush diagnostics:"
             echo "Loki write pods:"
             uds zarf tools kubectl get pods -n loki -l app.kubernetes.io/component=write || true
-            echo "Port-forward output is available at ${PORT_FORWARD_LOG} during task execution."
+            echo "Port-forward output:"
+            if [ -s "${PORT_FORWARD_LOG}" ]; then
+              while IFS= read -r line; do
+                echo "  ${line}"
+              done < "${PORT_FORWARD_LOG}"
+            else
+              echo "  No port-forward output captured."
+            fi
           }
 
           fail() {
@@ -168,6 +181,9 @@ tasks:
           echo "Pushed test log and flushed Loki chunks."
 
       - description: Verify Loki chunks object write
+        shell:
+          darwin: bash
+          linux: bash
         cmd: |
           set -euo pipefail
 

--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -61,23 +61,23 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
-      - from: '{{- $secret := lookup "v1" "Secret" "loki" "loki" -}}
-          {{- $pastDate := now | dateModify "-48h" | date "2006-01-02" -}}
-          {{- $futureDate := now | dateModify "+48h" | date "2006-01-02" -}}
+      - from: "{{- $secret := lookup \"v1\" \"Secret\" \"loki\" \"loki\" -}}
+          {{- $pastDate := now | dateModify \"-48h\" | date \"2006-01-02\" -}}
+          {{- $futureDate := now | dateModify \"+48h\" | date \"2006-01-02\" -}}
           {{- $result := $pastDate -}}
           {{- if $secret -}}
-          {{- $result = $futureDate -}}
-          {{- if (index $secret.data "config.yaml") -}}
-          {{- $configYAML := (index $secret.data "config.yaml" | b64dec | fromYaml) -}}
-          {{- range $configYAML.schema_config.configs -}}
-          {{- if and (eq .store "tsdb") (eq .schema "v13") -}}
-          {{- $result = .from -}}
-          {{- break -}}
+            {{- $result = $futureDate -}}
+            {{- if (index $secret.data \"config.yaml\") -}}
+              {{- $configYAML := (index $secret.data \"config.yaml\" | b64dec | fromYaml) -}}
+              {{- range $configYAML.schema_config.configs -}}
+                {{- if and (eq .store \"tsdb\") (eq .schema \"v13\") -}}
+                  {{- $result = .from -}}
+                  {{- break -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
           {{- end -}}
-          {{- end -}}
-          {{- end -}}
-          {{- end -}}
-          {{- $result -}}'
+          {{- $result -}}"
         store: tsdb
         object_store: "{{ .Values.loki.storage.type }}"
         schema: v13
@@ -224,7 +224,7 @@ write:
   # Use shared loki SA instead of creating a write-specific one
   # https://github.com/grafana-community/helm-charts/issues/390
   serviceAccount:
-    create: true # temporarily set to true to test broken irsa config and validate CI test fails when it should.
+    create: false
 
 backend:
   # Remove default anti-affinity to support single node

--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -61,23 +61,23 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
-      - from: "{{- $secret := lookup \"v1\" \"Secret\" \"loki\" \"loki\" -}}
-          {{- $pastDate := now | dateModify \"-48h\" | date \"2006-01-02\" -}}
-          {{- $futureDate := now | dateModify \"+48h\" | date \"2006-01-02\" -}}
+      - from: '{{- $secret := lookup "v1" "Secret" "loki" "loki" -}}
+          {{- $pastDate := now | dateModify "-48h" | date "2006-01-02" -}}
+          {{- $futureDate := now | dateModify "+48h" | date "2006-01-02" -}}
           {{- $result := $pastDate -}}
           {{- if $secret -}}
-            {{- $result = $futureDate -}}
-            {{- if (index $secret.data \"config.yaml\") -}}
-              {{- $configYAML := (index $secret.data \"config.yaml\" | b64dec | fromYaml) -}}
-              {{- range $configYAML.schema_config.configs -}}
-                {{- if and (eq .store \"tsdb\") (eq .schema \"v13\") -}}
-                  {{- $result = .from -}}
-                  {{- break -}}
-                {{- end -}}
-              {{- end -}}
-            {{- end -}}
+          {{- $result = $futureDate -}}
+          {{- if (index $secret.data "config.yaml") -}}
+          {{- $configYAML := (index $secret.data "config.yaml" | b64dec | fromYaml) -}}
+          {{- range $configYAML.schema_config.configs -}}
+          {{- if and (eq .store "tsdb") (eq .schema "v13") -}}
+          {{- $result = .from -}}
+          {{- break -}}
           {{- end -}}
-          {{- $result -}}"
+          {{- end -}}
+          {{- end -}}
+          {{- end -}}
+          {{- $result -}}'
         store: tsdb
         object_store: "{{ .Values.loki.storage.type }}"
         schema: v13
@@ -224,7 +224,7 @@ write:
   # Use shared loki SA instead of creating a write-specific one
   # https://github.com/grafana-community/helm-charts/issues/390
   serviceAccount:
-    create: false
+    create: true # temporarily set to true to test broken irsa config and validate CI test fails when it should.
 
 backend:
   # Remove default anti-affinity to support single node

--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -61,23 +61,23 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
-      - from: '{{- $secret := lookup "v1" "Secret" "loki" "loki" -}}
-          {{- $pastDate := now | dateModify "-48h" | date "2006-01-02" -}}
-          {{- $futureDate := now | dateModify "+48h" | date "2006-01-02" -}}
+      - from: "{{- $secret := lookup \"v1\" \"Secret\" \"loki\" \"loki\" -}}
+          {{- $pastDate := now | dateModify \"-48h\" | date \"2006-01-02\" -}}
+          {{- $futureDate := now | dateModify \"+48h\" | date \"2006-01-02\" -}}
           {{- $result := $pastDate -}}
           {{- if $secret -}}
-          {{- $result = $futureDate -}}
-          {{- if (index $secret.data "config.yaml") -}}
-          {{- $configYAML := (index $secret.data "config.yaml" | b64dec | fromYaml) -}}
-          {{- range $configYAML.schema_config.configs -}}
-          {{- if and (eq .store "tsdb") (eq .schema "v13") -}}
-          {{- $result = .from -}}
-          {{- break -}}
+            {{- $result = $futureDate -}}
+            {{- if (index $secret.data \"config.yaml\") -}}
+              {{- $configYAML := (index $secret.data \"config.yaml\" | b64dec | fromYaml) -}}
+              {{- range $configYAML.schema_config.configs -}}
+                {{- if and (eq .store \"tsdb\") (eq .schema \"v13\") -}}
+                  {{- $result = .from -}}
+                  {{- break -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
           {{- end -}}
-          {{- end -}}
-          {{- end -}}
-          {{- end -}}
-          {{- $result -}}'
+          {{- $result -}}"
         store: tsdb
         object_store: "{{ .Values.loki.storage.type }}"
         schema: v13
@@ -224,7 +224,7 @@ write:
   # Use shared loki SA instead of creating a write-specific one
   # https://github.com/grafana-community/helm-charts/issues/390
   serviceAccount:
-    create: true
+    create: false
 
 backend:
   # Remove default anti-affinity to support single node

--- a/src/loki/values/values.yaml
+++ b/src/loki/values/values.yaml
@@ -61,23 +61,23 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
-      - from: "{{- $secret := lookup \"v1\" \"Secret\" \"loki\" \"loki\" -}}
-          {{- $pastDate := now | dateModify \"-48h\" | date \"2006-01-02\" -}}
-          {{- $futureDate := now | dateModify \"+48h\" | date \"2006-01-02\" -}}
+      - from: '{{- $secret := lookup "v1" "Secret" "loki" "loki" -}}
+          {{- $pastDate := now | dateModify "-48h" | date "2006-01-02" -}}
+          {{- $futureDate := now | dateModify "+48h" | date "2006-01-02" -}}
           {{- $result := $pastDate -}}
           {{- if $secret -}}
-            {{- $result = $futureDate -}}
-            {{- if (index $secret.data \"config.yaml\") -}}
-              {{- $configYAML := (index $secret.data \"config.yaml\" | b64dec | fromYaml) -}}
-              {{- range $configYAML.schema_config.configs -}}
-                {{- if and (eq .store \"tsdb\") (eq .schema \"v13\") -}}
-                  {{- $result = .from -}}
-                  {{- break -}}
-                {{- end -}}
-              {{- end -}}
-            {{- end -}}
+          {{- $result = $futureDate -}}
+          {{- if (index $secret.data "config.yaml") -}}
+          {{- $configYAML := (index $secret.data "config.yaml" | b64dec | fromYaml) -}}
+          {{- range $configYAML.schema_config.configs -}}
+          {{- if and (eq .store "tsdb") (eq .schema "v13") -}}
+          {{- $result = .from -}}
+          {{- break -}}
           {{- end -}}
-          {{- $result -}}"
+          {{- end -}}
+          {{- end -}}
+          {{- end -}}
+          {{- $result -}}'
         store: tsdb
         object_store: "{{ .Values.loki.storage.type }}"
         schema: v13
@@ -224,7 +224,7 @@ write:
   # Use shared loki SA instead of creating a write-specific one
   # https://github.com/grafana-community/helm-charts/issues/390
   serviceAccount:
-    create: false
+    create: true
 
 backend:
   # Remove default anti-affinity to support single node


### PR DESCRIPTION
## Description

Adds test to EKS workflow to verify that Loki can flush to S3.

## Related Issue

Relates to CORE-495

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Steps to Validate
- Happy Path - Successful workflow completion
- Sad Path - Break Loki write s3 permissions. Run workflow. Validate test fails as expected.
  - example failing run created by changing loki-write service account in commit [756131d](https://github.com/defenseunicorns/uds-core/pull/2673/commits/756131dc7d3583e405685f2aa1752e8328591e0a) - https://github.com/defenseunicorns/uds-core/actions/runs/26062032260/job/76624324060?pr=2673#step:16:102

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed