### PR TITLE
fix: set KC_CACHE=local for single-node postgres to prevent Infinispan deadlock

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -300,6 +300,10 @@ spec:
             - name: KC_CACHE_EMBEDDED_MTLS_ENABLED
               value: "false"
           {{- end }}
+          {{- if and (not .Values.autoscaling.enabled) (eq (include "keycloak.postgresql.config" .) "true") }}
+            - name: KC_CACHE
+              value: local
+          {{- end }}
           {{- if eq (include "keycloak.postgresql.config" .) "true" }}
             # Postgres database configuration
             - name: KC_DB

--- a/src/keycloak/chart/templates/uds-package.yaml
+++ b/src/keycloak/chart/templates/uds-package.yaml
@@ -105,8 +105,7 @@ spec:
           app: istiod
         port: 15012
 
-      {{- if .Values.autoscaling.enabled }}
-      # HA for keycloak
+      # JGroups ports for Keycloak clustering (required for multi-replica deployments)
       - direction: Ingress
         remoteGenerated: IntraNamespace
         ports:
@@ -117,7 +116,6 @@ spec:
         ports:
           - 7800
           - 57800
-      {{- end }}
 
       # Custom rules for additional networking access
       {{- with .Values.additionalNetworkAllow }}

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -341,8 +341,7 @@ prometheusRule:
 
 autoscaling:
   # If `true`, an autoscaling/v2beta2 HorizontalPodAutoscaler resource is created (requires Kubernetes 1.18 or above)
-  # Autoscaling seems to be most reliable when using KUBE_PING service discovery (see README for details)
-  # This disables the `replicas` field in the StatefulSet
+  # Autoscaling enables HA mode with distributed Infinispan caches (KC_CACHE=ispn) and JDBC_PING cluster discovery
   enabled: false
   # Additional HorizontalPodAutoscaler labels
   labels: {}


### PR DESCRIPTION
## Description

When `autoscaling.enabled: false` (the default) and postgres is configured, `KC_CACHE` was not set. Keycloak defaults to `ispn`, which starts Infinispan with JGroups and JDBC_PING cluster discovery. On a single-node deployment, `StateTransferManagerImpl.start()` blocks on a `CompletableFuture` that never resolves which results in the node waiting for cluster members that will never join.

The bug became deterministic in Keycloak 26.6.0 due to the Infinispan 15 → 16 upgrade ([#45380](https://github.com/keycloak/keycloak/pull/45380)), which introduced more complex state transfer coordination that consistently deadlocks on singleton clusters.

## Fix

Set `KC_CACHE=local` when postgres is configured and autoscaling is disabled. Local cache skips JGroups/Infinispan clustering entirely, which is correct for single-replica deployments where there are no cluster peers to coordinate with.

HA mode (`autoscaling.enabled: true`) is unchanged, it continues to use `KC_CACHE=ispn`.

## Steps to Validate

Testing:
setup the uds-ha-config.yaml to look like this:
```
# Copyright 2025 Defense Unicorns
# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial

variables:
  core-identity-authorization:
    keycloak_ha: false
    keycloak_pg_username: postgres
    keycloak_pg_password: unicorn123!@#UN
    keycloak_pg_database: keycloak
    keycloak_pg_host: host.k3d.internal
    keycloak_devmode: false
    insecure_admin_password_generation: true
    AUTHSERVICE_REPLICA_COUNT: 2

  # Authservice config is managed by the operator in the base layer
  # core-base:
  #   AUTHSERVICE_REDIS_URI: redis://authservice:authservice@host.k3d.internal:6379
```
and then create a docker container for postgres:
```
docker run -d \
  --name postgres \
  -e POSTGRES_USER=keycloak \
  -e POSTGRES_PASSWORD=keycloakpass1234 \
  -e POSTGRES_DB=keycloak \
  -p 5432:5432 \
  postgres:16
```

then build the k3d-slim-dev:
```
uds run create:k3d-slim-dev-bundle
```

and then deploy:
```
UDS_CONFIG=bundles/k3d-slim-dev/uds-external-db-config.yaml \
  uds deploy bundles/k3d-slim-dev/uds-bundle.yaml --confirm
```

The fix:
use my PR branch and do the same thing again.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
