### PR TITLE
fix: avoid virtual threads in Keycloak

### DIFF
--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -177,9 +177,12 @@ spec:
             - "--spi-connections-http-client-default-jitter-factor={{ .Values.httpRetry.jitterFactor }}"
             {{- end }}
             {{- end }}
+            {{- if .Values.disableVirtualThreads }}
             # Infinispan 16 introduced virtual threads, enabled by default. In constrained environments, such as Kubernetes with fewer than 4 vCPUs, it is highly recommended
             # to disable this feature to reduce the risk of deadlocks. See https://github.com/keycloak/keycloak/issues/48792 for more details.
+            # The switch if officially supported, see https://infinispan.org/blog/2025/11/10/infinispan-16-0
             - "-Dorg.infinispan.threads.virtual=false"
+            {{- end }}
           {{- with .Values.lifecycleHooks }}
           lifecycle:
           {{- toYaml . | nindent 12 }}

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -179,7 +179,7 @@ spec:
             {{- end }}
             # Infinispan 16 introduced virtual threads, enabled by default. In constrained environments, such as Kubernetes with fewer than 4 vCPUs, it is highly recommended
             # to disable this feature to reduce the risk of deadlocks. See https://github.com/keycloak/keycloak/issues/48792 for more details.
-            - Dorg.infinispan.threads.virtual=false
+            - "-Dorg.infinispan.threads.virtual=false"
           {{- with .Values.lifecycleHooks }}
           lifecycle:
           {{- toYaml . | nindent 12 }}

--- a/src/keycloak/chart/templates/statefulset.yaml
+++ b/src/keycloak/chart/templates/statefulset.yaml
@@ -177,6 +177,9 @@ spec:
             - "--spi-connections-http-client-default-jitter-factor={{ .Values.httpRetry.jitterFactor }}"
             {{- end }}
             {{- end }}
+            # Infinispan 16 introduced virtual threads, enabled by default. In constrained environments, such as Kubernetes with fewer than 4 vCPUs, it is highly recommended
+            # to disable this feature to reduce the risk of deadlocks. See https://github.com/keycloak/keycloak/issues/48792 for more details.
+            - Dorg.infinispan.threads.virtual=false
           {{- with .Values.lifecycleHooks }}
           lifecycle:
           {{- toYaml . | nindent 12 }}

--- a/src/keycloak/chart/tests/kc_infinispan_virtual_threads_test.yaml
+++ b/src/keycloak/chart/tests/kc_infinispan_virtual_threads_test.yaml
@@ -1,0 +1,16 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: Keycloak - Infinispan Virtual Threads
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: should render Infinispan virtual-threads disabled flag
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-Dorg.infinispan.threads.virtual=false"

--- a/src/keycloak/chart/tests/kc_infinispan_virtual_threads_test.yaml
+++ b/src/keycloak/chart/tests/kc_infinispan_virtual_threads_test.yaml
@@ -8,9 +8,27 @@ templates:
   - statefulset.yaml
 
 tests:
-  - it: should render Infinispan virtual-threads disabled flag
+  - it: should render Infinispan virtual-threads disabled flag by default
     template: statefulset.yaml
     asserts:
       - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-Dorg.infinispan.threads.virtual=false"
+
+  - it: should render Infinispan virtual-threads disabled flag when disableVirtualThreads is true
+    set:
+      disableVirtualThreads: true
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "-Dorg.infinispan.threads.virtual=false"
+
+  - it: should not render Infinispan virtual-threads disabled flag when disableVirtualThreads is false
+    set:
+      disableVirtualThreads: false
+    template: statefulset.yaml
+    asserts:
+      - notContains:
           path: spec.template.spec.containers[0].args
           content: "-Dorg.infinispan.threads.virtual=false"

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -206,6 +206,9 @@
     "devMode": {
       "type": "boolean"
     },
+    "disableVirtualThreads": {
+      "type": "boolean"
+    },
     "domain": {
       "type": "string"
     },

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -159,6 +159,11 @@ debugMode: false
 # Enable JSON logging format for Keycloak
 jsonLogFormat: true
 
+# Disable Infinispan virtual threads. Infinispan 16 introduced virtual threads, enabled by default. In constrained
+# environments, such as Kubernetes with fewer than 4 vCPUs, it is highly recommended to disable this feature to reduce
+# the risk of deadlocks. See https://github.com/keycloak/keycloak/issues/48792 for more details.
+disableVirtualThreads: true
+
 # Enable SMTP networkPolicy and config
 smtp:
   enabled: false


### PR DESCRIPTION
## Description

This Pull Request uses an alternative approach to https://github.com/defenseunicorns/uds-core/pull/2682

Instead of conditionally disabling clustering, it disables the Virtual Threads. 

See these links for more details:

- https://github.com/keycloak/keycloak/issues/48792
- https://github.com/keycloak/keycloak/issues/49203


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Run a single replica Keycloak, with PostreSQL and without HA. 

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
