### PR TITLE
fix: broken grafana tests

### DIFF
--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -70,7 +70,7 @@ test("validate namespace dashboard", async ({ page }) => {
     await gotoGrafana(page, `/dashboards`);
     await page.click('text="Kubernetes / Compute Resources / Namespace (Pods)"');
     // Grafana 13+ does not eagerly load dropdown options even when a variable has a
-    // pre-selected value. Re-navigate with the namespace set in the URL to bypass this.
+    // preselected value. Re-navigate with the namespace set in the URL to bypass this.
     await page.waitForURL(/\/d\//);
     const url = new URL(page.url());
     url.searchParams.set("var-namespace", fullCore ? "authservice-sidecar-test-app" : "grafana");

--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -69,17 +69,13 @@ test("validate namespace dashboard", async ({ page }) => {
   await test.step("check dashboard", async () => {
     await gotoGrafana(page, `/dashboards`);
     await page.click('text="Kubernetes / Compute Resources / Namespace (Pods)"');
-    await page
-      .getByTestId(
-        "data-testid Dashboard template variables Variable Value DropDown value link text authservice",
-      )
-      .click();
-    if (!fullCore) {
-      // Check grafana if not a full core deploy
-      await page.getByRole("option", { name: "grafana" }).click();
-      return;
-    }
-    await page.getByRole("option", { name: "authservice-sidecar-test-app" }).click();
+    // Grafana 13+ does not eagerly load dropdown options even when a variable has a
+    // pre-selected value. Re-navigate with the namespace set in the URL to bypass this.
+    await page.waitForURL(/\/d\//);
+    const url = new URL(page.url());
+    url.searchParams.set("var-namespace", fullCore ? "authservice-sidecar-test-app" : "grafana");
+    await page.goto(url.toString());
+    await closeGrafanaModals(page);
   });
 });
 
@@ -90,16 +86,14 @@ test("validate loki dashboard", async ({ page }) => {
     await gotoGrafana(page, `/dashboards`);
     await page.getByPlaceholder("Search for dashboards and folders").fill("Loki");
     await page.click('text="Loki Dashboard quick search"');
-    // Grafana 13+ lazy-loads variables with no saved current value, so the namespace
-    // dropdown may start empty rather than preselected to "authservice". Use a partial
-    // selector that matches regardless of the current displayed value.
-    await page
-      .locator(
-        '[data-testid^="data-testid Dashboard template variables Variable Value DropDown value link text"]',
-      )
-      .first()
-      .click();
-    await page.getByRole("option", { name: "authservice-sidecar-test-app" }).click();
+    // Grafana 13+ lazy-loads variables with no saved current value — clicking the empty
+    // dropdown does not reliably trigger the Prometheus query to populate options.
+    // Re-navigate with the namespace set in the URL to bypass lazy loading entirely.
+    await page.waitForURL(/\/d\//);
+    const url = new URL(page.url());
+    url.searchParams.set("var-namespace", "authservice-sidecar-test-app");
+    await page.goto(url.toString());
+    await closeGrafanaModals(page);
     await expect(
       page
         .getByTestId("data-testid Panel header Logs Panel")

--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -90,17 +90,16 @@ test("validate loki dashboard", async ({ page }) => {
     await gotoGrafana(page, `/dashboards`);
     await page.getByPlaceholder("Search for dashboards and folders").fill("Loki");
     await page.click('text="Loki Dashboard quick search"');
+    // Grafana 13+ lazy-loads variables with no saved current value, so the namespace
+    // dropdown may start empty rather than preselected to "authservice". Use a partial
+    // selector that matches regardless of the current displayed value.
     await page
-      .getByTestId(
-        "data-testid Dashboard template variables Variable Value DropDown value link text authservice",
+      .locator(
+        '[data-testid^="data-testid Dashboard template variables Variable Value DropDown value link text"]',
       )
+      .first()
       .click();
-    if (!fullCore) {
-      // Check grafana if not a full core deploy
-      await page.getByRole("option", { name: "grafana" }).click();
-    } else {
-      await page.getByRole("option", { name: "authservice-sidecar-test-app" }).click();
-    }
+    await page.getByRole("option", { name: "authservice-sidecar-test-app" }).click();
     await expect(
       page
         .getByTestId("data-testid Panel header Logs Panel")

--- a/test/playwright/grafana.test.ts
+++ b/test/playwright/grafana.test.ts
@@ -76,6 +76,7 @@ test("validate namespace dashboard", async ({ page }) => {
     url.searchParams.set("var-namespace", fullCore ? "authservice-sidecar-test-app" : "grafana");
     await page.goto(url.toString());
     await closeGrafanaModals(page);
+    await expect(page.locator('[data-testid="data-testid dashboard controls"]')).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Description

- Fixes nightly EKS and HA k3d CI failures introduced by the Grafana 12 → 13 upgrade (#2584)
- `validate namespace dashboard` and `validate loki dashboard` both timed out waiting for template variable dropdown options to populate
- Grafana 13 lazy-loads variable values, which means clicking a dropdown no longer reliably triggers the Prometheus query to populate options, so tests waiting on `authservice-sidecar-test-app` to appear would time out
- Fix: after navigating to each dashboard, re-navigate with `var-namespace` set directly in the URL; Grafana resolves explicit URL params synchronously with no query required



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)



## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
