### PR TITLE
Security: YAML Parsing Without Schema Validation in Istio ConfigMap Sync

### DIFF
--- a/src/pepr/operator/controllers/istio/istio-configmap-sync.ts
+++ b/src/pepr/operator/controllers/istio/istio-configmap-sync.ts
@@ -33,7 +33,7 @@ export async function restartGatewayPods(istioConfig: kind.ConfigMap): Promise<v
   const mesh = istioConfig?.data?.["mesh"];
 
   if (mesh) {
-    const meshConfig = yaml.load(mesh) as IstioConfiguration;
+    const meshConfig = yaml.load(mesh, { schema: yaml.SAFE_SCHEMA }) as IstioConfiguration;
     const newProxyProtocol = JSON.stringify(
       meshConfig.defaultConfig?.gatewayTopology?.proxyProtocol,
     );


### PR DESCRIPTION
## Summary

Security: YAML Parsing Without Schema Validation in Istio ConfigMap Sync

## Problem

**Severity**: `Medium` | **File**: `src/pepr/operator/controllers/istio/istio-configmap-sync.ts:L45`

The `restartGatewayPods` function in `src/pepr/operator/controllers/istio/istio-configmap-sync.ts` parses YAML from a ConfigMap using `yaml.load()` without specifying a schema or safe loading options. While the input comes from a ConfigMap within the cluster, this could potentially be exploited if an attacker gains access to modify the ConfigMap, allowing arbitrary object construction through YAML tags.

## Solution

Use `yaml.load()` with the `schema: yaml.SAFE_SCHEMA` option or use `yaml.safeLoad()` to prevent potential arbitrary object construction. Validate the parsed object structure against a strict schema before use.

## Changes

- `src/pepr/operator/controllers/istio/istio-configmap-sync.ts` (modified)