### PR TITLE
ci: excluding portal package from registry1 flavor CI tests

### DIFF
--- a/.github/workflows/test-aks.yaml
+++ b/.github/workflows/test-aks.yaml
@@ -125,7 +125,7 @@ jobs:
         # webhook disruptions during test-app deploy, playwright, or vitest phases.
         run: |
           for attempt in 1 2 3; do
-            if uds run -f tasks/test.yaml uds-core-non-k3d --set EXCLUDED_PACKAGES="${{ matrix.flavor == 'registry1' && 'metrics-server portal' || 'metrics-server' }}"; then
+            if uds run -f tasks/test.yaml uds-core-non-k3d --set FLAVOR=${{ matrix.flavor }} --set EXCLUDED_PACKAGES="${{ matrix.flavor == 'registry1' && 'metrics-server,portal' || 'metrics-server' }}"; then
               echo "TEST_ATTEMPTS=$attempt" >> $GITHUB_ENV
               exit 0
             fi

--- a/.github/workflows/test-aks.yaml
+++ b/.github/workflows/test-aks.yaml
@@ -125,7 +125,7 @@ jobs:
         # webhook disruptions during test-app deploy, playwright, or vitest phases.
         run: |
           for attempt in 1 2 3; do
-            if uds run -f tasks/test.yaml uds-core-non-k3d --set EXCLUDED_PACKAGES="metrics-server"; then
+            if uds run -f tasks/test.yaml uds-core-non-k3d --set EXCLUDED_PACKAGES="${{ matrix.flavor == 'registry1' && 'metrics-server portal' || 'metrics-server' }}"; then
               echo "TEST_ATTEMPTS=$attempt" >> $GITHUB_ENV
               exit 0
             fi

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -102,7 +102,7 @@ jobs:
         timeout-minutes: 40
 
       - name: Test UDS Core
-        run: uds run -f tasks/test.yaml uds-core-non-k3d --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }}
+        run: uds run -f tasks/test.yaml uds-core-non-k3d --set FLAVOR=${{ matrix.flavor }} --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }}
 
       - name: Validate Loki chunks S3 writes
         run: uds run -f src/loki/tasks.yaml validate-object-storage-writes --no-progress --with provider=aws --with iac_dir=.github/test-infra/aws/eks

--- a/.github/workflows/test-eks.yaml
+++ b/.github/workflows/test-eks.yaml
@@ -102,7 +102,7 @@ jobs:
         timeout-minutes: 40
 
       - name: Test UDS Core
-        run: uds run -f tasks/test.yaml uds-core-non-k3d
+        run: uds run -f tasks/test.yaml uds-core-non-k3d --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }}
 
       - name: Validate Loki chunks S3 writes
         run: uds run -f src/loki/tasks.yaml validate-object-storage-writes --no-progress --with provider=aws --with iac_dir=.github/test-infra/aws/eks

--- a/.github/workflows/test-k3d-ha.yaml
+++ b/.github/workflows/test-k3d-ha.yaml
@@ -57,11 +57,11 @@ jobs:
 
       - name: Run UDS Core Install HA Test
         if: ${{ matrix.test-type == 'install' }}
-        run: uds run test-uds-core-ha --set FLAVOR=${{ matrix.flavor }} --no-progress
+        run: uds run test-uds-core-ha --set FLAVOR=${{ matrix.flavor }} --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }} --no-progress
 
       - name: Run UDS Core Upgrade HA Test
         if: ${{ matrix.test-type == 'upgrade' }}
-        run: uds run test-uds-core-ha-upgrade --set FLAVOR=${{ matrix.flavor }} --no-progress
+        run: uds run test-uds-core-ha-upgrade --set FLAVOR=${{ matrix.flavor }} --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }} --no-progress
 
       - name: Debug Output
         if: ${{ always() }}

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -104,7 +104,7 @@ jobs:
         timeout-minutes: 40
 
       - name: Test UDS Core
-        run: uds run -f tasks/test.yaml uds-core-non-k3d --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }}
+        run: uds run -f tasks/test.yaml uds-core-non-k3d --set FLAVOR=${{ matrix.flavor }} --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }}
 
       - name: Debug Output
         if: ${{ always() }}

--- a/.github/workflows/test-rke2.yaml
+++ b/.github/workflows/test-rke2.yaml
@@ -104,7 +104,7 @@ jobs:
         timeout-minutes: 40
 
       - name: Test UDS Core
-        run: uds run -f tasks/test.yaml uds-core-non-k3d
+        run: uds run -f tasks/test.yaml uds-core-non-k3d --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }}
 
       - name: Debug Output
         if: ${{ always() }}

--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -105,7 +105,7 @@ tasks:
       - description: Adds Cluster LoadBalancer IP Addresses to match appropriate hosts names in /etc/hosts
         mute: true
         cmd: |
-          echo "$ADMIN_GW_IP keycloak.admin.uds.dev grafana.admin.uds.dev demo.admin.uds.dev\n$TENANT_GW_IP sso.uds.dev demo-8080.uds.dev demo-8081.uds.dev protected.uds.dev ambient-protected.uds.dev ambient2-protected.uds.dev podinfo.uds.dev" | sudo tee -a /etc/hosts
+          echo "$ADMIN_GW_IP keycloak.admin.uds.dev grafana.admin.uds.dev demo.admin.uds.dev\n$TENANT_GW_IP sso.uds.dev demo-8080.uds.dev demo-8081.uds.dev protected.uds.dev ambient-protected.uds.dev ambient2-protected.uds.dev podinfo.uds.dev portal.uds.dev" | sudo tee -a /etc/hosts
 
   - name: rename-flavored-packages
     description: "Rename flavored package files by removing the flavor suffix"


### PR DESCRIPTION
## Description

Other CI adjustments to exclude portal package from registry1 flavor tests

## Related Issue

Related to CORE-536

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Will need to validate IaC tests following weekend

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
