### PR TITLE
fix: exclude portal from registry1 private pki tests

### DIFF
--- a/.github/workflows/private-pki-test.yaml
+++ b/.github/workflows/private-pki-test.yaml
@@ -56,7 +56,7 @@ jobs:
           installK3d: 'true'
 
       - name: Run UDS Core Private PKI Test
-        run: uds run -f tasks/test.yaml uds-core-private-pki --set FLAVOR=${{ matrix.flavor }} --no-progress
+        run: uds run -f tasks/test.yaml uds-core-private-pki --set FLAVOR=${{ matrix.flavor }} --set EXCLUDED_PACKAGES=${{ matrix.flavor == 'registry1' && 'portal' || '' }} --no-progress
 
       - name: Debug Output
         if: ${{ always() }}


### PR DESCRIPTION
## Description
Excludes the `portal` package from Private PKI CI when running the `registry1` flavor.
This applies the same registry1 workaround used by the other CI jobs in #2703, where `portal` is skipped because it is not supported for registry1 validation.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
