### PR TITLE
feat: allow a list of principals to access keycloak admin API

### DIFF
--- a/src/keycloak/chart/templates/istio-authpol-admin.yaml
+++ b/src/keycloak/chart/templates/istio-authpol-admin.yaml
@@ -26,6 +26,12 @@ spec:
             notNamespaces:
               - istio-admin-gateway
               - "pepr-system"
+            {{- with .Values.adminApiAllowedPrincipals }}
+            notPrincipals:
+              {{- range . }}
+              - {{ . }}
+              {{- end }}
+            {{- end }}
     - to:
         - operation:
             ports:
@@ -54,6 +60,12 @@ spec:
             notNamespaces:
               - pepr-system
               - istio-admin-gateway
+            {{- with .Values.adminApiAllowedPrincipals }}
+            notPrincipals:
+              {{- range . }}
+              - {{ . }}
+              {{- end }}
+            {{- end }}
     - when:
         - key: request.headers[istio-mtls-client-certificate]
           values: ["*"]

--- a/src/keycloak/chart/templates/istio-authpol-admin.yaml
+++ b/src/keycloak/chart/templates/istio-authpol-admin.yaml
@@ -29,7 +29,7 @@ spec:
             {{- with .Values.adminApiAllowedPrincipals }}
             notPrincipals:
               {{- range . }}
-              - {{ . }}
+              - {{ . | quote }}
               {{- end }}
             {{- end }}
     - to:
@@ -63,7 +63,7 @@ spec:
             {{- with .Values.adminApiAllowedPrincipals }}
             notPrincipals:
               {{- range . }}
-              - {{ . }}
+              - {{ . | quote }}
               {{- end }}
             {{- end }}
     - when:

--- a/src/keycloak/chart/tests/kc_admin_api_allowed_principals_test.yaml
+++ b/src/keycloak/chart/tests/kc_admin_api_allowed_principals_test.yaml
@@ -1,0 +1,112 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+# Rules are selected by their operation paths rather than array index so the
+# assertions stay correct if the AuthorizationPolicy rules are reordered.
+suite: Keycloak - Admin API Allowed Principals
+templates:
+  - istio-authpol-admin.yaml
+capabilities:
+  apiVersions:
+    - security.istio.io/v1
+
+tests:
+  - it: should not render notPrincipals by default, leaving notNamespaces intact
+    asserts:
+      - notExists:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin*")].from[0].source.notPrincipals'
+      - notExists:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin/realms/uds/clients")].from[0].source.notPrincipals'
+      # baseline behavior must be unchanged when the feature is off
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin*")].from[0].source.notNamespaces'
+          value:
+            - istio-admin-gateway
+            - pepr-system
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin/realms/uds/clients")].from[0].source.notNamespaces'
+          value:
+            - pepr-system
+            - istio-admin-gateway
+
+  - it: should render notPrincipals on the admin and clients rules when principals are set
+    set:
+      adminApiAllowedPrincipals:
+        - cluster.local/ns/argo/sa/workflow-service-account
+    asserts:
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin*")].from[0].source.notPrincipals'
+          value:
+            - cluster.local/ns/argo/sa/workflow-service-account
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin/realms/uds/clients")].from[0].source.notPrincipals'
+          value:
+            - cluster.local/ns/argo/sa/workflow-service-account
+
+  - it: should render all configured principals in order
+    set:
+      adminApiAllowedPrincipals:
+        - cluster.local/ns/argo/sa/workflow-service-account
+        - cluster.local/ns/ci-tooling/sa/realm-sync
+    asserts:
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin*")].from[0].source.notPrincipals'
+          value:
+            - cluster.local/ns/argo/sa/workflow-service-account
+            - cluster.local/ns/ci-tooling/sa/realm-sync
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin/realms/uds/clients")].from[0].source.notPrincipals'
+          value:
+            - cluster.local/ns/argo/sa/workflow-service-account
+            - cluster.local/ns/ci-tooling/sa/realm-sync
+
+  - it: should render notPrincipals on the clients rule for a non-default realm
+    set:
+      realm: myrealm
+      adminApiAllowedPrincipals:
+        - cluster.local/ns/argo/sa/workflow-service-account
+    asserts:
+      # the clients rule path is realm-dependent, so it tracks the configured realm
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin/realms/myrealm/clients")].from[0].source.notPrincipals'
+          value:
+            - cluster.local/ns/argo/sa/workflow-service-account
+      # the realm-independent /admin* rule is unaffected by the realm value
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin*")].from[0].source.notPrincipals'
+          value:
+            - cluster.local/ns/argo/sa/workflow-service-account
+
+  - it: should not leak notPrincipals onto non-admin rules
+    set:
+      adminApiAllowedPrincipals:
+        - cluster.local/ns/argo/sa/workflow-service-account
+    asserts:
+      # metrics endpoint (port 9000) must stay scoped to the monitoring namespace
+      - notExists:
+          path: 'spec.rules[?(@.to[0].operation.ports[0]=="9000")].from[0].source.notPrincipals'
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.ports[0]=="9000")].from[0].source.notNamespaces'
+          value:
+            - monitoring
+      # mTLS client-cert catch-all rule must not exempt configured principals
+      - notExists:
+          path: 'spec.rules[?(@.when)].from[0].source.notPrincipals'
+
+  - it: should preserve notNamespaces alongside notPrincipals
+    set:
+      adminApiAllowedPrincipals:
+        - cluster.local/ns/argo/sa/workflow-service-account
+    asserts:
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin*")].from[0].source.notNamespaces'
+          value:
+            - istio-admin-gateway
+            - pepr-system
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin/realms/uds/clients")].from[0].source.notNamespaces'
+          value:
+            - pepr-system
+            - istio-admin-gateway

--- a/src/keycloak/chart/tests/kc_admin_api_allowed_principals_test.yaml
+++ b/src/keycloak/chart/tests/kc_admin_api_allowed_principals_test.yaml
@@ -79,6 +79,24 @@ tests:
           value:
             - cluster.local/ns/argo/sa/workflow-service-account
 
+  - it: should quote principals so wildcard values render as valid YAML
+    set:
+      adminApiAllowedPrincipals:
+        # leading '*' would parse as a YAML alias if rendered unquoted
+        - "*/ns/argo/sa/workflow-service-account"
+        - cluster.local/ns/argo/sa/*
+    asserts:
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin*")].from[0].source.notPrincipals'
+          value:
+            - "*/ns/argo/sa/workflow-service-account"
+            - cluster.local/ns/argo/sa/*
+      - equal:
+          path: 'spec.rules[?(@.to[0].operation.paths[0]=="/admin/realms/uds/clients")].from[0].source.notPrincipals'
+          value:
+            - "*/ns/argo/sa/workflow-service-account"
+            - cluster.local/ns/argo/sa/*
+
   - it: should not leak notPrincipals onto non-admin rules
     set:
       adminApiAllowedPrincipals:

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -7,7 +7,10 @@
       "type": "object",
       "properties": {
         "cpu": {
-          "type": ["number", "string"]
+          "type": [
+            "number",
+            "string"
+          ]
         },
         "memory": {
           "type": "string"
@@ -533,7 +536,10 @@
             "type": "string"
           }
         },
-        "required": ["name", "value"]
+        "required": [
+          "name",
+          "value"
+        ]
       }
     },
     "extraVolumes": {
@@ -575,7 +581,12 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "enum": ["background.png", "footer.png", "logo.png", "favicon.png"]
+                    "enum": [
+                      "background.png",
+                      "footer.png",
+                      "logo.png",
+                      "favicon.png"
+                    ]
                   },
                   "configmap": {
                     "type": "object",
@@ -609,20 +620,31 @@
                       "type": "string"
                     }
                   },
-                  "required": ["key", "name"]
+                  "required": [
+                    "key",
+                    "name"
+                  ]
                 }
               },
               "oneOf": [
                 {
-                  "required": ["inline"],
+                  "required": [
+                    "inline"
+                  ],
                   "not": {
-                    "required": ["configmap"]
+                    "required": [
+                      "configmap"
+                    ]
                   }
                 },
                 {
-                  "required": ["configmap"],
+                  "required": [
+                    "configmap"
+                  ],
                   "not": {
-                    "required": ["inline"]
+                    "required": [
+                      "inline"
+                    ]
                   }
                 }
               ]
@@ -653,12 +675,17 @@
             },
             "tlsCertificateFormat": {
               "type": "string",
-              "enum": ["PEM", "AWS"]
+              "enum": [
+                "PEM",
+                "AWS"
+              ]
             }
           }
         }
       },
-      "required": ["tls"]
+      "required": [
+        "tls"
+      ]
     },
     "detailedObservability": {
       "type": "object",

--- a/src/keycloak/chart/values.schema.json
+++ b/src/keycloak/chart/values.schema.json
@@ -7,10 +7,7 @@
       "type": "object",
       "properties": {
         "cpu": {
-          "type": [
-            "number",
-            "string"
-          ]
+          "type": ["number", "string"]
         },
         "memory": {
           "type": "string"
@@ -134,6 +131,12 @@
       "type": "string"
     },
     "additionalGatewayNamespaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "adminApiAllowedPrincipals": {
       "type": "array",
       "items": {
         "type": "string"
@@ -530,10 +533,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "name",
-          "value"
-        ]
+        "required": ["name", "value"]
       }
     },
     "extraVolumes": {
@@ -575,12 +575,7 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "enum": [
-                      "background.png",
-                      "footer.png",
-                      "logo.png",
-                      "favicon.png"
-                    ]
+                    "enum": ["background.png", "footer.png", "logo.png", "favicon.png"]
                   },
                   "configmap": {
                     "type": "object",
@@ -614,31 +609,20 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "key",
-                    "name"
-                  ]
+                  "required": ["key", "name"]
                 }
               },
               "oneOf": [
                 {
-                  "required": [
-                    "inline"
-                  ],
+                  "required": ["inline"],
                   "not": {
-                    "required": [
-                      "configmap"
-                    ]
+                    "required": ["configmap"]
                   }
                 },
                 {
-                  "required": [
-                    "configmap"
-                  ],
+                  "required": ["configmap"],
                   "not": {
-                    "required": [
-                      "inline"
-                    ]
+                    "required": ["inline"]
                   }
                 }
               ]
@@ -669,17 +653,12 @@
             },
             "tlsCertificateFormat": {
               "type": "string",
-              "enum": [
-                "PEM",
-                "AWS"
-              ]
+              "enum": ["PEM", "AWS"]
             }
           }
         }
       },
-      "required": [
-        "tls"
-      ]
+      "required": ["tls"]
     },
     "detailedObservability": {
       "type": "object",

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -23,6 +23,12 @@ additionalGatewayNamespaces: []
 # Example
 # - "istio-login-gateway"
 
+# Istio source principals (mTLS SPIFFE identities) allowed to reach the Keycloak Admin API,
+# in addition to the istio-admin-gateway and pepr-system namespaces. Entries are used verbatim.
+adminApiAllowedPrincipals: []
+# Example
+# - "cluster.local/ns/argo/sa/workflow-service-account"
+
 # Enables an EnvoyFilter to block path-parameter bypasses of AuthorizationPolicy rules
 # Should only be disabled if this is incorrectly blocking paths you expect to be allowed
 pathParameterProtection: true

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -23,8 +23,7 @@ additionalGatewayNamespaces: []
 # Example
 # - "istio-login-gateway"
 
-# Istio source principals (mTLS SPIFFE identities) allowed to reach the Keycloak Admin API,
-# in addition to the istio-admin-gateway and pepr-system namespaces. Entries are used verbatim.
+# Istio source principals (mTLS SPIFFE identities) allowed to reach the Keycloak Admin API
 adminApiAllowedPrincipals: []
 # Example
 # - "cluster.local/ns/argo/sa/workflow-service-account"


### PR DESCRIPTION
## Description

Adds a new adminApiAllowedPrincipals value to the Keycloak chart that lets operators allowlist specific Istio source principals (mTLS SPIFFE identities) to reach the Keycloak Admin API.

By default, the keycloak-block-admin-access-from-public-gateway AuthorizationPolicy denies Admin API access (/admin*, /realms/master*, and the clients endpoint) to all sources outside the admin gateway and pepr-system. This change renders a notPrincipals exclusion on those DENY rules for each configured principal, so trusted in-cluster workloads (e.g. an automation/CI service account) can be granted Admin API access without routing through the admin gateway.

Key points:
- New value adminApiAllowedPrincipals (array of strings), defaulting to [] — no behavioral change when unset.
- Exclusion is scoped only to the two Admin API DENY rules; the metrics (:9000) and mTLS catch-all rules are unaffected.
- Principal values are rendered with | quote so wildcard SPIFFE identities (e.g. */ns/argo/sa/foo) don't misparse as YAML aliases.
- values.schema.json updated to validate the new value.

## Related Issue

Fixes CORE-591

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
1. Set the value, e.g.:
```
adminApiAllowedPrincipals:
  - "cluster.local/ns/argo/sa/workflow-service-account"
```
2. Deploy Keycloak and confirm the keycloak-block-admin-access-from-public-gateway AuthorizationPolicy renders notPrincipals on the /admin* and /admin/realms/<realm>/clients rules.
3. From a workload running as the configured principal, confirm the Admin API is reachable; confirm a workload with a different identity is still denied.
4. Run the chart unit tests: `uds run lint:helm-unittest` (or helm unittest src/keycloak/chart).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
