### PR TITLE
docs: portal how-to configuration and flavor page updates

### DIFF
--- a/docs/concepts/platform/flavors.mdx
+++ b/docs/concepts/platform/flavors.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3.005
 ---
 
-import { Card, LinkCard } from '@astrojs/starlight/components';
+import { Card } from '@astrojs/starlight/components';
 
 UDS Core is published in multiple **flavors**. A flavor determines the container image source registry and hardening posture for every component in the platform. All flavors expose the same configuration surface and the same components, with the exception of the Portal layer.
 

--- a/docs/concepts/platform/flavors.mdx
+++ b/docs/concepts/platform/flavors.mdx
@@ -23,7 +23,7 @@ UDS Core is published in multiple **flavors**. A flavor determines the container
 <Card title="Unicorn flavor" icon="star">
 The `unicorn` flavor is the Defense Unicorns supported option for production. Its images are FIPS-validated and undergo additional patching and curation, giving it a near-zero CVE posture.
 
-**Compare CVE counts:** You can view current CVE counts for the `upstream` and `registry1` flavors on the [UDS Registry Core Package](https://registry.defenseunicorns.com/repo/public/core/versions). The `unicorn` flavor undergoes additional patching and curation by Defense Unicorns, resulting in significantly fewer CVEs.
+**Compare CVE counts:** You can view current CVE counts for the `upstream` and `registry1` flavors on the [UDS Registry Core Package](https://registry.defenseunicorns.com/repo/airgap-store/core/versions). The `unicorn` flavor undergoes additional patching and curation by Defense Unicorns, resulting in significantly fewer CVEs.
 
 The `unicorn` flavor is only available in a private organization on the [UDS Registry](https://registry.defenseunicorns.com). It requires a Defense Unicorns support agreement. [Contact Defense Unicorns](https://www.defenseunicorns.com/contact) for access.
 </Card>

--- a/docs/concepts/platform/flavors.mdx
+++ b/docs/concepts/platform/flavors.mdx
@@ -5,24 +5,28 @@ sidebar:
   order: 3.005
 ---
 
-UDS Core is published in multiple **flavors**. A flavor determines the container image source registry and hardening posture for every component in the platform. All flavors contain the same components and expose the same configuration surface; only the images differ.
+import { Card, LinkCard } from '@astrojs/starlight/components';
+
+UDS Core is published in multiple **flavors**. A flavor determines the container image source registry and hardening posture for every component in the platform. All flavors expose the same configuration surface and the same components, with the exception of the Portal layer.
 
 ## Available flavors
 
 | Flavor | Image Source | Hardening | Availability | Typical Use |
 |--------|-------------|-----------|-------------|-------------|
-| **`upstream`** | Default chart sources (Docker Hub, GHCR, Quay) | Community-maintained | Public | Local development, CI, demos |
-| **`registry1`** | [Iron Bank](https://p1.dso.mil/services/iron-bank) (DoD hardened images) | STIG-hardened, CVE-scanned | Public | Production deployments requiring DoD compliance |
 | **`unicorn`** | Defense Unicorns curated registry | FIPS-validated, near-zero CVE posture | Private | Production deployments with Defense Unicorns support agreement |
+| **`registry1`** | [Iron Bank](https://p1.dso.mil/services/iron-bank) (DoD hardened images) | STIG-hardened, CVE-scanned | Public | Production deployments requiring DoD compliance |
+| **`upstream`** | Default chart sources (Docker Hub, GHCR, Quay) | Community-maintained | Public | Local development, CI, demos |
 
-> [!NOTE]
-> The `unicorn` flavor is only available in a private organization on the [UDS Registry](https://registry.defenseunicorns.com). It requires a Defense Unicorns support agreement. [Contact Defense Unicorns](https://www.defenseunicorns.com/contact) for access.
+> [!WARNING]
+> Do not use the `upstream` flavor in production. Its community-maintained images may not meet the hardening or CVE-scanning requirements of regulated environments.
 
-> [!CAUTION]
-> The `upstream` flavor is not recommended for production. Upstream images are community-maintained and may not meet the hardening or CVE-scanning requirements of regulated environments.
+<Card title="Unicorn flavor" icon="star">
+The `unicorn` flavor is the Defense Unicorns supported option for production. Its images are FIPS-validated and undergo additional patching and curation, giving it a near-zero CVE posture.
 
-> [!TIP]
-> **Compare CVE counts:** You can view current CVE counts for the `upstream` and `registry1` flavors on the [UDS Registry Core Package](https://registry.defenseunicorns.com/repo/public/core/versions). The `unicorn` flavor undergoes additional patching and curation by Defense Unicorns, resulting in significantly fewer CVEs. [Contact Defense Unicorns](https://www.defenseunicorns.com/contact) to learn more.
+**Compare CVE counts:** You can view current CVE counts for the `upstream` and `registry1` flavors on the [UDS Registry Core Package](https://registry.defenseunicorns.com/repo/public/core/versions). The `unicorn` flavor undergoes additional patching and curation by Defense Unicorns, resulting in significantly fewer CVEs.
+
+The `unicorn` flavor is only available in a private organization on the [UDS Registry](https://registry.defenseunicorns.com). It requires a Defense Unicorns support agreement. [Contact Defense Unicorns](https://www.defenseunicorns.com/contact) for access.
+</Card>
 
 ## Flavors and bundles
 
@@ -31,4 +35,7 @@ You select a flavor when building a UDS Bundle. All Core packages within a bundl
 - **Production users** create their own bundles, selecting `registry1` or `unicorn` packages.
 - **Demo bundles** (`k3d-core-demo`, `k3d-core-slim-dev`) are published from `upstream` only.
 
-Switching flavors requires no application-side changes. The same functional layers, CRDs, and configuration surface apply regardless of flavor. Only the bundle references change.
+Switching flavors requires no application-side changes. The CRDs and configuration surface apply regardless of flavor, and only the bundle references change.
+
+> [!NOTE]
+> The Portal functional layer is the one exception to flavor parity: it is not published in the `registry1` flavor, and is the only component whose availability depends on flavor. For the full layer and flavor matrix, see [Functional Layers](/concepts/platform/functional-layers/).

--- a/docs/how-to-guides/platform-features/overview.mdx
+++ b/docs/how-to-guides/platform-features/overview.mdx
@@ -1,13 +1,13 @@
 ---
 title: Platform Features
-description: Guides for platform-wide UDS Core features including functional layer bundles, automatic pod reload, and the security classification banner.
+description: Guides for platform-wide UDS Core features including functional layer bundles, automatic pod reload, the security classification banner, and the UDS Portal.
 sidebar:
   order: 10.000
 ---
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-Platform-wide UDS Core capabilities that aren't tied to a single component. These guides cover custom layer bundles, automatic pod restarts, and UI-level classification markings.
+Platform-wide UDS Core capabilities that aren't tied to a single component. These guides cover custom layer bundles, automatic pod restarts, UI-level classification markings, and customizing the UDS Portal.
 
 ## Guides
 
@@ -26,5 +26,10 @@ Platform-wide UDS Core capabilities that aren't tied to a single component. Thes
     title="Enable the classification banner"
     description="Inject a security classification banner into web UIs via Istio EnvoyFilter."
     href="/how-to-guides/platform-features/enable-classification-banner/"
+  />
+  <LinkCard
+    title="Customize UDS Portal app tiles"
+    description="Set an application's UDS Portal tile title and icon, and hide specific exposed endpoints."
+    href="/how-to-guides/platform-features/portal/"
   />
 </CardGrid>

--- a/docs/how-to-guides/platform-features/portal.mdx
+++ b/docs/how-to-guides/platform-features/portal.mdx
@@ -1,0 +1,108 @@
+---
+title: Customize UDS Portal app tiles
+description: "Customize how an application appears in the UDS Portal: set its tile title and icon, and hide specific exposed endpoints."
+sidebar:
+  order: 10.004
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+## What you'll accomplish
+
+The UDS Portal is the landing page where users discover the applications they can access in a UDS environment. This guide covers the tile settings you configure for an application: its title, its icon, and which of its exposed endpoints appear.
+
+> [!NOTE]
+> The Portal layer ships in the `upstream` and `unicorn` flavors only. It is not available in `registry1`. See [Functional Layers](/concepts/platform/functional-layers/) for the full layer and flavor matrix.
+
+## Prerequisites
+
+- [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- Access to a Kubernetes cluster with UDS Core deployed, including the Identity & Authorization and Portal layers
+- An application deployed with a [`Package` CR](/reference/operator-and-crds/packages-v1alpha1-cr/) that has an `sso` section and at least one `network.expose` entry
+
+## How the Portal builds tiles
+
+The Portal builds its app list from `Package` CRs in the cluster, creating one tile per `network.expose` entry. A package must define an `sso` section or it produces no tiles, even when it exposes services.
+
+The Portal has no access controls of its own. It reflects each application's SSO authorization, so a user sees a tile only for an app they can access. That access is governed by the app's `Package` CR through `spec.sso[].groups.anyOf`: list groups to restrict the app, or omit it to allow all authenticated users. You configure access on the SSO client, not in the Portal:
+
+- [Register and customize SSO clients](/how-to-guides/identity-and-authorization/register-and-customize-sso-clients/) - define an application's SSO client.
+- [Enforce group-based access controls](/how-to-guides/identity-and-authorization/enforce-group-based-access/) - restrict which Keycloak groups can access an app, which in turn controls its tile visibility.
+
+The rest of this guide covers only the Portal-specific tile settings: title, icon, and endpoint hiding.
+
+## Steps
+
+<Steps>
+
+1. **Set the tile title and icon**
+
+   Add the `dev.uds.title` and `dev.uds.icon` annotations to the Zarf package `metadata.annotations` in `zarf.yaml`. These annotations live on the Zarf package, not the `Package` CR.
+
+   ```yaml title="zarf.yaml"
+   kind: ZarfPackageConfig
+   metadata:
+     name: my-app
+     annotations:
+       dev.uds.title: My Application                 # display name shown on the tile
+       dev.uds.icon: "https://my-app.uds.dev/icon.svg" # tile logo; a URL or a data URI
+   ```
+
+   If `dev.uds.title` is absent, the title falls back to a formatted version of the package name (for example, `uds-registry` becomes `UDS Registry`). If `dev.uds.icon` is absent, the Portal shows a default logo.
+
+   > [!TIP]
+   > The icon value accepts a URL or an inline data URI such as `data:image/svg+xml;base64,<base64-encoded-svg>`. A data URI avoids an extra network fetch and works in the airgap.
+
+2. **(Optional) Hide specific exposed endpoints**
+
+   A package that exposes multiple endpoints (for example, an application and its separate pages service) generates a tile for each one. To hide specific endpoints, set the `uds.dev/portal-hide-apps` annotation on the `Package` CR to a comma-separated list of `network.expose[].host` values.
+
+   ```yaml title="package.yaml"
+   metadata:
+     name: my-app
+     annotations:
+       # Hide the tiles for these exposed hosts
+       uds.dev/portal-hide-apps: "my-app-pages,my-app-registry"
+   ```
+
+   Expose entries with a wildcard `host` (for example, `*.pages`) are always excluded automatically.
+
+3. **Deploy your application**
+
+   Include the updated `zarf.yaml` and `Package` CR in your Zarf package, then create and deploy it. See [Packaging applications](/how-to-guides/packaging-applications/overview/) for general packaging guidance.
+
+   ```bash
+   uds zarf package create --confirm
+   uds zarf package deploy zarf-package-*.tar.zst --confirm
+   ```
+
+   > [!NOTE]
+   > The title and icon come from the deployed Zarf package metadata, so they update only on `zarf package deploy`, not by applying the `Package` CR alone.
+
+</Steps>
+
+## Verification
+
+Log in to the Portal at `https://portal.<your-domain>` (for example, `https://portal.uds.dev`) and confirm the tile appears with the expected title and icon, and that any hidden endpoints are absent.
+
+## Troubleshooting
+
+### Problem: Title or icon does not update
+
+**Symptom:** The tile shows the default title or logo.
+
+**Solution:** The `dev.uds.title` and `dev.uds.icon` annotations must be on the Zarf package `metadata.annotations` in `zarf.yaml`, not the `Package` CR. Setting them on the `Package` CR has no effect. Repackage and redeploy after correcting them.
+
+### Problem: App tile does not appear
+
+**Symptom:** Your application is deployed and exposed, but no tile shows up.
+
+**Solution:** Confirm the `Package` CR has an `sso` section; a package without one produces no tiles. If the app restricts access with `groups.anyOf`, a missing tile is expected for users outside the allowed groups. See [Enforce group-based access controls](/how-to-guides/identity-and-authorization/enforce-group-based-access/).
+
+## Related documentation
+
+- [`Package` CR reference](/reference/operator-and-crds/packages-v1alpha1-cr/) - all available `spec.sso` and `network.expose` fields
+- [Enforce group-based access controls](/how-to-guides/identity-and-authorization/enforce-group-based-access/) - restrict which Keycloak groups can access an app, which in turn controls its tile visibility
+- [Register and customize SSO clients](/how-to-guides/identity-and-authorization/register-and-customize-sso-clients/) - configure SSO clients and Keycloak groups
+- [Functional Layers](/concepts/platform/functional-layers/) - how the Portal layer fits into UDS Core and which flavors include it
+- [UDS Portal repository](https://github.com/defenseunicorns/uds-portal) - source and additional configuration details

--- a/docs/how-to-guides/platform-features/portal.mdx
+++ b/docs/how-to-guides/platform-features/portal.mdx
@@ -44,14 +44,14 @@ The rest of this guide covers only the Portal-specific tile settings: title, ico
    metadata:
      name: my-app
      annotations:
-       dev.uds.title: My Application                 # display name shown on the tile
-       dev.uds.icon: "https://my-app.uds.dev/icon.svg" # tile logo; a URL or a data URI
+       dev.uds.title: My Application  # display name shown on the tile
+       dev.uds.icon: "data:image/svg+xml;base64,<base64-encoded-svg>"  # tile logo as a base64 data URI
    ```
 
    If `dev.uds.title` is absent, the title falls back to a formatted version of the package name (for example, `uds-registry` becomes `UDS Registry`). If `dev.uds.icon` is absent, the Portal shows a default logo.
 
    > [!TIP]
-   > The icon value accepts a URL or an inline data URI such as `data:image/svg+xml;base64,<base64-encoded-svg>`. A data URI avoids an extra network fetch and works in the airgap.
+   > Provide the icon as a base64-encoded data URI so it renders without an external fetch and works in the airgap. A plain image URL only works if every user's browser can reach it, so avoid URLs in airgapped deployments.
 
 2. **(Optional) Hide specific exposed endpoints**
 


### PR DESCRIPTION
## Description

 - Document Portal as a functional layer and correct the flavors page to reflect that Portal is the one exception to flavor parity (not published in registry1)
  - Add how-to guide for customizing Portal app tiles (title, icon, hiding exposed endpoints)
  - Add the new guide to the Platform Features overview
  - Restructure callouts on flavors page and move unicorn flavor references to card (CVE posture, support access)

## Related Issue

Relates to CORE-538

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

N/A

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
