### PR TITLE
chore(renovate): group envoy-gateway updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,6 +91,13 @@
     },
     {
       "matchFileNames": [
+        "src/envoy-gateway/**"
+      ],
+      "groupName": "envoy-gateway",
+      "commitMessageTopic": "envoy-gateway"
+    },
+    {
+      "matchFileNames": [
         "test/**/*",
         ".github/**",
         "bundles/**",

--- a/scripts/renovate/getImagesAndCharts.spec.ts
+++ b/scripts/renovate/getImagesAndCharts.spec.ts
@@ -390,4 +390,51 @@ metadata:
       ],
     });
   });
+
+  test("should normalize prefixed distroless image tags", async () => {
+    (fs.readFileSync as Mock).mockImplementation(filePath => {
+      if (filePath === "test-dir/zarf.yaml") {
+        return `
+kind: ZarfPackageConfig
+metadata:
+  name: uds-core-envoy-gateway
+components:
+  - name: envoy-gateway
+    images:
+      - docker.io/envoyproxy/gateway:v1.8.0
+      - docker.io/envoyproxy/envoy:distroless-v1.38.0
+      - registry1.dso.mil/ironbank/opensource/envoy_proxy/envoy-distroless:v1.38.0
+      - cgr.dev/defenseunicorns.com/envoy-fips:distroless-v1.38.0
+`;
+      }
+      if (filePath === "test-dir/common/zarf.yaml") {
+        return `
+kind: ZarfPackageConfig
+metadata:
+  name: uds-core-envoy-gateway-common
+components:
+  - name: envoy-gateway
+    required: false
+`;
+      }
+      return "";
+    });
+
+    await getImagesAndCharts("test-dir");
+
+    const imagesContent = (fs.writeFileSync as Mock).mock.calls.find(
+      call => call[0] === "test-dir/extract/images.yaml",
+    )![1];
+
+    const images = yaml.parse(imagesContent);
+
+    expect(images).toEqual({
+      "1.8.0": ["docker.io/envoyproxy/gateway:v1.8.0"],
+      "1.38.0": [
+        "docker.io/envoyproxy/envoy:distroless-v1.38.0",
+        "registry1.dso.mil/ironbank/opensource/envoy_proxy/envoy-distroless:v1.38.0",
+        "cgr.dev/defenseunicorns.com/envoy-fips:distroless-v1.38.0",
+      ],
+    });
+  });
 });

--- a/scripts/renovate/getImagesAndCharts.ts
+++ b/scripts/renovate/getImagesAndCharts.ts
@@ -137,15 +137,10 @@ function processImage(imagePullString: string, images: Record<string, string[]>)
 
   if (!imageName || !imageTag) return;
 
-  // Normalize version by removing 'v' prefix and any suffixes
+  // Normalize version by extracting semver from tags with optional prefixes/suffixes
   let normalizedTag = imageTag;
 
-  // Remove 'v' prefix if present
-  if (normalizedTag.startsWith("v")) {
-    normalizedTag = normalizedTag.substring(1);
-  }
-
-  // Remove prefixes/suffixes (e.g., distroless-v1.38.0, 1.2.3-beta.1)
+  // (e.g., v1.2.3, distroless-v1.38.0, 1.2.3-beta.1)
   const versionMatch = normalizedTag.match(/v?(\d+\.\d+\.\d+)/);
   if (versionMatch) {
     normalizedTag = versionMatch[1];

--- a/scripts/renovate/getImagesAndCharts.ts
+++ b/scripts/renovate/getImagesAndCharts.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2025-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -82,7 +82,7 @@ function findZarfYamlFiles(dir: string): string[] {
 // Define a ZarfConfig type to replace 'any'
 interface ZarfComponent {
   charts?: Array<{ name: string; version: string; localPath?: string; url?: string }>;
-  images?: Array<{ name: string }>;
+  images?: string[];
 }
 
 interface ZarfConfig {
@@ -145,8 +145,8 @@ function processImage(imagePullString: string, images: Record<string, string[]>)
     normalizedTag = normalizedTag.substring(1);
   }
 
-  // Remove suffixes (e.g., -beta.1)
-  const versionMatch = normalizedTag.match(/^(\d+\.\d+\.\d+)/);
+  // Remove prefixes/suffixes (e.g., distroless-v1.38.0, 1.2.3-beta.1)
+  const versionMatch = normalizedTag.match(/v?(\d+\.\d+\.\d+)/);
   if (versionMatch) {
     normalizedTag = versionMatch[1];
   }


### PR DESCRIPTION
## Description
Groups Envoy Gateway dependency updates into a single Renovate PR and updates renovate readiness extraction to handle Envoy's prefixed distroless image tags.

## Changes

- Add `src/envoy-gateway/**` to the `envoy-gateway` Renovate group.
- Normalize image tags like `distroless-v1.38.0` to `1.38.0` in renovate readiness extraction.
- Add test coverage for Envoy Gateway image tag normalization.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
