### PR TITLE
feat: add a check for UDS Package CRs before removal of UDS Core Base for a safer removal UX

### DIFF
--- a/packages/base/zarf.yaml
+++ b/packages/base/zarf.yaml
@@ -96,4 +96,4 @@ components:
                 echo "$PACKAGES"
                 exit 1
               fi
-            description: "Verify no UDS Package CRs exist before removal" 
+            description: "Verify no UDS Package CRs exist before removal"

--- a/packages/base/zarf.yaml
+++ b/packages/base/zarf.yaml
@@ -84,6 +84,7 @@ components:
       path: ../../src/envoy-gateway
 
   - name: remove-safely
+    required: true
     actions:
       # before we remove any "base" components we should check that nothing depends on this package (i.e. has Package CRs).
       onRemove:

--- a/packages/base/zarf.yaml
+++ b/packages/base/zarf.yaml
@@ -82,3 +82,17 @@ components:
     required: false
     import:
       path: ../../src/envoy-gateway
+
+  - name: remove-safely
+    actions:
+      # before we remove any "base" components we should check that nothing depends on this package (i.e. has Package CRs).
+      onRemove:
+        before:
+          - cmd: |
+              PACKAGES=$(./zarf tools kubectl get package -A --no-headers 2>/dev/null)
+              if [ -n "$PACKAGES" ]; then
+                echo "Found existing UDS Package CRs - remove all UDS Packages before removing UDS Core:"
+                echo "$PACKAGES"
+                exit 1
+              fi
+            description: "Verify no UDS Package CRs exist before removal" 

--- a/packages/standard/zarf.yaml
+++ b/packages/standard/zarf.yaml
@@ -88,7 +88,7 @@ components:
     required: false
     import:
       path: ../base
-  
+
   - name: remove-safely
     required: true
     import:

--- a/packages/standard/zarf.yaml
+++ b/packages/standard/zarf.yaml
@@ -90,7 +90,7 @@ components:
       path: ../base
   
   - name: remove-safely
-    required: false
+    required: true
     import:
       path: ../base
 

--- a/packages/standard/zarf.yaml
+++ b/packages/standard/zarf.yaml
@@ -88,6 +88,11 @@ components:
     required: false
     import:
       path: ../base
+  
+  - name: remove-safely
+    required: false
+    import:
+      path: ../base
 
   - name: keycloak
     required: true


### PR DESCRIPTION
## Description

This adds a check for UDS Package CRs prior to UDS Core Base being removed so that the cluster is less likely to enter a bad state if someone attempts to remove UDS Core without removing other UDS Packages first.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
