### PR TITLE
feat(istio): add option to use post-quantum key exchange

### DIFF
--- a/.github/workflows/test-pqc.yaml
+++ b/.github/workflows/test-pqc.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+name: Test PQC
+
+# Runs the dedicated post-quantum cryptography (COMPLIANCE_POLICY=pqc) force-mode scenario on the
+# upstream flavor. Kept out of the standard test matrix because forcing PQC mesh-wide makes the
+# tenant gateway reject the non-PQC clients the standard suite relies on. Trigger manually, or call
+# it from an orchestrating workflow.
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+
+permissions:
+  contents: read
+  id-token: write # This is needed for OIDC federation.
+  packages: read # Allows reading the published GHCR packages
+
+jobs:
+  test-pqc:
+    runs-on: uds-ubuntu-big-boy-8-core
+    timeout-minutes: 40
+    name: Test PQC (upstream)
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Environment setup
+        uses: ./.github/actions/setup
+        with:
+          ghToken: ${{ secrets.GITHUB_TOKEN }}
+          installK3d: "true"
+
+      - name: Force PQC and run the PQC force-mode scenario
+        run: uds run test-uds-core-pqc --set FLAVOR=upstream --no-progress
+
+      - name: Debug Output
+        if: ${{ always() }}
+        uses: ./.github/actions/debug-output
+
+      - name: Save logs
+        if: always()
+        uses: ./.github/actions/save-logs
+        with:
+          suffix: -pqc-upstream

--- a/bundles/k3d-slim-dev/README.md
+++ b/bundles/k3d-slim-dev/README.md
@@ -27,6 +27,16 @@ The k3d uds-dev-stack provides:
 
 ### Package: core
 
+##### istio-controlplane (istiod)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `ISTIO_COMPLIANCE_POLICY` | Istio COMPLIANCE_POLICY (control plane + data plane). Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off. | pilot.env.COMPLIANCE_POLICY |
+
+##### istio-controlplane (ztunnel)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `ISTIO_COMPLIANCE_POLICY` | Istio COMPLIANCE_POLICY for the ztunnel L4 mTLS hop. Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off. | env.COMPLIANCE_POLICY |
+
 ##### istio-admin-gateway (uds-istio-config)
 | Variable | Description | Path |
 |----------|-------------|------|

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -90,6 +90,14 @@ packages:
               description: "CPU limit for the Istio Proxy Sidecar"
               path: "global.proxy.resources.limits.cpu"
               default: "2000m"
+            - name: ISTIO_COMPLIANCE_POLICY
+              description: "Istio COMPLIANCE_POLICY (control plane + data plane). Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off."
+              path: "pilot.env.COMPLIANCE_POLICY"
+        ztunnel:
+          variables:
+            - name: ISTIO_COMPLIANCE_POLICY
+              description: "Istio COMPLIANCE_POLICY for the ztunnel L4 mTLS hop. Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off."
+              path: "env.COMPLIANCE_POLICY"
       istio-admin-gateway:
         uds-istio-config:
           variables:

--- a/bundles/k3d-standard/README.md
+++ b/bundles/k3d-standard/README.md
@@ -31,6 +31,16 @@ This bundle is used for demonstration, development, and testing of UDS Core. In 
 | `LOKI_S3_ACCESS_KEY_ID` | The S3 Access Key ID | loki.storage.s3.accessKeyId |
 | `LOKI_S3_SECRET_ACCESS_KEY` | The S3 Secret Access Key | loki.storage.s3.secretAccessKey |
 
+##### istio-controlplane (istiod)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `ISTIO_COMPLIANCE_POLICY` | Istio COMPLIANCE_POLICY (control plane + data plane). Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off. | pilot.env.COMPLIANCE_POLICY |
+
+##### istio-controlplane (ztunnel)
+| Variable | Description | Path |
+|----------|-------------|------|
+| `ISTIO_COMPLIANCE_POLICY` | Istio COMPLIANCE_POLICY for the ztunnel L4 mTLS hop. Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off. | env.COMPLIANCE_POLICY |
+
 ##### istio-admin-gateway (uds-istio-config)
 | Variable | Description | Path |
 |----------|-------------|------|

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -106,6 +106,17 @@ packages:
               path: backend.replicas
               description: "Loki backend replicas"
               default: "1"
+      istio-controlplane:
+        istiod:
+          variables:
+            - name: ISTIO_COMPLIANCE_POLICY
+              description: "Istio COMPLIANCE_POLICY (control plane + data plane). Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off."
+              path: "pilot.env.COMPLIANCE_POLICY"
+        ztunnel:
+          variables:
+            - name: ISTIO_COMPLIANCE_POLICY
+              description: "Istio COMPLIANCE_POLICY for the ztunnel L4 mTLS hop. Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off."
+              path: "env.COMPLIANCE_POLICY"
       istio-admin-gateway:
         uds-istio-config:
           variables:

--- a/docs/how-to-guides/networking/enable-post-quantum-cryptography.mdx
+++ b/docs/how-to-guides/networking/enable-post-quantum-cryptography.mdx
@@ -1,0 +1,125 @@
+---
+title: Enable post-quantum cryptography
+description: Force Istio's COMPLIANCE_POLICY to pqc across the UDS Core service mesh, then verify the tenant gateway and control plane enforce X25519MLKEM768 post-quantum key exchange.
+sidebar:
+  order: 2.012
+---
+
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+## What you'll accomplish
+
+After completing this guide, the UDS Core service mesh will force post-quantum cryptography (PQC): every TLS and mTLS handshake negotiates the `X25519MLKEM768` hybrid key exchange group, and peers that cannot negotiate it are rejected. You will set the `ISTIO_COMPLIANCE_POLICY` toggle, deploy Core with it enabled, and verify enforcement at both the tenant gateway and the control plane.
+
+## Prerequisites
+
+- [UDS CLI](https://github.com/defenseunicorns/uds-cli/releases) installed
+- Access to a Kubernetes cluster running UDS Core on the `upstream` (non-FIPS) flavor in ambient mode
+- OpenSSL 3.5 or newer for client-side verification (earlier versions do not recognize the `X25519MLKEM768` group name)
+- Familiarity with setting UDS bundle variables through `uds-config.yaml` or `--set`
+
+## Before you begin
+
+This toggle forces PQC mesh-wide; it does not prefer it. Any client or upstream that cannot negotiate `X25519MLKEM768` is rejected rather than downgraded, so egress to non-PQC hosts and ingress from non-PQC clients will fail. PQC is supported only on the `upstream` flavor: the FIPS flavors (`registry1`, `unicorn`) ship a ztunnel that cannot negotiate the hybrid group. For the full support matrix and behavior details, see [Post-quantum cryptography](/reference/configuration/post-quantum-cryptography/).
+
+## Steps
+
+<Steps>
+
+1. **Provide the `pqc` value**
+
+   The UDS Core standard and slim-dev bundles already declare `ISTIO_COMPLIANCE_POLICY` on the `istiod` and `ztunnel` charts, so you only supply the value. Add it to a config file, or skip this step and pass it as a deploy flag in the next step.
+
+   ```yaml title="uds-config.yaml"
+   variables:
+     core:
+       # Force post-quantum key exchange across the mesh
+       ISTIO_COMPLIANCE_POLICY: pqc
+   ```
+
+2. **Deploy UDS Core with PQC enabled**
+
+   Deploy the bundle with the value set, using either the config file or a deploy flag.
+
+   <Tabs>
+   <TabItem label="Config file">
+
+   ```bash
+   UDS_CONFIG=uds-config.yaml uds deploy <bundle> --confirm
+   ```
+
+   </TabItem>
+   <TabItem label="Deploy flag">
+
+   ```bash
+   uds deploy <bundle> --set ISTIO_COMPLIANCE_POLICY=pqc --confirm
+   ```
+
+   </TabItem>
+   </Tabs>
+
+   The control plane and ztunnel restart with `COMPLIANCE_POLICY=pqc`, and istiod propagates the policy to the Envoy gateways.
+
+</Steps>
+
+## Verification
+
+Confirm the policy reached both workloads, then confirm the gateway enforces it on the wire.
+
+First, check that `COMPLIANCE_POLICY=pqc` is set on the control plane and the ztunnel data plane:
+
+```bash
+uds zarf tools kubectl get deployment istiod -n istio-system \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="COMPLIANCE_POLICY")].value}'
+# Expected: pqc
+
+uds zarf tools kubectl get daemonset ztunnel -n istio-system \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="COMPLIANCE_POLICY")].value}'
+# Expected: pqc
+```
+
+Next, confirm a PQC-capable client negotiates the hybrid group at the tenant gateway. Replace `<app-host>` with an application host served by the tenant gateway:
+
+```bash
+echo | openssl s_client -connect <app-host>:443 -groups X25519MLKEM768 -tls1_3 2>/dev/null \
+  | grep -iE "negotiated tls1.3 group|server temp key"
+# Expected (OpenSSL 3.5+): Negotiated TLS1.3 group: X25519MLKEM768
+# (older OpenSSL prints: Server Temp Key: X25519MLKEM768, 1216 bits)
+```
+
+Finally, confirm force mode by checking that a classical-only client is rejected. This is what distinguishes force from prefer:
+
+```bash
+echo | openssl s_client -connect <app-host>:443 -groups X25519 -tls1_3 2>&1 \
+  | grep -iE "negotiated tls1.3 group|server temp key|handshake failure|alert"
+# Expected: handshake failure (tls alert handshake failure); the negotiated group is <NULL>, not a real group
+```
+
+> [!NOTE]
+> If the classical-only client still completes the handshake and reports a negotiated group, the gateway is behaving as prefer rather than force on that path. Treat that as a finding to investigate, not a reason to relax the check.
+
+## Troubleshooting
+
+### Problem: Browsers or API clients can no longer connect
+
+**Symptom:** Clients that previously worked now fail the TLS handshake against the tenant gateway.
+
+**Solution:** This is expected under force mode. Only PQC-capable clients (current Chrome and Firefox, and tools built with OpenSSL 3.5+) can connect. Upgrade the client to one that negotiates `X25519MLKEM768`, or leave `ISTIO_COMPLIANCE_POLICY` unset if you cannot require PQC-capable clients.
+
+### Problem: Mesh mTLS fails after enabling pqc on a FIPS flavor
+
+**Symptom:** Workloads cannot establish mTLS, and ztunnel logs show key exchange failures, after setting `pqc` on a `registry1` or `unicorn` deployment.
+
+**Solution:** PQC is not supported on FIPS flavors. Their ztunnel uses a vendored BoringSSL that predates `X25519MLKEM768`. Unset `ISTIO_COMPLIANCE_POLICY` and redeploy.
+
+### Problem: openssl reports an unknown group
+
+**Symptom:** `openssl s_client` fails with an error about the `X25519MLKEM768` group name.
+
+**Solution:** Use OpenSSL 3.5 or newer. Earlier versions do not know the hybrid group. Run the check from a container image that ships a recent OpenSSL if your local version is older.
+
+## Related documentation
+
+- [Post-quantum cryptography](/reference/configuration/post-quantum-cryptography/) - variable reference, support matrix, and force-mode behavior
+- [Configure TLS certificates for gateways](/how-to-guides/networking/configure-tls-certificates/) - related gateway TLS configuration
+- [Istio 1.27 change notes](https://istio.io/latest/news/releases/1.27.x/announcing-1.27/change-notes/) - upstream introduction of the `COMPLIANCE_POLICY` post-quantum option

--- a/docs/how-to-guides/networking/overview.mdx
+++ b/docs/how-to-guides/networking/overview.mdx
@@ -64,4 +64,9 @@ For background on how the service mesh, gateways, and authorization model work, 
     description="Distribute custom CA certificates across the cluster for private PKI or DoD CAs."
     href="/how-to-guides/networking/manage-trust-bundles/"
   />
+  <LinkCard
+    title="Enable post-quantum cryptography"
+    description="Force post-quantum hybrid key exchange (X25519MLKEM768) across the service mesh and verify enforcement."
+    href="/how-to-guides/networking/enable-post-quantum-cryptography/"
+  />
 </CardGrid>

--- a/docs/reference/configuration/overview.mdx
+++ b/docs/reference/configuration/overview.mdx
@@ -24,4 +24,9 @@ Configuration surfaces exposed by UDS Core components: the fields, defaults, and
     Storage backend, bucket names, schema versioning, and bundle overrides for Loki log storage.
     <LinkCard title="View reference" href="/reference/configuration/loki-storage/" />
   </Card>
+
+  <Card title="Post-quantum cryptography" icon="approve-check-circle">
+    Force TLS 1.3 with post-quantum hybrid key exchange (X25519MLKEM768) across the Istio service mesh.
+    <LinkCard title="View reference" href="/reference/configuration/post-quantum-cryptography/" />
+  </Card>
 </CardGrid>

--- a/docs/reference/configuration/post-quantum-cryptography.md
+++ b/docs/reference/configuration/post-quantum-cryptography.md
@@ -1,0 +1,78 @@
+---
+title: Post-quantum cryptography
+description: Reference for the ISTIO_COMPLIANCE_POLICY toggle that forces post-quantum hybrid key exchange (X25519MLKEM768) across the UDS Core Istio service mesh, including accepted values, the support matrix, and force-mode behavior.
+sidebar:
+  order: 3.004
+---
+
+UDS Core can force post-quantum cryptography (PQC) across the Istio service mesh through the `ISTIO_COMPLIANCE_POLICY` variable, which sets Istio's `COMPLIANCE_POLICY` on both the control plane and the ztunnel data plane. The toggle is off by default: until you set it, the mesh keeps Istio's standard TLS behavior, and deployments render identically to a build without the variable.
+
+## Compliance policy variable
+
+`ISTIO_COMPLIANCE_POLICY` is a single variable declared on both the `istiod` and `ztunnel` charts of the `istio-controlplane` package, so one value sets both injection points.
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `ISTIO_COMPLIANCE_POLICY` | string | unset | Sets Istio's `COMPLIANCE_POLICY`. Accepted value: `pqc`. When set to `pqc`, Istio enforces TLS 1.3, the `TLS_AES_128_GCM_SHA256` and `TLS_AES_256_GCM_SHA384` cipher suites, and the `X25519MLKEM768` hybrid key exchange group on Envoy mTLS, Envoy downstream and upstream TLS (including gateways), the ztunnel L4 mTLS hop, and the xDS channel. When unset, the mesh uses Istio's default behavior. |
+
+> [!NOTE]
+> In ambient mode the policy must be set on both `istiod` and `ztunnel`. Setting it on `istiod` alone does not flip the ztunnel L4 hop, so the variable maps to two chart paths: `pilot.env.COMPLIANCE_POLICY` on `istiod` and `env.COMPLIANCE_POLICY` on `ztunnel`.
+
+> [!NOTE]
+> `pqc` is the only value UDS Core supports through this toggle. Istio's upstream `COMPLIANCE_POLICY` also accepts `fips-140-2`, but UDS Core does not support that value here.
+
+The UDS Core standard and slim-dev bundles already declare `ISTIO_COMPLIANCE_POLICY` on both charts, so you can set the value at deploy time without editing the bundle:
+
+```yaml title="uds-config.yaml"
+variables:
+  core:
+    # Force post-quantum key exchange across the mesh
+    ISTIO_COMPLIANCE_POLICY: pqc
+```
+
+You can also pass it as a deploy flag with `uds deploy <bundle> --set ISTIO_COMPLIANCE_POLICY=pqc`.
+
+In a custom bundle, declare the variable on both charts so a single value drives the control plane and the ztunnel data plane together:
+
+```yaml title="uds-bundle.yaml"
+overrides:
+  core:
+    istio-controlplane:
+      istiod:
+        variables:
+          - name: ISTIO_COMPLIANCE_POLICY
+            path: pilot.env.COMPLIANCE_POLICY
+      ztunnel:
+        variables:
+          - name: ISTIO_COMPLIANCE_POLICY
+            path: env.COMPLIANCE_POLICY
+```
+
+## Support matrix
+
+PQC depends on the cryptographic library that ztunnel is built against, so support is limited to the non-FIPS `upstream` flavor running in ambient mode.
+
+| Flavor | PQC (`pqc`) supported | Reason |
+|---|---|---|
+| `upstream` | Yes | ztunnel is built against aws-lc-rs, which supports the `X25519MLKEM768` hybrid group |
+| `registry1` | No | The FIPS ztunnel uses a vendored BoringSSL that predates the hybrid group |
+| `unicorn` | No | The FIPS ztunnel uses a vendored BoringSSL that predates the hybrid group |
+
+> [!CAUTION]
+> Do not set `ISTIO_COMPLIANCE_POLICY=pqc` on a FIPS flavor (`registry1` or `unicorn`). The FIPS ztunnel cannot negotiate `X25519MLKEM768`, so mesh mTLS will fail. PQC with FIPS is not supported.
+
+## Force-mode behavior
+
+The `pqc` policy forces post-quantum key exchange; it does not prefer it. Any TLS peer that cannot negotiate `X25519MLKEM768` is rejected rather than downgraded to a classical group. Two consequences follow directly:
+
+- **Egress.** Traffic that leaves the mesh through the egress waypoint to an external host without `X25519MLKEM768` support fails the TLS handshake.
+- **Ingress.** The tenant gateway accepts only PQC-capable clients. Current Chrome and Firefox negotiate the group; older browsers, some API clients, and older Safari and iOS versions may fail to connect.
+
+> [!NOTE]
+> Forcing PQC at the edge while still accepting classical clients at ingress (a per-gateway "prefer" mode) is not part of this toggle. The policy applies mesh-wide.
+
+## Related documentation
+
+- [Enable post-quantum cryptography](/how-to-guides/networking/enable-post-quantum-cryptography/) - turn on PQC and verify the gateway and mesh enforce it
+- [Configure core network access](/how-to-guides/networking/configure-core-network-access/) - related ingress and egress configuration
+- [Istio 1.27 change notes](https://istio.io/latest/news/releases/1.27.x/announcing-1.27/change-notes/) - upstream introduction of the `COMPLIANCE_POLICY` post-quantum option

--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -41,6 +41,9 @@ components:
           - name: PROXY_CPU_REQUEST
             description: "CPU requests for sidecars in cluster"
             path: "global.proxy.resources.requests.cpu"
+          - name: ISTIO_COMPLIANCE_POLICY
+            description: "Istio COMPLIANCE_POLICY (control plane + data plane). Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off."
+            path: "pilot.env.COMPLIANCE_POLICY"
       - name: uds-global-istio-config
         namespace: istio-system
         version: 0.1.0
@@ -59,6 +62,10 @@ components:
         namespace: istio-system
         valuesFiles:
           - "../values/base-ztunnel.yaml"
+        variables:
+          - name: ISTIO_COMPLIANCE_POLICY
+            description: "Istio COMPLIANCE_POLICY for the ztunnel L4 mTLS hop. Set to 'pqc' to force post-quantum hybrid key exchange (X25519MLKEM768). Empty = default/off."
+            path: "env.COMPLIANCE_POLICY"
     actions:
       onDeploy:
         before:

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -144,6 +144,11 @@ tasks:
     actions:
       - task: test:uds-core-upgrade
 
+  - name: test-uds-core-pqc
+    description: "Deploy UDS Core with PQC (COMPLIANCE_POLICY=pqc) forced and run the PQC force-mode scenario (upstream flavor only)"
+    actions:
+      - task: test:uds-core-pqc
+
   - name: lint-check
     description: "Run linting checks"
     actions:

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -175,3 +175,17 @@ tasks:
     actions:
       - description: "Deploy the checkpoint K3d + UDS Core Slim zarf package"
         cmd: ./uds zarf package deploy build/zarf-package-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst --confirm
+
+  - name: k3d-standard-bundle-pqc
+    description: "Deploy the UDS Core standard bundle with COMPLIANCE_POLICY=pqc forced (upstream flavor only)"
+    actions:
+      - description: "PQC is only supported on the non-FIPS upstream flavor"
+        cmd: |
+          if [ "${FLAVOR}" != "upstream" ]; then
+            echo "ERROR: the PQC scenario requires FLAVOR=upstream (got '${FLAVOR}'); PQC is not supported on FIPS flavors." >&2
+            exit 1
+          fi
+      # Setting ISTIO_COMPLIANCE_POLICY=pqc forces post-quantum key exchange on istiod and ztunnel;
+      # istiod propagates the policy to the gateway Envoys via xDS.
+      - description: "Deploy the standard bundle with ISTIO_COMPLIANCE_POLICY=pqc forced"
+        cmd: ./uds deploy bundles/k3d-standard/uds-bundle-k3d-core-demo-${UDS_ARCH}-${VERSION}.tar.zst --set INSECURE_ADMIN_PASSWORD_GENERATION=true --set FALCO_SANDBOX_RULES_ENABLED=true --set FALCO_INCUBATING_RULES_ENABLED=true --set ISTIO_COMPLIANCE_POLICY=pqc --confirm --no-progress

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -254,3 +254,34 @@ tasks:
           ./uds zarf tools kubectl wait package ambient-httpbin -n authservice-ambient-test-app --for=condition=Ready --timeout=300s
       - task: private-pki:private-pki-tests
       - task: trust-bundle:trust-bundle-tests
+
+  - name: pqc-tests
+    description: "Run the PQC (COMPLIANCE_POLICY=pqc) force-mode vitest spec. Requires PQC already forced on the cluster."
+    actions:
+      - dir: test/vitest
+        cmd: |
+          npm ci
+          PQC_TESTS=true npx vitest run istio-pqc.spec.ts
+
+  - name: uds-core-pqc
+    description: "Deploy UDS Core (upstream) with COMPLIANCE_POLICY=pqc forced and run the PQC force-mode scenario. Kept separate from the standard suite, which forced PQC would break."
+    actions:
+      - task: create:standard-package
+        with:
+          create_options: "--skip-sbom"
+      - task: create:k3d-standard-bundle
+      - task: deploy:k3d-standard-bundle-pqc
+      - task: validate-packages
+      # Deploy the tenant demo app (demo-8080) via the test-apps package directly. The
+      # test-resources:create-deploy task verifies ingress with non-PQC curl/HTTP clients, which a
+      # force-PQC gateway rejects; the PQC-capable in-cluster probe in the spec does that checking
+      # instead, so deploy the package without the task-level verification waits.
+      - description: "Build the test-apps package"
+        cmd: ./uds zarf package create src/test --confirm --skip-sbom -a ${UDS_ARCH}
+      - description: "Deploy the tenant demo app (no PQC-incompatible verification waits)"
+        cmd: ./uds zarf package deploy build/zarf-package-uds-core-test-apps-*.zst --confirm --no-progress
+      - description: "Wait for the tenant demo app and its Package to be ready"
+        cmd: |
+          ./uds zarf tools kubectl rollout status deployment/http-echo-multi-port -n test-tenant-app --timeout=180s
+          ./uds zarf tools kubectl wait packages.uds.dev/test-tenant-app -n test-tenant-app --for=condition=Ready --timeout=300s
+      - task: pqc-tests

--- a/test/vitest/istio-pqc.spec.ts
+++ b/test/vitest/istio-pqc.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2026 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+import { K8s, kind } from "pepr";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { createTempPod, deleteTempPod, execInPod } from "./helpers/k8s";
+
+// Image pull plus the openssl handshakes need headroom on slow CI API servers.
+vi.setConfig({ testTimeout: 60000, hookTimeout: 120000 });
+
+// Forcing pqc makes the tenant gateway reject non-PQC clients, which would break the standard
+// e2e suite's external egress and browser checks. This spec therefore only runs when the
+// dedicated PQC scenario opts in, mirroring the EGRESS_TESTS gate in network.spec.ts.
+const runPqcTests = process.env.PQC_TESTS === "true";
+
+// Pinned image shipping the OpenSSL >= 3.5 CLI, which knows the X25519MLKEM768 hybrid group.
+// Older OpenSSL and the FIPS BoringSSL builds do not recognize the group name.
+// renovate: datasource=docker depName=alpine/openssl
+const OPENSSL_IMAGE =
+  "alpine/openssl@sha256:923270611179f81b420bfb5bb5c18bf07fd59d84ed4163ac04cb371faa6d150f";
+
+// kube-system is exempt from UDS policies and the Zarf mutating webhook, and a pod there can
+// reach the tenant gateway. This mirrors the temp-pod approach in falco.spec.ts.
+const PROBE_NS = "kube-system";
+const PROBE_CONTAINER = "main"; // createTempPod names the container "main"
+
+// An application host served by the tenant gateway. Override for clusters using a different host.
+const GATEWAY_HOST = process.env.PQC_GATEWAY_HOST ?? "demo-8080.uds.dev";
+const GATEWAY_PORT = process.env.PQC_GATEWAY_PORT ?? "443";
+
+(runPqcTests ? describe : describe.skip)("Istio COMPLIANCE_POLICY=pqc force mode", () => {
+  let probePod = "";
+
+  beforeAll(async () => {
+    probePod = await createTempPod({
+      name: `openssl-pqc-probe-${Date.now()}`,
+      namespace: PROBE_NS,
+      image: OPENSSL_IMAGE,
+      command: ["sleep", "3600"],
+    });
+  });
+
+  afterAll(async () => {
+    if (probePod) {
+      await deleteTempPod(probePod, PROBE_NS);
+    }
+  });
+
+  // Offer exactly one key-exchange group over TLS 1.3 and capture the result. `2>&1` keeps
+  // handshake alerts in stdout; the trailing marker exposes openssl's own exit code, since the
+  // exec exit code reflects the wrapping `sh` (which the trailing echo always makes 0).
+  async function handshakeWithGroup(group: string) {
+    return execInPod(PROBE_NS, probePod, PROBE_CONTAINER, [
+      "sh",
+      "-c",
+      `echo | openssl s_client -connect ${GATEWAY_HOST}:${GATEWAY_PORT} ` +
+        `-servername ${GATEWAY_HOST} -groups ${group} -tls1_3 2>&1; echo "OPENSSL_EXIT:$?"`,
+    ]);
+  }
+
+  // C. Plumbing. The ztunnel L4 mTLS hop is not observable on the wire, so assert the policy is
+  // present on both workloads; combined with the aws-lc ztunnel build this is the L4 evidence.
+  test("sets COMPLIANCE_POLICY=pqc on the istiod Deployment and ztunnel DaemonSet", async () => {
+    const istiod = await K8s(kind.Deployment).InNamespace("istio-system").Get("istiod");
+    const istiodPolicy = (istiod.spec?.template?.spec?.containers ?? [])
+      .flatMap(c => c.env ?? [])
+      .find(e => e.name === "COMPLIANCE_POLICY");
+    expect(istiodPolicy?.value, "COMPLIANCE_POLICY on the istiod Deployment").toBe("pqc");
+
+    const ztunnel = await K8s(kind.DaemonSet).InNamespace("istio-system").Get("ztunnel");
+    const ztunnelPolicy = (ztunnel.spec?.template?.spec?.containers ?? [])
+      .flatMap(c => c.env ?? [])
+      .find(e => e.name === "COMPLIANCE_POLICY");
+    expect(ztunnelPolicy?.value, "COMPLIANCE_POLICY on the ztunnel DaemonSet").toBe("pqc");
+  });
+
+  // OpenSSL >= 3.5 prints "Negotiated TLS1.3 group: <name>" (older OpenSSL: "Server Temp Key: <name>").
+  // On a rejected handshake the value is "<NULL>", so a *real* negotiated group is the prefix followed
+  // by a name other than "<NULL>".
+  const GROUP_PREFIX = String.raw`(?:Negotiated TLS1\.3 group|Server Temp Key):\s*`;
+  const REAL_GROUP = new RegExp(GROUP_PREFIX + String.raw`(?!<NULL>)\S`, "i");
+
+  // A. Positive. A PQC-capable client must negotiate the hybrid group at the gateway downstream.
+  test("tenant gateway negotiates X25519MLKEM768 with a PQC-capable client", async () => {
+    const res = await handshakeWithGroup("X25519MLKEM768");
+    const detail = `host=${GATEWAY_HOST}:${GATEWAY_PORT}\n${res.stdout}`;
+    expect(res.stdout, detail).toMatch(new RegExp(GROUP_PREFIX + "X25519MLKEM768", "i"));
+  });
+
+  // B. Negative. This is what distinguishes FORCE from PREFER: a classical-only TLS 1.3 client
+  // MUST be rejected. If it connects instead, the test fails honestly rather than passing.
+  test("tenant gateway rejects a classical-only (X25519) client", async () => {
+    const res = await handshakeWithGroup("X25519");
+    const detail = `Classical-only client must be REJECTED (force, not prefer). host=${GATEWAY_HOST}:${GATEWAY_PORT}\n${res.stdout}`;
+    const exitMatch = res.stdout.match(/OPENSSL_EXIT:(\d+)/);
+    const opensslExit = exitMatch ? Number(exitMatch[1]) : NaN;
+
+    // No real key-exchange group was negotiated (OpenSSL prints "<NULL>" on a rejected handshake)...
+    expect(res.stdout, detail).not.toMatch(REAL_GROUP);
+    // ...and the handshake failed (non-zero openssl exit, or an explicit TLS alert).
+    const handshakeFailed =
+      opensslExit !== 0 ||
+      /handshake failure|no shared|illegal[_ ]parameter|alert/i.test(res.stdout);
+    expect(handshakeFailed, detail).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Add an opt-in, default-off knob that forces post-quantum hybrid key exchange (X25519MLKEM768) across the Istio mesh by setting COMPLIANCE_POLICY=pqc on istiod and ztunnel. Supported only on the non-FIPS upstream flavor.

- src/istio/common/zarf.yaml: shared ISTIO_COMPLIANCE_POLICY chart variable on the istiod (pilot.env.COMPLIANCE_POLICY) and ztunnel (env.COMPLIANCE_POLICY) charts, no default so the unset case renders identically to main
- bundles/k3d-standard and k3d-slim-dev: expose the variable as a bundle override on both charts and document it in each bundle README
- docs: new reference page and networking how-to (accepted value pqc, default-off, ambient + upstream-only support matrix, force-everywhere caveats)
- test/vitest/istio-pqc.spec.ts: PQC force-mode scenario (gated by PQC_TESTS) asserting the negotiated group, classical-client rejection, and COMPLIANCE_POLICY=pqc on both workloads
- tasks and .github/workflows/test-pqc.yaml: deploy/test wiring for the separate upstream PQC scenario

Validated on k3d: the default-off suite is green (120 vitest + 15 playwright, 0 failed; no COMPLIANCE_POLICY env on either workload) and the PQC scenario is green (3/3 assertions; the tenant gateway negotiates X25519MLKEM768 and rejects classical-only clients).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

- Run the full e2e tests (no regressions)
- Run the PQC specific tests in `istio-pqc.spec.ts`

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
