### PR TITLE
chore(renovate): fix renovate matching for envoy-fips images from cgr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -187,6 +187,14 @@
         "registry1.dso.mil/ironbank/opensource/falcosecurity/falcosidekick"
       ],
       "allowedVersions": "!/99.99.99/"
+    },
+    {
+      "matchPackageNames": [
+        "cgr.dev/defenseunicorns.com/envoy-fips",
+        "docker.io/envoyproxy/envoy"
+      ],
+      "versioning": "regex:^distroless-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "description": "Envoy distroless images use a 'distroless-v<semver>' tag prefix that the default docker versioning rejects as invalid-value, blocking updates"
     }
   ]
 }


### PR DESCRIPTION
## Description
Renovate unable to match envoy-fips image tags.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)


## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
