### PR TITLE
chore(CORE-610): remove java heap workaround

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -185,11 +185,6 @@ packages:
             - name: KEYCLOAK_DEVMODE
               description: "Enables Keycloak dev mode"
               path: devMode
-            # This is a workaround for Keycloak and Kernel 6.12+ memory issue. It will be removed once
-            # https://github.com/defenseunicorns/uds-core/issues/1212 is sorted
-            - name: KEYCLOAK_HEAP_OPTIONS
-              description: "Sets the JAVA_OPTS_KC_HEAP environment variable in Keycloak"
-              path: env[0].value
           values:
             - path: realmInitEnv
               value:
@@ -200,7 +195,3 @@ packages:
                 GOOGLE_IDP_CORE_ENTITY_ID: "https://sso.uds.dev/realms/uds"
                 GOOGLE_IDP_ADMIN_GROUP: "uds-core-dev-admin"
                 GOOGLE_IDP_AUDITOR_GROUP: "uds-core-dev-auditor"
-            - path: env[0]
-              value:
-                name: JAVA_OPTS_KC_HEAP
-                value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -166,11 +166,6 @@ packages:
             - name: KEYCLOAK_DEVMODE
               description: "Enables Keycloak dev mode"
               path: devMode
-            # This is a workaround for Keycloak and Kernel 6.12+ memory issue. It will be removed once
-            # https://github.com/defenseunicorns/uds-core/issues/1212 is sorted
-            - name: KEYCLOAK_HEAP_OPTIONS
-              description: "Sets the JAVA_OPTS_KC_HEAP environment variable in Keycloak"
-              path: env[0].value
             - name: KEYCLOAK_EXTRA_VOLUME_MOUNTS
               description: "Extra volume mounts for Keycloak"
               path: extraVolumeMounts
@@ -196,10 +191,6 @@ packages:
                 GOOGLE_IDP_CORE_ENTITY_ID: "https://sso.uds.dev/realms/uds"
                 GOOGLE_IDP_ADMIN_GROUP: "uds-core-dev-admin"
                 GOOGLE_IDP_AUDITOR_GROUP: "uds-core-dev-auditor"
-            - path: env[0]
-              value:
-                name: JAVA_OPTS_KC_HEAP
-                value: "-XX:MaxRAMPercentage=70 -XX:MinRAMPercentage=70 -XX:InitialRAMPercentage=50 -XX:MaxRAM=1G"
       grafana:
         grafana:
           variables:

--- a/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
+++ b/docs/operations/troubleshooting-and-runbooks/keycloak-credential-recovery.mdx
@@ -47,7 +47,7 @@ This runbook uses the Keycloak [Admin bootstrap and recovery](https://www.keyclo
 3. **Confirm the Keycloak container has at least 1.5G of memory allocated**
 
    > [!CAUTION]
-   > The bootstrap-admin recovery command requires at least 1.5G of memory. You may need to temporarily increase the memory limit before starting. If you use the `JAVA_OPTS_KC_HEAP` environment variable, ensure the `-XX:MaxRAM` setting corresponds to the container memory limits.
+   > The bootstrap-admin recovery command requires at least 1.5G of memory. You may need to temporarily increase the container memory limit before starting.
 
 </Steps>
 
@@ -118,4 +118,3 @@ If this runbook doesn't resolve your issue:
 
 - [Identity & Authorization](/concepts/core-features/identity-and-authorization/) - how Keycloak fits into UDS Core's identity architecture
 - [Keycloak High Availability](/how-to-guides/high-availability/keycloak/) - HA configuration for Keycloak
-


### PR DESCRIPTION
## Description

This issue removed the Keycloak Heap workaround from the UDS Core codebase.

Upstream ticket: https://github.com/keycloak/keycloak/issues/36609

## Related Issue

CORE-610

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

This issue can be automatically tested by invoking `uds run test-uds-core` on the following systems:

* [x] `amd64` Fedora with `6.19.11-200` kernel
* [x] M5 Mac (thank you @s-urbaniak!)
* [x] M4 Mac (thank you @chance-coleman!)
* [x] Ubuntu (thank you @chance-coleman!)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
