### PR TITLE
chore(CORE-606): bump keycloak limits

### DIFF
--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -139,7 +139,7 @@ packages:
             - name: KEYCLOAK_MEMORY_REQUEST
               description: "Memory request for the Keycloak pod"
               path: "resources.requests.memory"
-              default: "512Mi"
+              default: "700Mi"
             - name: KEYCLOAK_CPU_REQUEST
               description: "CPU request for the Keycloak pod"
               path: "resources.requests.cpu"
@@ -147,11 +147,11 @@ packages:
             - name: KEYCLOAK_MEMORY_LIMIT
               description: "Memory limit for the Keycloak pod"
               path: "resources.limits.memory"
-              default: "1Gi"
+              default: "2Gi"
             - name: KEYCLOAK_CPU_LIMIT
               description: "CPU limit for the Keycloak pod"
               path: "resources.limits.cpu"
-              default: "1000m"
+              default: "2"
             - name: KEYCLOAK_WAYPOINT_HPA_ENABLED
               description: "Whether the HPA is enabled for the waypoint"
               path: "waypoint.horizontalPodAutoscaler.enabled"

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -220,8 +220,8 @@ resources:
     cpu: "100m"
     memory: "700Mi"
   limits:
-    cpu: "1"
-    memory: "1Gi"
+    cpu: "2"
+    memory: "2Gi"
 
 # Persistence settings for PVC management (when enabled=false, an emptyDir will be used)
 # `devMode` overrides the enabled flag for `data` and `themes` to allow hot-reloads of the theme/plugin in k3d


### PR DESCRIPTION
## Summary

This PR increases the Keycloak Limits which makes the bootstrapping process faster. Cuts roughly ~1m from the CI job. 

## Related tickets

CORE-606