### PR TITLE
feat: add support for fqdn as host in uds-istio-config

### DIFF
--- a/src/istio/charts/uds-istio-config/templates/_helpers.tpl
+++ b/src/istio/charts/uds-istio-config/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Conditionally expand a hostname with the domain name.
+Must be passed a dictionary containing the "host" and "domain" keys as a scope.
+*/}}
+{{- define "uds-istio-config.expandHost" -}}
+{{- if regexMatch "^\\.$" $.host }}
+{{- $.domain }}
+{{- else if regexMatch "\\.$" $.host }}
+{{- $.host }}
+{{- else }}
+{{- $.host }}.{{ $.domain }}
+{{- end }}
+{{- end }}

--- a/src/istio/charts/uds-istio-config/templates/gateway.yaml
+++ b/src/istio/charts/uds-istio-config/templates/gateway.yaml
@@ -16,10 +16,10 @@ spec:
   selector:
     app: {{ .Values.name }}-ingressgateway
   servers:
-    {{ range $name,$server := .Values.tls.servers }}
+    {{- range $name,$server := .Values.tls.servers }}
     - hosts:
         {{- range $server.hosts | default (list "*") }}
-        - "{{ . }}.{{ $domain }}"
+        - "{{ include "uds-istio-config.expandHost" (dict "host" . "domain" $domain) }}"
         {{- end }}
       port:
         name: "http-{{ $name }}"
@@ -31,7 +31,7 @@ spec:
       {{- end }}
     - hosts:
         {{- range $server.hosts | default (list "*") }}
-        - "{{ . }}.{{ $domain }}"
+        - "{{ include "uds-istio-config.expandHost" (dict "host" . "domain" $domain) }}"
         {{- end }}
       port:
         name: "https-{{ $name }}"
@@ -40,14 +40,14 @@ spec:
       tls:
         mode: {{ $server.mode }}
         {{- if ne $server.mode "PASSTHROUGH" }}
-        {{ if and ($server.tls).cert (not ($server.tls).credentialName) }}
+        {{- if and ($server.tls).cert (not ($server.tls).credentialName) }}
         credentialName: "{{ $name }}-tls"
-        {{ else }}
+        {{- else }}
         credentialName: {{ ($server.tls).credentialName | default $.Values.tls.credentialName | default "gateway-tls" | quote }}
-        {{ end }}
+        {{- end }}
         minProtocolVersion: {{ if $.Values.tls.supportTLSV1_2 }}TLSV1_2{{ else }}TLSV1_3{{ end }}
         {{- end }}
-    {{ end }}
+    {{- end }}
     {{- if .Values.rootDomain.enabled }}
     - hosts:
         - "{{ $domain }}"


### PR DESCRIPTION
## Description

This change allows a fully qualified domain name to be passed as a server host value for the uds-istio-config chart, which prevents the hostname from being expanded with the cluster domain.

For example, for the cluster domain `cluster.example.com`:

- Host `sso` should be expanded to `sso.cluster.example.com`.
- Host `.` should be expanded to `cluster.example.com`.
- Host `sso.example.com` should be expanded to `sso.example.com.cluster.example.com`.
- Host `sso.example.com.` should be expanded to `sso.example.com.`.

## Related Issue

Relates to #2784

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
