### PR TITLE
chore: add grafana portal title annotation

### DIFF
--- a/src/grafana/chart/templates/uds-package.yaml
+++ b/src/grafana/chart/templates/uds-package.yaml
@@ -47,6 +47,8 @@ spec:
         gateway: admin
         port: 80
         targetPort: 3000
+        annotations:
+          portal.uds.dev/title: "Grafana"
         {{- if .Values.uptime.enabled }}
         uptime:
           checks:


### PR DESCRIPTION
## Description

Add portal title annotation to Grafana so that it shows `Grafana` instead of `UDS Core` in portal (the zarf package title annotation). 

## Related Issue

Relates to CORE-613

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- `uds run` check that Grafana icon in portal reads `Grafana`

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
