### PR TITLE
fix(operator): extract SAML IdP cert with a scoped, non-greedy regex

### DIFF
--- a/docs/how-to-guides/identity-and-authorization/register-and-customize-sso-clients.mdx
+++ b/docs/how-to-guides/identity-and-authorization/register-and-customize-sso-clients.mdx
@@ -384,15 +384,23 @@ uds zarf tools kubectl logs -n pepr-system -l app=pepr-uds-core-watcher --tail=5
 
 If you specified `secretConfig.name`, the secret uses that name instead of the default `sso-client-<clientId>`.
 
-### Problem: SAML IdP certificate missing from secret
+### Problem: SAML client fails to reconcile with a certificate error
 
-**Symptom:** The `samlIdpCertificate` key is empty or missing in the generated secret.
+**Symptom:** A `Package` with a SAML client stays in the `Failed` phase, and the status or events reference a failure to get the SAML IdP certificate.
 
-**Solution:** The operator fetches the certificate from Keycloak's SAML descriptor endpoint at `http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/saml/descriptor`. If Keycloak is not ready or the endpoint is unreachable, the certificate will be empty. Verify Keycloak is healthy:
+**Solution:** The operator fetches the realm's signing certificate from Keycloak's SAML descriptor endpoint at `http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/saml/descriptor` and stores it in the secret as `samlIdpCertificate`. If the descriptor is unreachable or contains no signing certificate, the operator fails the reconciliation with a descriptive error instead of writing a broken certificate. Check the `Package` status for the specific error:
+
+```bash
+uds zarf tools kubectl get package <name> -n <namespace> -o jsonpath='{.status}'
+```
+
+If the error is a fetch failure, verify Keycloak is healthy:
 
 ```bash
 uds zarf tools kubectl get pods -n keycloak -l app.kubernetes.io/name=keycloak
 ```
+
+When the realm has more than one active signing key (a normal state during key rotation), the descriptor advertises multiple signing certificates. Keycloak lists them active-key first, so the operator uses the first signing certificate. If your application still fails SAML signature validation after rotation, remove the stale signing key from the realm and trigger the `Package` to reconcile so the secret regenerates.
 
 ## Related documentation
 

--- a/src/pepr/operator/controllers/keycloak/client-sync.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/client-sync.spec.ts
@@ -1,12 +1,21 @@
 /**
- * Copyright 2024 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
+import { X509Certificate } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, MockedFunction, vi } from "vitest";
-import { Sso, UDSPackage } from "../../crd";
+import { Protocol, Sso, UDSPackage } from "../../crd";
 import { syncClient } from "./client-sync";
 import * as clientCredentials from "./clients/client-credentials";
+
+// Shared spy used inside the hoisted vi.mock factory for pepr's fetch. vi.hoisted
+// ensures it is initialized before the (also hoisted) mock factory runs.
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
 
 // Mock the logger before importing the modules that use it
 vi.mock("../../../logger", () => ({
@@ -25,6 +34,7 @@ import {
   convertSsoToClient,
   extractSamlCertificateFromXML,
   generateSecretData,
+  getSamlCertificate,
 } from "./client-sync";
 import { Client } from "./types";
 
@@ -34,6 +44,7 @@ const mockApply = vi.fn().mockImplementation(resource => Promise.resolve(resourc
 // Mock the pepr module
 vi.mock("pepr", () => {
   return {
+    fetch: (...args: unknown[]) => mockFetch(...args),
     K8s: () => ({
       Apply: mockApply,
     }),
@@ -108,38 +119,140 @@ const mockClientStringified: Record<string, string> = {
   standardFlowEnabled: "true",
 };
 
-describe("Test XML Extraction Using Regex", () => {
-  it("extract xml", async () => {
-    // Sample XML string with namespace prefixes
-    const xmlString = `
-    <md:EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://keycloak.admin.uds.dev/realms/uds">
-        <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-            <md:KeyDescriptor use="signing">
-                <ds:KeyInfo>
-                    <ds:KeyName>SO1zm7gOpX2xlm16-pZ08zOJui0i7PwEHIqM6h4d9Sw</ds:KeyName>
-                    <ds:X509Data>
-                        <ds:X509Certificate>FOUND THE CERT</ds:X509Certificate>
-                    </ds:X509Data>
-                </ds:KeyInfo>
-            </md:KeyDescriptor>
-            <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml/resolve" index="0"></md:ArtifactResolutionService>
-            <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleLogoutService>
-            <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleLogoutService>
-            <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleLogoutService>
-            <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleLogoutService>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
-            <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
-            <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleSignOnService>
-            <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleSignOnService>
-            <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleSignOnService>
-            <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleSignOnService>
-        </md:IDPSSODescriptor>
-    </md:EntityDescriptor>
-    `;
+// Builds a SAML IdP descriptor modeled on a real Keycloak descriptor: the
+// KeyDescriptors use the `ds:` prefix and elements use the `md:` prefix, as
+// Keycloak does. `signingKeys` describes the signing KeyDescriptors in the order
+// Keycloak would emit them (active key first).
+function buildDescriptor({
+  signingKeys = [],
+  encryptionCert,
+}: {
+  signingKeys?: { keyName?: string; cert?: string }[];
+  encryptionCert?: string;
+}) {
+  const keyDescriptors = signingKeys
+    .map(
+      k => `
+      <md:KeyDescriptor use="signing">
+        <ds:KeyInfo>
+          ${k.keyName !== undefined ? `<ds:KeyName>${k.keyName}</ds:KeyName>` : ""}
+          <ds:X509Data>
+            ${k.cert !== undefined ? `<ds:X509Certificate>${k.cert}</ds:X509Certificate>` : ""}
+          </ds:X509Data>
+        </ds:KeyInfo>
+      </md:KeyDescriptor>`,
+    )
+    .join("");
 
-    expect(extractSamlCertificateFromXML(xmlString)).toEqual("FOUND THE CERT");
+  const encryptionDescriptor =
+    encryptionCert !== undefined
+      ? `
+      <md:KeyDescriptor use="encryption">
+        <ds:KeyInfo>
+          <ds:X509Data>
+            <ds:X509Certificate>${encryptionCert}</ds:X509Certificate>
+          </ds:X509Data>
+        </ds:KeyInfo>
+      </md:KeyDescriptor>`
+      : "";
+
+  const idpDescriptor = `
+    <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">${keyDescriptors}${encryptionDescriptor}
+      <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://keycloak.admin.uds.dev/realms/uds/protocol/saml"></md:SingleSignOnService>
+    </md:IDPSSODescriptor>`;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="https://keycloak.admin.uds.dev/realms/uds">${idpDescriptor}
+</md:EntityDescriptor>`;
+}
+
+describe("extractSamlCertificateFromXML", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the certificate for a single signing KeyDescriptor", () => {
+    const xml = buildDescriptor({
+      signingKeys: [{ keyName: "KEY-1", cert: "CERT-ONE" }],
+    });
+    expect(extractSamlCertificateFromXML(xml)).toEqual("CERT-ONE");
+  });
+
+  it("returns the first signing cert (the active key) when multiple are present", () => {
+    // Regression for the original bug: a greedy match ran the two certificates
+    // together. Keycloak sorts signing keys active-first, so the first is correct.
+    const xml = buildDescriptor({
+      signingKeys: [
+        { keyName: "KEY-1", cert: "CERT-ONE" },
+        { keyName: "KEY-2", cert: "CERT-TWO" },
+      ],
+    });
+    const result = extractSamlCertificateFromXML(xml);
+    expect(result).toEqual("CERT-ONE");
+    // No XML fragments leak into the extracted certificate
+    expect(result).not.toContain("<");
+    expect(result).not.toContain("KeyDescriptor");
+  });
+
+  it("ignores encryption KeyDescriptors", () => {
+    const xml = buildDescriptor({
+      signingKeys: [{ keyName: "KEY-1", cert: "SIGNING-CERT" }],
+      encryptionCert: "ENCRYPTION-CERT",
+    });
+    expect(extractSamlCertificateFromXML(xml)).toEqual("SIGNING-CERT");
+  });
+
+  it("strips whitespace and line breaks from the certificate", () => {
+    const xml = buildDescriptor({
+      signingKeys: [{ keyName: "KEY-1", cert: "CERT\n  WITH\n  BREAKS" }],
+    });
+    expect(extractSamlCertificateFromXML(xml)).toEqual("CERTWITHBREAKS");
+  });
+
+  it("throws when there is no signing X509Certificate", () => {
+    const xml = buildDescriptor({
+      signingKeys: [{ keyName: "KEY-1" }],
+    });
+    expect(() => extractSamlCertificateFromXML(xml)).toThrow(/no signing X509Certificate/);
+  });
+
+  // Real-shape descriptor: exercises the extraction against a full Keycloak SAML
+  // IdP descriptor captured during a signing-key rotation (two signing keys, a
+  // signed descriptor, and the usual service endpoints).
+  it("extracts the active signing cert from a real rotation descriptor fixture", () => {
+    const xml = readFileSync(join(__dirname, "testdata", "saml-descriptor-rotation.xml"), "utf-8");
+
+    const result = extractSamlCertificateFromXML(xml);
+
+    // No XML fragments leaked into the certificate (the original bug)
+    expect(result).not.toContain("<");
+    expect(result).not.toContain("KeyDescriptor");
+
+    // The result is a single, valid X509 certificate, and it is the descriptor's
+    // active signing key (the first signing KeyDescriptor, which Keycloak sorts
+    // active-key first) rather than the previous, still-advertised key.
+    const cert = new X509Certificate(Buffer.from(result, "base64"));
+    expect(cert.subject).toContain("uds-realm-key-1");
+    expect(cert.subject).not.toContain("uds-realm-key-2");
+  });
+});
+
+describe("getSamlCertificate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when the descriptor fetch fails", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503, statusText: "Service Unavailable" });
+    await expect(getSamlCertificate()).rejects.toThrow(/503, Service Unavailable/);
+  });
+
+  it("returns the extracted certificate on a successful fetch", async () => {
+    const xml = buildDescriptor({
+      signingKeys: [{ keyName: "KEY-1", cert: "FETCHED-CERT" }],
+    });
+    mockFetch.mockResolvedValueOnce({ ok: true, data: xml });
+    await expect(getSamlCertificate()).resolves.toEqual("FETCHED-CERT");
   });
 });
 
@@ -433,5 +546,80 @@ describe("syncClient secretConfig preservation", () => {
     // Use type assertion to fix TypeScript error
     const appliedResource = mockApply.mock.calls[0][0] as { metadata: { name: string } };
     expect(appliedResource.metadata.name).toBe("custom-secret-name");
+  });
+});
+
+describe("syncClient SAML certificate handling", () => {
+  const mockPkg: UDSPackage = {
+    apiVersion: "uds.dev/v1alpha1",
+    kind: "Package",
+    metadata: {
+      name: "test-package",
+      namespace: "test-namespace",
+      generation: 1,
+    },
+    spec: {},
+  };
+
+  const mockSamlSso: Sso = {
+    clientId: "test-client",
+    name: "Test Client",
+    protocol: Protocol.Saml,
+  };
+
+  const descriptorXml = buildDescriptor({
+    signingKeys: [{ keyName: "KEY-1", cert: "SAML-SIGNING-CERT" }],
+  });
+
+  let mockCredentialsCreateOrUpdate: MockedFunction<
+    typeof clientCredentials.credentialsCreateOrUpdate
+  >;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCredentialsCreateOrUpdate = clientCredentials.credentialsCreateOrUpdate as MockedFunction<
+      typeof clientCredentials.credentialsCreateOrUpdate
+    >;
+    mockCredentialsCreateOrUpdate.mockResolvedValue({
+      id: "test-id",
+      clientId: "test-client",
+      protocol: "saml",
+      secret: "generated-secret",
+    } as Client & { id: string });
+  });
+
+  it("stores the fetched SAML IdP certificate in the secret", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, data: descriptorXml });
+
+    await syncClient(mockSamlSso, mockPkg);
+
+    const appliedResource = mockApply.mock.calls[0][0] as { data: Record<string, string> };
+    expect(Buffer.from(appliedResource.data.samlIdpCertificate, "base64").toString()).toBe(
+      "SAML-SIGNING-CERT",
+    );
+  });
+
+  it("retries the descriptor fetch once on a transient failure", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: "Service Unavailable" })
+      .mockResolvedValueOnce({ ok: true, data: descriptorXml });
+
+    await syncClient(mockSamlSso, mockPkg);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const appliedResource = mockApply.mock.calls[0][0] as { data: Record<string, string> };
+    expect(Buffer.from(appliedResource.data.samlIdpCertificate, "base64").toString()).toBe(
+      "SAML-SIGNING-CERT",
+    );
+  });
+
+  it("fails with client and package context when the descriptor fetch keeps failing", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 503, statusText: "Service Unavailable" });
+
+    await expect(syncClient(mockSamlSso, mockPkg)).rejects.toThrow(
+      /Failed to get SAML IdP certificate for client 'test-client', package test-namespace\/test-package/,
+    );
+    // Initial attempt plus one retry
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/pepr/operator/controllers/keycloak/client-sync.ts
+++ b/src/pepr/operator/controllers/keycloak/client-sync.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -9,6 +9,7 @@ import { Component, setupLogger } from "../../../logger";
 import { Sso, UDSPackage } from "../../crd";
 import { getOwnerRef, purgeOrphans, sanitizeResourceName } from "../utils";
 import { credentialsCreateOrUpdate, credentialsDelete } from "./clients/client-credentials";
+import { throwErrorIfNeeded } from "./clients/common";
 import { Client, clientKeys } from "./types";
 
 const samlDescriptorUrl =
@@ -20,15 +21,16 @@ const secretTemplateRegex = new RegExp(
   "gm",
 );
 
-// Template regex to match IDPSSODescriptor in the SAML IDP Descriptor XML, see https://regex101.com/r/DGvzjd/1
-const idpSSODescriptorRegex = new RegExp(
-  /<[^>]*:IDPSSODescriptor[^>]*>((.|[\n\r])*)<\/[^>]*:IDPSSODescriptor>/,
-);
+// Matches a signing KeyDescriptor block, non-greedy so that a descriptor
+// advertising multiple signing keys (the normal state during signing key
+// rotation) does not collapse into one greedy match spanning every certificate,
+// which was the original bug. Keycloak sorts signing KeyDescriptors active-key
+// first, so the first match holds the realm's active signing key.
+const signingKeyDescriptorRegex =
+  /<[^>]*:KeyDescriptor[^>]*use="signing"[^>]*>([\s\S]*?)<\/[^>]*:KeyDescriptor>/;
 
-// Template regex to match the X509Certificate within the IDPSSODescriptor XML, see https://regex101.com/r/NjGZF5/1
-const x509CertRegex = new RegExp(
-  /<[^>]*:X509Certificate[^>]*>((.|[\n\r])*)<\/[^>]*:X509Certificate>/,
-);
+// Matches the X509Certificate within a KeyDescriptor block.
+const x509CertRegex = /<[^>]*:X509Certificate[^>]*>([\s\S]*?)<\/[^>]*:X509Certificate>/;
 
 // configure subproject logger
 const log = setupLogger(Component.OPERATOR_KEYCLOAK);
@@ -123,53 +125,51 @@ export function convertSsoToClient(sso: Partial<Sso>): Client {
   return client as Client;
 }
 
-export async function syncClient(
-  { secretConfig, ...clientReq }: Sso,
-  pkg: UDSPackage,
-  isRetry = false,
-) {
+/**
+ * Run a Keycloak operation, retrying once on failure to tolerate intermittent
+ * errors. If the retry also fails, an error carrying the provided context is
+ * thrown so the failure surfaces on the Package CR.
+ *
+ * @param operation the operation to run
+ * @param failureContext description of the operation used in error/log messages
+ */
+async function retryOnce<T>(operation: () => Promise<T>, failureContext: string): Promise<T> {
+  try {
+    return await operation();
+  } catch (err) {
+    const msg = `${failureContext}. Error: ${err.message}`;
+    log.error(`${msg}, retrying...`);
+    try {
+      return await operation();
+    } catch (retryErr) {
+      // Log the retry error but throw the original context since the retry failed
+      log.error(`${failureContext}, retry failed. Error: ${retryErr.message}`);
+      throw new Error(msg);
+    }
+  }
+}
+
+export async function syncClient({ secretConfig, ...clientReq }: Sso, pkg: UDSPackage) {
   log.debug(pkg.metadata, `Processing client request: ${clientReq.clientId}`);
 
   // Not including the CR data in the ref because Keycloak client IDs must be unique already
   const name = `sso-client-${clientReq.clientId}`;
   let client = convertSsoToClient(clientReq);
+  const pkgRef = `${pkg.metadata?.namespace}/${pkg.metadata?.name}`;
 
-  try {
-    client = await credentialsCreateOrUpdate(client);
-  } catch (err) {
-    const msg =
-      `Failed to process Keycloak request for client '${client.clientId}', package ` +
-      `${pkg.metadata?.namespace}/${pkg.metadata?.name}. Error: ${err.message}`;
-
-    // Throw the error if this is the retry or was an initial client creation attempt
-    if (isRetry) {
-      log.error(`${msg}, retry failed.`);
-      // Throw the original error captured from the first attempt
-      throw new Error(msg);
-    } else {
-      // Retry the request in case it is an intermittent failure
-      log.error(`${msg}, retrying...`);
-
-      try {
-        // Ensure we pass the same inputs to this function, including the secretConfig
-        return await syncClient({ secretConfig, ...clientReq }, pkg, true);
-      } catch (retryErr) {
-        // If the retry fails, log the retry error and throw the original error
-        const retryMsg =
-          `Retry of Keycloak request failed for client '${client.clientId}', package ` +
-          `${pkg.metadata?.namespace}/${pkg.metadata?.name}. Error: ${retryErr.message}`;
-        log.error(retryMsg);
-        // Throw the error from the original attempt since our retry failed
-        throw new Error(msg);
-      }
-    }
-  }
+  client = await retryOnce(
+    () => credentialsCreateOrUpdate(client),
+    `Failed to process Keycloak request for client '${client.clientId}', package ${pkgRef}`,
+  );
 
   // Remove the registrationAccessToken from the client object to avoid problems (one-time use token)
   delete client.registrationAccessToken;
 
   if (client.protocol === "saml") {
-    client.samlIdpCertificate = await getSamlCertificate();
+    client.samlIdpCertificate = await retryOnce(
+      () => getSamlCertificate(),
+      `Failed to get SAML IdP certificate for client '${client.clientId}', package ${pkgRef}`,
+    );
   }
 
   // Create or update the client secret
@@ -239,17 +239,31 @@ export function generateSecretData(client: Client, secretTemplate?: { [key: stri
 
 export async function getSamlCertificate() {
   const resp = await fetch<string>(samlDescriptorUrl);
-
-  if (!resp.ok) {
-    return undefined;
-  }
-
+  await throwErrorIfNeeded(resp);
   return extractSamlCertificateFromXML(resp.data);
 }
 
-export function extractSamlCertificateFromXML(xmlString: string) {
-  const extractedIDPSSODescriptor = xmlString.match(idpSSODescriptorRegex)?.[1] || "";
-  return extractedIDPSSODescriptor.match(x509CertRegex)?.[1] || "";
+/**
+ * Extract the realm's active signing certificate from the SAML IdP descriptor XML.
+ *
+ * A realm can advertise multiple signing KeyDescriptors (normal during signing-key
+ * rotation). Keycloak sorts them active-key first, so the first signing
+ * KeyDescriptor holds the realm's active signing key. Matching that block
+ * non-greedily keeps the certificates from running together (the original bug).
+ *
+ * Throws when no signing certificate is found so the error surfaces on the Package
+ * CR instead of silently provisioning a broken secret.
+ */
+export function extractSamlCertificateFromXML(xmlString: string): string {
+  const signingKeyDescriptor = xmlString.match(signingKeyDescriptorRegex)?.[1];
+  // Keycloak may line-wrap the base64; strip all whitespace.
+  const cert = signingKeyDescriptor?.match(x509CertRegex)?.[1]?.replace(/\s+/g, "");
+
+  if (!cert) {
+    throw new Error("SAML IdP descriptor contains no signing X509Certificate");
+  }
+
+  return cert;
 }
 
 /**

--- a/src/pepr/operator/controllers/keycloak/client-sync.ts
+++ b/src/pepr/operator/controllers/keycloak/client-sync.ts
@@ -25,7 +25,7 @@ const secretTemplateRegex = new RegExp(
 // advertising multiple signing keys (the normal state during signing key
 // rotation) does not collapse into one greedy match spanning every certificate,
 // which was the original bug. Keycloak sorts signing KeyDescriptors active-key
-// first, so the first match holds the realm's active signing key.
+// first, so the first match holds the realm's active signing key. See https://regex101.com/r/YrDx8V/1
 const signingKeyDescriptorRegex =
   /<[^>]*:KeyDescriptor[^>]*use="signing"[^>]*>([\s\S]*?)<\/[^>]*:KeyDescriptor>/;
 

--- a/src/pepr/operator/controllers/keycloak/client-sync.ts
+++ b/src/pepr/operator/controllers/keycloak/client-sync.ts
@@ -29,7 +29,7 @@ const secretTemplateRegex = new RegExp(
 const signingKeyDescriptorRegex =
   /<[^>]*:KeyDescriptor[^>]*use="signing"[^>]*>([\s\S]*?)<\/[^>]*:KeyDescriptor>/;
 
-// Matches the X509Certificate within a KeyDescriptor block.
+// Matches the X509Certificate within a KeyDescriptor block. See https://regex101.com/r/NjGZF5/4
 const x509CertRegex = /<[^>]*:X509Certificate[^>]*>([\s\S]*?)<\/[^>]*:X509Certificate>/;
 
 // configure subproject logger

--- a/src/pepr/operator/controllers/keycloak/testdata/saml-descriptor-rotation.xml
+++ b/src/pepr/operator/controllers/keycloak/testdata/saml-descriptor-rotation.xml
@@ -1,7 +1,7 @@
-/**
- * Copyright 2025-2026 Defense Unicorns
- * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
- */
+<!--
+  Copyright 2025-2026 Defense Unicorns
+  SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Representative Keycloak SAML IdP descriptor for realm "uds", captured during a

--- a/src/pepr/operator/controllers/keycloak/testdata/saml-descriptor-rotation.xml
+++ b/src/pepr/operator/controllers/keycloak/testdata/saml-descriptor-rotation.xml
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2025-2026 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Representative Keycloak SAML IdP descriptor for realm "uds", captured during a
+  signing-key rotation: two active signing keys. Keycloak sorts signing
+  KeyDescriptors active-key first, so the first signing KeyDescriptor (KID Xk9LpWv7yZ0aB1cD4eF5gH6iJ8kL9mN0oPq3nRfT2mQ)
+  is the realm's active signing key.
+
+  This descriptor is signed (dsig:Signature below), and the signer is that same
+  first/active key. Keycloak only emits the Signature block when realm metadata
+  signing is enabled, so it is not always present; the operator therefore does not
+  rely on it and simply takes the first signing KeyDescriptor. See issue #2798.
+
+  KIDs are synthetic and certificates are self-signed test certs (not from a
+  production realm). To refresh this fixture, curl the in-cluster descriptor
+  endpoint: /realms/uds/protocol/saml/descriptor
+-->
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="ID_7bf3c9e21a4d4e8b9c2f5d6a7b8c9d0e1f2a3b4c" entityID="https://sso.uds.dev/realms/uds">
+  <dsig:Signature xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+    <dsig:SignedInfo>
+      <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <dsig:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <dsig:Reference URI="#ID_7bf3c9e21a4d4e8b9c2f5d6a7b8c9d0e1f2a3b4c">
+        <dsig:Transforms>
+          <dsig:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <dsig:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        </dsig:Transforms>
+        <dsig:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <dsig:DigestValue>bxM9aQ2Zk1p0Rv7yZ0aB1cD4eF5gH6iJ8kL9mN0oPq=</dsig:DigestValue>
+      </dsig:Reference>
+    </dsig:SignedInfo>
+    <dsig:SignatureValue>c2lnbmF0dXJldmFsdWVwbGFjZWhvbGRlcmZvcnRlc3RmaXh0dXJl</dsig:SignatureValue>
+    <dsig:KeyInfo>
+      <dsig:KeyName>Xk9LpWv7yZ0aB1cD4eF5gH6iJ8kL9mN0oPq3nRfT2mQ</dsig:KeyName>
+      <dsig:X509Data>
+        <dsig:X509Certificate>MIIDFTCCAf2gAwIBAgIUJmYlnwvJEh8VoJTH1DrWXBllE7IwDQYJKoZIhvcNAQELBQAwGjEYMBYGA1UEAwwPdWRzLXJlYWxtLWtleS0xMB4XDTI2MDcxMDE5NDA1M1oXDTM2MDcwNzE5NDA1M1owGjEYMBYGA1UEAwwPdWRzLXJlYWxtLWtleS0xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAskYwWSj04g2M6sXO5nuo0loLgpRhGjnnqhIsT5vBacM7dE8WLECEwkykHIizs7qd1YsRljJcwUpkT8n7KZap1qMH2bHL0Nj2acdTyBSBRu0wv4LjzrkptdlvjUvjrrNYjApGq/C4Za3iEyD3URiQzxGMRJMxPY4kRU3PmV4MTFPMsWqWSWvW8JiIzts2vd07e9nR+8joAFP2gASHckIqRcJTnqYl6NkAm8zIQvDYkBXrZ+eK/59caQPR7Dj7LBWitWh2uL7Wwd4w9SkjsFIhJBGFGTCajq2P0C0dHn6pf6tqwQTjYMKx2CuvwM2ht2Duy6Ph11ZCMgj0R9yrTb8nCQIDAQABo1MwUTAdBgNVHQ4EFgQUO/qldFl1bG50d7X340A/ltCXfkkwHwYDVR0jBBgwFoAUO/qldFl1bG50d7X340A/ltCXfkkwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAd2HjPrKMJ14oj9vY2/0jvtpZPQn1HmYuH/pCFzWSgRZwwc3ytxAszKMsoq3d+wO5G8aXvoxK1JN0oU7RlMc2eEePZxSyTepBiWjk/a9trS7jSYHvLIJ0eXw9IIkexX9RkCSmVZZP/jNRL2GQAUUuP+M+zGMuSvP66F+xmGWPLX0SvP5wdCNfFNvgza9Kiupve8akiMtLZtVL6AKGnnW/Z/Bbvrnzu5I79jogV8aojghK7JUicdRKb4x1WuupyBMe+kJvvVKP28oO/FUaX63dATd9vxm9TzpDZOi+GoPGyntu9gpguiyuLxj6nSxTG9IiAJyleNm/p+/dFg2CtP2iDg==</dsig:X509Certificate>
+      </dsig:X509Data>
+    </dsig:KeyInfo>
+  </dsig:Signature>
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:KeyName>Xk9LpWv7yZ0aB1cD4eF5gH6iJ8kL9mN0oPq3nRfT2mQ</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDFTCCAf2gAwIBAgIUJmYlnwvJEh8VoJTH1DrWXBllE7IwDQYJKoZIhvcNAQELBQAwGjEYMBYGA1UEAwwPdWRzLXJlYWxtLWtleS0xMB4XDTI2MDcxMDE5NDA1M1oXDTM2MDcwNzE5NDA1M1owGjEYMBYGA1UEAwwPdWRzLXJlYWxtLWtleS0xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAskYwWSj04g2M6sXO5nuo0loLgpRhGjnnqhIsT5vBacM7dE8WLECEwkykHIizs7qd1YsRljJcwUpkT8n7KZap1qMH2bHL0Nj2acdTyBSBRu0wv4LjzrkptdlvjUvjrrNYjApGq/C4Za3iEyD3URiQzxGMRJMxPY4kRU3PmV4MTFPMsWqWSWvW8JiIzts2vd07e9nR+8joAFP2gASHckIqRcJTnqYl6NkAm8zIQvDYkBXrZ+eK/59caQPR7Dj7LBWitWh2uL7Wwd4w9SkjsFIhJBGFGTCajq2P0C0dHn6pf6tqwQTjYMKx2CuvwM2ht2Duy6Ph11ZCMgj0R9yrTb8nCQIDAQABo1MwUTAdBgNVHQ4EFgQUO/qldFl1bG50d7X340A/ltCXfkkwHwYDVR0jBBgwFoAUO/qldFl1bG50d7X340A/ltCXfkkwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAd2HjPrKMJ14oj9vY2/0jvtpZPQn1HmYuH/pCFzWSgRZwwc3ytxAszKMsoq3d+wO5G8aXvoxK1JN0oU7RlMc2eEePZxSyTepBiWjk/a9trS7jSYHvLIJ0eXw9IIkexX9RkCSmVZZP/jNRL2GQAUUuP+M+zGMuSvP66F+xmGWPLX0SvP5wdCNfFNvgza9Kiupve8akiMtLZtVL6AKGnnW/Z/Bbvrnzu5I79jogV8aojghK7JUicdRKb4x1WuupyBMe+kJvvVKP28oO/FUaX63dATd9vxm9TzpDZOi+GoPGyntu9gpguiyuLxj6nSxTG9IiAJyleNm/p+/dFg2CtP2iDg==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:KeyName>q8SbsBY9Lf0_Atgo3UNfpbnByCn8IOYl_pT31U0e9cg</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDFTCCAf2gAwIBAgIUB3wD3NT8tUiGX2l5MSS4JEpVkZkwDQYJKoZIhvcNAQELBQAwGjEYMBYGA1UEAwwPdWRzLXJlYWxtLWtleS0yMB4XDTI2MDcxMDE5NDA1M1oXDTM2MDcwNzE5NDA1M1owGjEYMBYGA1UEAwwPdWRzLXJlYWxtLWtleS0yMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApGWDkAfKifbgVgdXDV38rY1fNouEmEf1rpVVIfbc3tw7AOxwJYk/jJTMAmspgvvy8xlGjrkvlcdDgq+1w3z542pjTEPoVShg+q5oOcSApQy+Nq4wBvzVaRiZ+/3vrNOBI2TDc9gyBELArhladV0PFhVNhU1rznkJSK08fC0EcCvTrRLRqiYa7pZXwRpr1ee4CRBgDnlJvSglph/fnSIr5yZeYilZO973OJn50vUEAf02JLrozDQi4dRtCt7aaDz8tDeJQMWcbXt3kyOcZ6jDW4LXnnhJGjAy/s0wa9lg2E9dRdPD4I1zBjoqewjs6uRPb+73rlughlpExsARvaWX6wIDAQABo1MwUTAdBgNVHQ4EFgQUTrpJc7a1owOxGy7qcCsOh4hoHjQwHwYDVR0jBBgwFoAUTrpJc7a1owOxGy7qcCsOh4hoHjQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAl9oBxlguB8L+HkpfCd1Yw5uByyYXk0+TO3ifkk99wu1CSCr98FvM0pzV/TErZBR2Q0AyvhAHGyrK9hZNplAhz7yNSXLMYSttjLAkWn0L6P8Cx01FESu3jIDR4h5HkP3d336iMoiwQirx54StpU6y9nS74oVpfGP0AAa+yk61FlbYzHIyUo1O8GOgqjDDOWUIyBGbJUaDDzVHfvEdbuqT4GhzVJg0TrCu/0FuQduxanm6fnEOVl7bDAFhuDjGalGQZx4PV97YSE4svdK2LVwM6s76pKGxEGbNkBqkmrO3S9HAz5DAStk3gknVUxuGrexPurQ5qqLRQksHibgSZU+mFg==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sso.uds.dev/realms/uds/protocol/saml/resolve" index="0"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://sso.uds.dev/realms/uds/protocol/saml"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>


### PR DESCRIPTION
## Description

The operator read the SAML IdP signing certificate from Keycloak's descriptor endpoint (`/realms/uds/protocol/saml/descriptor`) using a greedy regex:

```
/<[^>]*:X509Certificate[^>]*>((.|[\n\r])*)<\/[^>]*:X509Certificate>/
```

When a realm has more than one active signing key — the normal, recommended state during signing-key rotation — the `IDPSSODescriptor` advertises multiple `X509Certificate` elements. The greedy capture group matched from the first opening tag all the way to the last closing tag, so `samlIdpCertificate` in the generated SSO secret became a corrupt blob: `cert1 + intervening descriptor XML + cert2`. That is not a valid certificate and breaks SAML signature validation in the consuming application. The operator surfaced no error; the failure only appeared downstream. (Reproduction: [https://regex101.com/r/NjGZF5/2](<https://regex101.com/r/NjGZF5/2>))

### Fix

Scope the match to a single `use="signing"` `KeyDescriptor` block and make the capture non-greedy, so multiple certificates can no longer run together. Keycloak sorts signing `KeyDescriptor`s active-key first (verified against the Keycloak signing path, including priority ties), so the **first** signing certificate is the realm's active key — no key-name or descriptor-signature matching is required.

An earlier iteration matched the descriptor's `dsig:Signature` `KeyName` to pick the active key, but that block is only emitted when realm metadata signing is enabled, so it is not reliable; take-first is both simpler and correct. No XML-parser dependency is added.

### Behavior change

Failures now surface on the `Package` CR instead of silently provisioning a broken secret:

* A failed descriptor fetch (which previously returned `undefined` and was written to the secret as the literal base64 string `"undefined"`) now throws.
* A descriptor with no signing certificate now throws.

Both fail the `Package` reconcile with a message naming the client and package. The descriptor fetch also retries once on a transient error, using a small shared `retryOnce` helper that the existing `credentialsCreateOrUpdate` call now shares (previously a bespoke recursive retry).

### Workaround for affected versions

In Keycloak, remove the stale realm signing key so the descriptor advertises a single signing certificate, then trigger the `Package` CR to reconcile so the secret regenerates.

## Related Issue

Fixes defenseunicorns/uds-core#2798

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

1. Deploy UDS Core with Identity & Authorization enabled.
2. In the `uds` realm, rotate the SAML signing key so two RSA signing keys are active at once. Confirm the descriptor advertises two `<md:KeyDescriptor use="signing">` entries:

   ```bash
   uds zarf tools kubectl run curl --rm -it --image=curlimages/curl --restart=Never -- \
     curl -s http://keycloak-http.keycloak.svc.cluster.local:8080/realms/uds/protocol/saml/descriptor
   ```
3. Deploy a `Package` with a `protocol: saml` SSO client.
4. Confirm `samlIdpCertificate` in the generated secret is a single valid base64 certificate (the first/active signing key) with no embedded XML:

   ```bash
   uds zarf tools kubectl get secret sso-client-<clientId> -n <namespace> \
     -o jsonpath='{.data.samlIdpCertificate}' | base64 -d | openssl x509 -noout -subject
   ```
5. Regression: with a single active signing key, confirm the same certificate is extracted as before.
6. Failure surfacing: point the operator at an unreachable/broken descriptor and confirm the `Package` enters `Failed` with an error naming the client and package, rather than writing a bad secret:

   ```bash
   uds zarf tools kubectl get package <name> -n <namespace> -o jsonpath='{.status}'
   ```

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](<https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md>) followed