### PR TITLE
docs: added manual steps for 1.6 User Profile Provider migration

### DIFF
--- a/docs/operations/release-notes/1-6.mdx
+++ b/docs/operations/release-notes/1-6.mdx
@@ -79,7 +79,7 @@ Apply the following steps once per cluster after upgrading to UDS Core 1.6:
 
 3. **Create the `usercertificateSKI` attribute**
 
-   Add the following json to the attributes array below usercertificateCN:
+   Add the following JSON to the attributes array below `usercertificateCN`:
    <Code code={jsonCode} lang="json" />
 
 </Steps>

--- a/docs/operations/release-notes/1-6.mdx
+++ b/docs/operations/release-notes/1-6.mdx
@@ -66,7 +66,7 @@ Identity Config [0.28.0](https://github.com/defenseunicorns/uds-identity-config/
 
 #### Manual realm changes (Identity Config 0.28.0)
 
-Apply the following steps once per cluster after upgrading to UDS Core 1.7:
+Apply the following steps once per cluster after upgrading to UDS Core 1.6:
 
 <Steps>
 1. **Open the Keycloak admin console and switch to the `uds` realm**

--- a/docs/operations/release-notes/1-6.mdx
+++ b/docs/operations/release-notes/1-6.mdx
@@ -5,23 +5,7 @@ sidebar:
   order: 3.989
 ---
 
-import { Steps, Code } from "@astrojs/starlight/components";
-
-export const jsonCode = `{
-  "name": "usercertificateSKI",
-  "displayName": "x509 User SKI",
-  "validations": {},
-  "annotations": {},
-  "permissions": {
-    "view": [
-      "admin"
-    ],
-    "edit": [
-      "admin"
-    ]
-  },
-  "multivalued": false
-}`
+import { Steps } from "@astrojs/starlight/components";
 
 > [!NOTE]
 > For general upgrade procedures, see the [Upgrade Overview](/operations/upgrades/overview/).
@@ -80,7 +64,23 @@ Apply the following steps once per cluster after upgrading to UDS Core 1.6:
 3. **Create the `usercertificateSKI` attribute**
 
    Add the following JSON to the attributes array below `usercertificateCN`:
-   <Code code={jsonCode} lang="json" />
+   ```json
+   {
+     "name": "usercertificateSKI",
+     "displayName": "x509 User SKI",
+     "validations": {},
+     "annotations": {},
+     "permissions": {
+       "view": [
+         "admin"
+       ],
+       "edit": [
+         "admin"
+       ]
+     },
+     "multivalued": false
+   }
+   ```
 
 </Steps>
 

--- a/docs/operations/release-notes/1-6.mdx
+++ b/docs/operations/release-notes/1-6.mdx
@@ -5,6 +5,24 @@ sidebar:
   order: 3.989
 ---
 
+import { Steps, Code } from "@astrojs/starlight/components";
+
+export const jsonCode = `{
+  "name": "usercertificateSKI",
+  "displayName": "x509 User SKI",
+  "validations": {},
+  "annotations": {},
+  "permissions": {
+    "view": [
+      "admin"
+    ],
+    "edit": [
+      "admin"
+    ]
+  },
+  "multivalued": false
+}`
+
 > [!NOTE]
 > For general upgrade procedures, see the [Upgrade Overview](/operations/upgrades/overview/).
 
@@ -46,7 +64,25 @@ Identity Config [0.28.0](https://github.com/defenseunicorns/uds-identity-config/
 - Bumps the internal Keycloak compile dependency to 26.6.3 (security update); the deployed Keycloak server version remains 26.6.2.
 - Updates branding references to "Unified Defense Stack".
 
-No manual realm changes are required for this release.
+#### Manual realm changes (Identity Config 0.28.0)
+
+Apply the following steps once per cluster after upgrading to UDS Core 1.7:
+
+<Steps>
+1. **Open the Keycloak admin console and switch to the `uds` realm**
+
+   Sign in with an admin account, then select the `uds` realm from the realm selector.
+
+2. **Navigate to the User Profile JSON Editor**
+
+   In the left sidebar click **Realm Settings**, select the **User Profile** tab, then select the **JSON Editor** tab.
+
+3. **Create the `usercertificateSKI` attribute**
+
+   Add the following json to the attributes array below usercertificateCN:
+   <Code code={jsonCode} lang="json" />
+
+</Steps>
 
 ## Related documentation
 

--- a/docs/operations/release-notes/1-6.mdx
+++ b/docs/operations/release-notes/1-6.mdx
@@ -81,6 +81,7 @@ Apply the following steps once per cluster after upgrading to UDS Core 1.6:
      "multivalued": false
    }
    ```
+   Click **Save** to apply the change.
 
 </Steps>
 


### PR DESCRIPTION
## Description

Adds the manual migration steps to update the user profile provider to include the new usercertificateSKI attribute.

## Related Issue

Fixes CORE-621

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
