### PR TITLE
chore: add retries to fix flakey fleet keycloak test

### DIFF
--- a/test/vitest/keycloak-fleet-admin.spec.ts
+++ b/test/vitest/keycloak-fleet-admin.spec.ts
@@ -135,7 +135,8 @@ set -eu
 token_response="$(mktemp)"
 trap 'rm -f "$token_response"' EXIT
 
-token_status="$(curl -sS -o "$token_response" -w "%{http_code}" -X POST "${keycloakPath(`/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`)}" \
+token_status="$(curl -sS --retry 5 --retry-all-errors --retry-delay 1 --retry-max-time 20 \
+  -o "$token_response" -w "%{http_code}" -X POST "${keycloakPath(`/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`)}" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   --data-urlencode "grant_type=client_credentials" \
   --data-urlencode "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \

--- a/test/vitest/keycloak-fleet-admin.spec.ts
+++ b/test/vitest/keycloak-fleet-admin.spec.ts
@@ -190,12 +190,14 @@ trap 'rm -f "$response_body" "$request_body"' EXIT
 
 if [ -n "$body" ]; then
   printf '%s' "$body" > "$request_body"
-  status="$(curl -sS -o "$response_body" -w "%{http_code}" -X "$method" "$url" \
+  status="$(curl -sS --retry 5 --retry-all-errors --retry-delay 1 --retry-max-time 20 \
+    -o "$response_body" -w "%{http_code}" -X "$method" "$url" \
     -H "Authorization: Bearer $(cat "${ACCESS_TOKEN_PATH}")" \
     -H "Content-Type: application/json" \
     --data-binary "@$request_body")"
 else
-  status="$(curl -sS -o "$response_body" -w "%{http_code}" -X "$method" "$url" \
+  status="$(curl -sS --retry 5 --retry-all-errors --retry-delay 1 --retry-max-time 20 \
+    -o "$response_body" -w "%{http_code}" -X "$method" "$url" \
     -H "Authorization: Bearer $(cat "${ACCESS_TOKEN_PATH}")")"
 fi
 


### PR DESCRIPTION
## Description

Fix flakey fleet admin tests with curl retries.  Example flake: https://github.com/defenseunicorns/uds-core/actions/runs/29604647464/job/87965197605?pr=2785

The flake is most likely coming from ambient mesh connectivity readiness when we spin up the pod that runs this test.  Simple retries should resolve.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
