### PR TITLE
chore(ci): update uptime tests to include uds-portal

### DIFF
--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -119,6 +119,8 @@ tasks:
             npx playwright test \
             "
       - description: "Run E2E Tests"
+        env:
+          - EXCLUDED_PACKAGES=${EXCLUDED_PACKAGES}
         cmd: |
           npm ci
           # TODO: Remove this conditional exclude once Fleet admin realm updates are included in a released Core baseline.

--- a/test/vitest/uptime.spec.ts
+++ b/test/vitest/uptime.spec.ts
@@ -33,7 +33,6 @@ describe("Uptime Probes", { timeout: 210000 }, () => {
     "https://sso.uds.dev/realms/uds/.well-known/openid-configuration",
     "https://keycloak.admin.uds.dev/",
     "https://grafana.admin.uds.dev/healthz",
-    "https://portal.uds.dev/healthz",
     "https://ambient-protected.uds.dev/",
     "https://ambient2-protected.uds.dev/",
     "https://protected.uds.dev/",
@@ -46,6 +45,28 @@ describe("Uptime Probes", { timeout: 210000 }, () => {
     const result = await expectProbeSuccess(url);
     expect(result).toBe(1);
   });
+
+  // Certain packages may not be deployed every test
+  const conditionalBlackboxTargets = new Map<string, string>([
+    ["https://portal.uds.dev/healthz", "portal"],
+  ]);
+
+  const excludedPackages = new Set(
+    (process.env.EXCLUDED_PACKAGES ?? "")
+      .split(",")
+      .map(packageName => packageName.trim())
+      .filter(Boolean),
+  );
+
+  for (const [url, packageName] of conditionalBlackboxTargets) {
+    test.skipIf(excludedPackages.has(packageName))(
+      `probe_success metric should be 1 for ${url}`,
+      async () => {
+        const result = await expectProbeSuccess(url);
+        expect(result).toBe(1);
+      },
+    );
+  }
 });
 
 describe("Uptime Recording Rules", { timeout: 210000 }, () => {

--- a/test/vitest/uptime.spec.ts
+++ b/test/vitest/uptime.spec.ts
@@ -33,6 +33,7 @@ describe("Uptime Probes", { timeout: 210000 }, () => {
     "https://sso.uds.dev/realms/uds/.well-known/openid-configuration",
     "https://keycloak.admin.uds.dev/",
     "https://grafana.admin.uds.dev/healthz",
+    "https://portal.uds.dev/healthz",
     "https://ambient-protected.uds.dev/",
     "https://ambient2-protected.uds.dev/",
     "https://protected.uds.dev/",


### PR DESCRIPTION
## Description

Added portal healthz endpoint to blackbox targets for e2e uptime tests.

## Related Issue

Fixes CORE-646

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
