### PR TITLE
chore: publish latest tag

### DIFF
--- a/.github/workflows/checkpoint.yaml
+++ b/.github/workflows/checkpoint.yaml
@@ -109,3 +109,21 @@ jobs:
         uses: ./.github/actions/save-logs
         with:
           suffix: -${{ matrix.architecture }}
+
+  tag-checkpoint-latest:
+    needs: checkpoint
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Environment setup
+        uses: ./.github/actions/setup
+        with:
+          ghToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag Checkpoint Package as Latest
+        run: uds run -f tasks/publish.yaml checkpoint-latest --no-progress

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -45,6 +45,14 @@ tasks:
         cmd: |
           ./uds zarf package publish build/zarf-package-k3d-core-slim-dev-${UDS_ARCH}-${VERSION}.tar.zst oci://ghcr.io/defenseunicorns/dev/uds/checkpoints
 
+  - name: checkpoint-latest
+    description: "Tag the latest UDS checkpoint package"
+    actions:
+      - description: "Tag the multi-architecture checkpoint package as latest"
+        cmd: |
+          pkgPath="ghcr.io/defenseunicorns/dev/uds/checkpoints/k3d-core-slim-dev"
+          ./uds zarf tools registry copy ${pkgPath}:${VERSION} ${pkgPath}:latest
+
   - name: bundles
     description: "Publish UDS Bundles"
     actions:


### PR DESCRIPTION
## Description

Publish a `latest` tag for the `k3d-core-slim-dev` checkpoint package.

The tag is promoted only after both architecture-specific publish jobs complete, ensuring `latest` references the complete multi-architecture package.

Consumers can deploy it with:

```sh
uds zarf package deploy oci://ghcr.io/defenseunicorns/dev/uds/checkpoints/k3d-core-slim-dev:latest
```

## Related Issue

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `git diff --check`
- Prettier validation for `tasks/publish.yaml`
- Registry publication was not tested locally because the UDS CLI and registry credentials were unavailable.