### PR TITLE
fix: classification banner tests for iac

### DIFF
--- a/.github/bundles/aks/uds-bundle.yaml
+++ b/.github/bundles/aks/uds-bundle.yaml
@@ -27,6 +27,16 @@ packages:
       - envoy-gateway
       - envoy-default-gateway
     overrides:
+      istio-controlplane:
+        uds-global-istio-config:
+          values:
+            - path: classificationBanner.text
+              value: "SAMPLE BANNER"
+            - path: classificationBanner.enabledHosts
+              value:
+                - "sso.uds.dev"
+                - "portal.uds.dev"
+                - "grafana.admin.uds.dev"
       istio-admin-gateway:
         gateway:
           values:

--- a/.github/bundles/eks/uds-bundle.yaml
+++ b/.github/bundles/eks/uds-bundle.yaml
@@ -28,6 +28,16 @@ packages:
       - envoy-gateway
       - envoy-default-gateway
     overrides:
+      istio-controlplane:
+        uds-global-istio-config:
+          values:
+            - path: classificationBanner.text
+              value: "SAMPLE BANNER"
+            - path: classificationBanner.enabledHosts
+              value:
+                - "sso.uds.dev"
+                - "portal.uds.dev"
+                - "grafana.admin.uds.dev"
       envoy-gateway:
         uds-envoy-gateway-config:
           values:

--- a/.github/bundles/rke2/uds-bundle.yaml
+++ b/.github/bundles/rke2/uds-bundle.yaml
@@ -49,6 +49,16 @@ packages:
       - envoy-gateway
       - envoy-default-gateway
     overrides:
+      istio-controlplane:
+        uds-global-istio-config:
+          values:
+            - path: classificationBanner.text
+              value: "SAMPLE BANNER"
+            - path: classificationBanner.enabledHosts
+              value:
+                - "sso.uds.dev"
+                - "portal.uds.dev"
+                - "grafana.admin.uds.dev"
       envoy-gateway:
         uds-envoy-gateway-config:
           values:


### PR DESCRIPTION
## Description

The classification banner tests rely on the feature being turned on. This was turned on only for the demo bundles. Turning these on for our IAC bundles.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
