### PR TITLE
docs: add brew tap trust

### DIFF
--- a/docs/getting-started/local-demo/install-and-deploy-uds.mdx
+++ b/docs/getting-started/local-demo/install-and-deploy-uds.mdx
@@ -19,7 +19,7 @@ import { Steps } from '@astrojs/starlight/components';
 1. **Install via Homebrew**
 
    ```bash
-   brew tap defenseunicorns/tap && brew install uds
+   brew trust --formula defenseunicorns/tap/uds && brew tap defenseunicorns/tap && brew install uds
    ```
 
 2. **Verify the installation**


### PR DESCRIPTION
## Description

We recommend `brew` as an installation mechanism in our Getting Started guide. There was an update to `brew` in June (v6) that required a "trust" step for third-party taps. This PR adds that step.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-core/issues/2859

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Steps to Validate

Go through the documentated Getting Started guide as a new user. In particular

https://docs.defenseunicorns.com/core/getting-started/local-demo/install-and-deploy-uds/

The amendment to the documentation will now allow `uds` installation to complete.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
