### PR TITLE
fix(CORE-671): prevent checkpoint node IP restore race

### DIFF
--- a/packages/checkpoint-dev/README.md
+++ b/packages/checkpoint-dev/README.md
@@ -22,14 +22,3 @@ uds zarf package deploy <path-to-zarf-tarball> --confirm
 
 > [!NOTE]
 > The pre-reqs for this package are the same as `uds-k3d` and you do not need to have a cluster running prior to deploying it.
-
-> [!NOTE]
-> **OrbStack users**: If you experience intermittent networking issues, configure a fixed Docker subnet. Navigate to **Settings → Docker → Docker Engine** and add the following to the engine config:
-
-```json
-{
-  "default-address-pools": [
-    {"base": "172.18.0.0/16", "size": 24}
-  ]
-}
-```

--- a/packages/checkpoint-dev/checkpoint.sh
+++ b/packages/checkpoint-dev/checkpoint.sh
@@ -14,6 +14,21 @@ if [ -z "$CONTAINER_ID" ]; then
   exit 1
 fi
 
+# A checkpoint preserves the source node Docker IP, but Docker can assign the
+# restored node a new IP. Kubelet preserves cloud provider addresses already in
+# Node status, while the embedded K3s cloud controller can reuse the stale
+# k3s.io/internal-ip annotation. Remove both persisted values and add the
+# standard uninitialized taint so startup waits for the restored agent to
+# publish its current IP before the cloud controller updates Node status.
+echo "Clearing node status for ${K3S_CONTAINER} ..."
+docker exec "$CONTAINER_ID" kubectl patch node "$K3S_CONTAINER" \
+  --type=merge -p '{"metadata":{"annotations":{"k3s.io/internal-ip":null}}}' >/dev/null
+docker exec "$CONTAINER_ID" kubectl taint node "$K3S_CONTAINER" \
+  node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule --overwrite >/dev/null
+docker exec "$CONTAINER_ID" kubectl patch node "$K3S_CONTAINER" \
+  --subresource=status --type=merge \
+  -p "{\"status\":{\"addresses\":[{\"address\":\"${K3S_CONTAINER}\",\"type\":\"Hostname\"}]}}" >/dev/null
+
 # Pause once to get a consistent snapshot of image and volumes together.
 echo "Pausing container ${K3S_CONTAINER} ..."
 docker pause "$CONTAINER_ID"


### PR DESCRIPTION
## Description

Checkpoint packages persist the Kubernetes Node object from the source cluster. Docker may assign the recreated server a different address during restore. In the reproduced failure, Kubernetes still advertised `172.18.0.2`, while Docker and flannel configured `eth0` as `172.18.0.3`. K3s started its network policy controller with the stale address, could not find a matching interface, and restarted while k3d was injecting its CoreDNS records.

This change removes the persisted `k3s.io/internal-ip` annotation and InternalIP status before creating the checkpoint. It also applies the standard cloud provider initialization taint. On restore, K3s already waits for that taint to be removed, so kubelet and the embedded cloud controller publish the current Docker address before network policy startup.

## Related Issue

* CORE-671

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

Use the [full checkpoint verifier](https://gist.github.com/slaskawi/c9fbce4902fcb53f41a8815cfd2d59e6).

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
