### PR TITLE
chore: update public CA config

### DIFF
--- a/certs/public/uds-core-public-ca-trust-config.yaml
+++ b/certs/public/uds-core-public-ca-trust-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 include:
@@ -724,3 +724,23 @@ exclude:
     certificateIssuerOrganization: "Microsec Ltd."
     geographicFocus: "Hungary, Europe"
     companyWebsite: "https://e-szigno.hu/en/"
+  - commonName: "SECOM TLS RSA Root CA 2024"
+    owner: "SECOM Trust Systems Co., Ltd."
+    certificateIssuerOrganization: "SECOM Trust Systems Co., Ltd."
+    geographicFocus: "Japan"
+    companyWebsite: "http://www.secomtrust.net/"
+  - commonName: "SECOM TLS ECC Root CA 2024"
+    owner: "SECOM Trust Systems Co., Ltd."
+    certificateIssuerOrganization: "SECOM Trust Systems Co., Ltd."
+    geographicFocus: "Japan"
+    companyWebsite: "http://www.secomtrust.net/"
+  - commonName: "Telia EC TLS Root CA v3"
+    owner: "Telia Company"
+    certificateIssuerOrganization: "Telia Company AB"
+    geographicFocus: "Finland, Sweden, Norway, Denmark, Lithuania, Estonia"
+    companyWebsite: "https://www.teliacompany.com/"
+  - commonName: "Telia RSA TLS Root CA v3"
+    owner: "Telia Company"
+    certificateIssuerOrganization: "Telia Company AB"
+    geographicFocus: "Finland, Sweden, Norway, Denmark, Lithuania, Estonia"
+    companyWebsite: "https://www.teliacompany.com/"


### PR DESCRIPTION
## Description

Classifies four new Mozilla CA roots as excluded, consistent with the existing policy for regionally focused certificate authorities.

Fixes the certificate drift reported by https://github.com/defenseunicorns/uds-core/actions/runs/31987909643.

## Related Issue

N/A

## Type of change

* [ ] Bug fix, non breaking change which fixes an issue
* [ ] New feature, non breaking change which adds functionality
* [x] Other, security configuration update

## Steps to Validate

1. Run `uds run update-ca-certs`.
2. Run `uds run check-ca-certs` and confirm no differences are detected.
3. Run `npm --prefix scripts/root-ca-retriever test` and confirm all tests pass.

## Checklist before merging

* [x] Tests updated or run, documentation and ADR changes are not needed
* [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed