### PR TITLE
feat: allow setting pepr webhook annotations via zarf values

### DIFF
--- a/packages/base/zarf-values.schema.json
+++ b/packages/base/zarf-values.schema.json
@@ -1333,6 +1333,14 @@
                 "tolerations": {
                   "type": "array"
                 },
+                "webhookAnnotations": {
+                  "properties": {
+                    "admissions.enforcer/disabled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
                 "webhookLabels": {
                   "properties": {},
                   "type": "object"

--- a/packages/standard/zarf-values.schema.json
+++ b/packages/standard/zarf-values.schema.json
@@ -19957,6 +19957,14 @@
                 "tolerations": {
                   "type": "array"
                 },
+                "webhookAnnotations": {
+                  "properties": {
+                    "admissions.enforcer/disabled": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
                 "webhookLabels": {
                   "properties": {},
                   "type": "object"

--- a/src/pepr/zarf.yaml
+++ b/src/pepr/zarf.yaml
@@ -113,7 +113,6 @@ components:
             excludePaths:
               - .pepr-uds-core.module.watcher.serviceMonitor
               - .pepr-uds-core.module.admission.serviceMonitor
-              - .pepr-uds-core.module.admission.webhookAnnotations
               - .pepr-uds-core.module.admission.image
               - .pepr-uds-core.module.watcher.image
               - .pepr-uds-core.module.admission.securityContext


### PR DESCRIPTION
## Description

Allows setting pepr webhook annotations via zarf values. Previously this was excluded but there are use cases for setting this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
