### PR TITLE
feat: add additionalNetworkAllow for envoy gateway

### DIFF
--- a/docs/how-to-guides/networking/configure-core-network-access.mdx
+++ b/docs/how-to-guides/networking/configure-core-network-access.mdx
@@ -42,6 +42,7 @@ The following Core components support `additionalNetworkAllow`:
 | Prometheus Stack | `uds-prometheus-config` | External scrape targets |
 | Grafana | `uds-grafana-config` | External datasources (Thanos, additional Prometheus) |
 | Keycloak | `keycloak` | External IdP, OCSP endpoints |
+| Envoy Gateway | `uds-envoy-gateway-config` | Extensions (Envoy AI Gateway) |
 
 ## Steps
 

--- a/packages/base/zarf-values.schema.json
+++ b/packages/base/zarf-values.schema.json
@@ -361,6 +361,9 @@
         },
         "uds-envoy-gateway-config": {
           "properties": {
+            "additionalNetworkAllow": {
+              "type": "array"
+            },
             "envoyService": {
               "properties": {
                 "annotations": {

--- a/packages/standard/zarf-values.schema.json
+++ b/packages/standard/zarf-values.schema.json
@@ -439,6 +439,9 @@
         },
         "uds-envoy-gateway-config": {
           "properties": {
+            "additionalNetworkAllow": {
+              "type": "array"
+            },
             "envoyService": {
               "properties": {
                 "annotations": {

--- a/src/envoy-gateway/chart/templates/uds-package.yaml
+++ b/src/envoy-gateway/chart/templates/uds-package.yaml
@@ -48,3 +48,8 @@ spec:
           app: certgen
         remoteGenerated: KubeAPI
         description: "KubeAPI access for certgen pre-install job"
+
+      # Custom rules for additional networking access
+      {{- with .Values.additionalNetworkAllow }}
+      {{ toYaml . | nindent 6 }}
+      {{- end }}

--- a/src/envoy-gateway/chart/values.yaml
+++ b/src/envoy-gateway/chart/values.yaml
@@ -4,3 +4,6 @@
 # Annotations for the managed Gateway's LoadBalancer Service (e.g. AWS needs these for UDP)
 envoyService:
   annotations: {}
+
+# Support for custom `network.allow` entries on the Package CR.
+additionalNetworkAllow: []


### PR DESCRIPTION
## Description

Exposes `additionalNetworkAllow` for envoy-gateway, supporting use-cases like [Envoy AI Gateway](https://aigateway.envoyproxy.io/docs/).