### PR TITLE
fix(addlicense): skip husky files

### DIFF
--- a/.license_config.yaml
+++ b/.license_config.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+license: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+copyright: Defense Unicorns
+ignore:
+  - .husky/
+  - .husky/**


### PR DESCRIPTION
## Description

`uds run lint-check` fails due to `addlicense` getting tripped up on husky files. So this change ignores the husky files.

...

## Related Issue

CLI-683

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
