### PR TITLE
fix: checkpoint invalid reference on cold docker image load

### DIFF
--- a/packages/checkpoint-dev/zarf.yaml
+++ b/packages/checkpoint-dev/zarf.yaml
@@ -57,10 +57,10 @@ components:
               VOL_K3S="k3d-${ZARF_VAR_CLUSTER_NAME}-k3s"
               VOL_KUBELET="k3d-${ZARF_VAR_CLUSTER_NAME}-kubelet"
 
-              # Load the checkpoint image and capture its local ref so k3d uses
-              # the bundled image — not a remote pull of the same tag.
-              CHECKPOINT_IMAGE=$(tar -xOf uds-checkpoint.tar uds-k3d-checkpoint-latest.tar \
-                | docker load | awk '{print $NF}')
+              # Load the checkpoint image under its known tag (same as in checkpoint.sh) so
+              # k3d uses the bundled image instead of pulling it from a registry.
+              CHECKPOINT_IMAGE="ghcr.io/defenseunicorns/uds-core/checkpoint:latest"
+              tar -xOf uds-checkpoint.tar uds-k3d-checkpoint-latest.tar | docker load >/dev/null
               docker load < busybox.tar >/dev/null
 
               # Create named Docker volumes and inject the checkpoint data by


### PR DESCRIPTION
## Description

This fixes the checkpoint "invalid reference" error when loading on a cold docker daemon.

## Related Issue

Fixes #N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
