### PR TITLE
chore(deps): update keycloak to v26.7.2 (#2889) (backport-1.11)

### DIFF
--- a/src/keycloak/chart/Chart.yaml
+++ b/src/keycloak/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: keycloak
 # renovate: datasource=docker depName=quay.io/keycloak/keycloak versioning=semver
-version: 26.7.1
+version: 26.7.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -5,7 +5,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.7.1"
+  tag: "26.7.2"
   # The Keycloak image pull policy
   pullPolicy: IfNotPresent
 

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -13,7 +13,7 @@ components:
       - name: keycloak
         namespace: keycloak
         # renovate: datasource=docker depName=quay.io/keycloak/keycloak versioning=semver
-        version: 26.7.1
+        version: 26.7.2
         localPath: ../chart
         templatedValuesFiles:
           - ../values/values.yaml

--- a/src/keycloak/values/registry1-values.yaml
+++ b/src/keycloak/values/registry1-values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips
-  tag: "26.7.1-fips"
+  tag: "26.7.2-fips"
 podSecurityContext:
   fsGroup: 1000
 securityContext:

--- a/src/keycloak/values/unicorn-values.yaml
+++ b/src/keycloak/values/unicorn-values.yaml
@@ -12,7 +12,7 @@ securityContext:
       - ALL
 image:
   repository: cgr.dev/defenseunicorns.com/keycloak-fips
-  tag: "v26.7.1"
+  tag: "v26.7.2"
 
 migrations:
   deleteGeneratedTrustStore: true

--- a/src/keycloak/values/upstream-values.yaml
+++ b/src/keycloak/values/upstream-values.yaml
@@ -5,4 +5,4 @@ podSecurityContext:
   fsGroup: 1000
 image:
   repository: quay.io/keycloak/keycloak
-  tag: "26.7.1"
+  tag: "26.7.2"

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -35,7 +35,7 @@ components:
         valuesFiles:
           - "values/upstream-values.yaml"
     images:
-      - quay.io/keycloak/keycloak:26.7.1
+      - quay.io/keycloak/keycloak:26.7.2
       - ghcr.io/defenseunicorns/uds/identity-config:0.30.0
 
   - name: keycloak
@@ -49,7 +49,7 @@ components:
         valuesFiles:
           - "values/registry1-values.yaml"
     images:
-      - registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.7.1-fips
+      - registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.7.2-fips
       - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.30.0
 
   - name: keycloak
@@ -63,5 +63,5 @@ components:
         valuesFiles:
           - "values/unicorn-values.yaml"
     images:
-      - cgr.dev/defenseunicorns.com/keycloak-fips:v26.7.1
+      - cgr.dev/defenseunicorns.com/keycloak-fips:v26.7.2
       - ghcr.io/defenseunicorns/uds/identity-config:0.30.0


### PR DESCRIPTION
Backport of commit: 2d92357abd799418a184bcdcc1967227e7ae0968

BEGIN_COMMIT_OVERRIDE
chore(deps): update keycloak to v26.7.2 (#2889) (backport-1.11) (#2901)

Release-As: 1.11.1
END_COMMIT_OVERRIDE