### PR TITLE
chore(deps): update keycloak to v26.7.2 (#2889) (backport-1.10) (#2902)

### DIFF
--- a/src/keycloak/chart/Chart.yaml
+++ b/src/keycloak/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: keycloak
 # renovate: datasource=docker depName=quay.io/keycloak/keycloak versioning=semver
-version: 26.7.0
+version: 26.7.2
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:
   - sso

--- a/src/keycloak/chart/values.yaml
+++ b/src/keycloak/chart/values.yaml
@@ -5,7 +5,7 @@ image:
   # The Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # Overrides the Keycloak image tag whose default is the chart appVersion
-  tag: "26.7.0"
+  tag: "26.7.2"
   # The Keycloak image pull policy
   pullPolicy: IfNotPresent
 

--- a/src/keycloak/common/zarf.yaml
+++ b/src/keycloak/common/zarf.yaml
@@ -13,7 +13,7 @@ components:
       - name: keycloak
         namespace: keycloak
         # renovate: datasource=docker depName=quay.io/keycloak/keycloak versioning=semver
-        version: 26.7.0
+        version: 26.7.2
         localPath: ../chart
         templatedValuesFiles:
           - ../values/values.yaml

--- a/src/keycloak/values/registry1-values.yaml
+++ b/src/keycloak/values/registry1-values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips
-  tag: "26.7.0-fips"
+  tag: "26.7.2-fips"
 podSecurityContext:
   fsGroup: 1000
 securityContext:

--- a/src/keycloak/values/unicorn-values.yaml
+++ b/src/keycloak/values/unicorn-values.yaml
@@ -12,7 +12,7 @@ securityContext:
       - ALL
 image:
   repository: cgr.dev/defenseunicorns.com/keycloak-fips
-  tag: "v26.7.0"
+  tag: "v26.7.2"
 
 migrations:
   deleteGeneratedTrustStore: true

--- a/src/keycloak/values/upstream-values.yaml
+++ b/src/keycloak/values/upstream-values.yaml
@@ -5,4 +5,4 @@ podSecurityContext:
   fsGroup: 1000
 image:
   repository: quay.io/keycloak/keycloak
-  tag: "26.7.0"
+  tag: "26.7.2"

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -36,7 +36,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.7.2
-      - ghcr.io/defenseunicorns/uds/identity-config:0.30.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.29.0
 
   - name: keycloak
     required: true
@@ -50,7 +50,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.7.2-fips
-      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.30.0
+      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.29.0
 
   - name: keycloak
     required: true
@@ -64,4 +64,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - cgr.dev/defenseunicorns.com/keycloak-fips:v26.7.2
-      - ghcr.io/defenseunicorns/uds/identity-config:0.30.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.29.0

--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -35,8 +35,8 @@ components:
         valuesFiles:
           - "values/upstream-values.yaml"
     images:
-      - quay.io/keycloak/keycloak:26.7.0
-      - ghcr.io/defenseunicorns/uds/identity-config:0.29.0
+      - quay.io/keycloak/keycloak:26.7.2
+      - ghcr.io/defenseunicorns/uds/identity-config:0.30.0
 
   - name: keycloak
     required: true
@@ -49,8 +49,8 @@ components:
         valuesFiles:
           - "values/registry1-values.yaml"
     images:
-      - registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.7.0-fips
-      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.29.0
+      - registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.7.2-fips
+      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.30.0
 
   - name: keycloak
     required: true
@@ -63,5 +63,5 @@ components:
         valuesFiles:
           - "values/unicorn-values.yaml"
     images:
-      - cgr.dev/defenseunicorns.com/keycloak-fips:v26.7.0
-      - ghcr.io/defenseunicorns/uds/identity-config:0.29.0
+      - cgr.dev/defenseunicorns.com/keycloak-fips:v26.7.2
+      - ghcr.io/defenseunicorns/uds/identity-config:0.30.0


### PR DESCRIPTION
Backport of commit: 2d92357abd799418a184bcdcc1967227e7ae0968

## Description
This patch release updates Keycloak to `26.7.2`, which contains the fix for CVE-2026-18963.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
