### PR TITLE
fix: revert identity-config version bump

### DIFF
--- a/src/keycloak/zarf.yaml
+++ b/src/keycloak/zarf.yaml
@@ -36,7 +36,7 @@ components:
           - "values/upstream-values.yaml"
     images:
       - quay.io/keycloak/keycloak:26.7.2
-      - ghcr.io/defenseunicorns/uds/identity-config:0.30.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.29.0
 
   - name: keycloak
     required: true
@@ -50,7 +50,7 @@ components:
           - "values/registry1-values.yaml"
     images:
       - registry1.dso.mil/ironbank/opensource/keycloak/keycloak-fips:26.7.2-fips
-      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.30.0
+      - registry1.dso.mil/ironbank/opensource/defenseunicorns/uds/uds-identity-config:0.29.0
 
   - name: keycloak
     required: true
@@ -64,4 +64,4 @@ components:
           - "values/unicorn-values.yaml"
     images:
       - cgr.dev/defenseunicorns.com/keycloak-fips:v26.7.2
-      - ghcr.io/defenseunicorns/uds/identity-config:0.30.0
+      - ghcr.io/defenseunicorns/uds/identity-config:0.29.0


### PR DESCRIPTION
## Description
Didn't need to bump the identity config version, this PR reverts that change.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
