### PR TITLE
fix: deploy pepr before Istio in dev identity setup

### DIFF
--- a/packages/monitoring/zarf-values.schema.json
+++ b/packages/monitoring/zarf-values.schema.json
@@ -7751,6 +7751,15 @@
         }
       },
       "type": "object"
+    },
+    "prometheus-operator-crds": {
+      "properties": {
+        "prometheus-operator-crds": {
+          "properties": {},
+          "type": "object"
+        }
+      },
+      "type": "object"
     }
   },
   "type": "object"

--- a/src/prometheus-stack/zarf-values.yaml
+++ b/src/prometheus-stack/zarf-values.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 # Default Zarf values for the Prometheus-Stack package.
+prometheus-operator-crds:
+  prometheus-operator-crds: {}
 kube-prometheus-stack:
   kube-prometheus-stack: {}
   uds-prometheus-config: {}

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -27,6 +27,9 @@ tasks:
       istio_components:
         description: "Comma separated list of istio components to deploy"
         default: ""
+      deploy_pepr:
+        description: "Deploy Pepr before Istio"
+        default: "false"
     actions:
       - description: "Create the dev cluster"
         task: setup:create-k3d-cluster
@@ -36,11 +39,16 @@ tasks:
           ./uds zarf tools kubectl create ns uds-policy-exemptions
           ./uds zarf tools kubectl create ns istio-system
           ./uds zarf tools kubectl create ns pepr-system
+          ./uds zarf tools kubectl label ns pepr-system zarf.dev/agent=ignore --overwrite
 
       - description: "Deploy the UDS CRDs and apply all hack dev manifests"
         cmd: |
           ./uds zarf tools kubectl apply -f src/pepr/uds-cluster-crds/templates/
           ./uds zarf tools kubectl apply -f hack/dev-manifests/
+
+      - description: "Deploy Pepr"
+        if: ${{ eq .inputs.deploy_pepr "true" }}
+        cmd: "npx pepr deploy --yes"
 
       # Note: the `registry-url` flag used here requires uds 0.19.2+
       - description: "Deploy the Istio source package with Zarf Dev"
@@ -81,9 +89,8 @@ tasks:
     description: "Create k3d cluster with istio, Pepr, Keycloak, and Authservice for development"
     actions:
       - task: dev-setup
-
-      - description: "Deploy Pepr"
-        cmd: "npx pepr deploy --yes"
+        with:
+          deploy_pepr: "true"
 
       - description: "Deploy Keycloak + Authservice"
         cmd: "./uds run dev-deploy --set LAYER=identity-authorization --no-progress"


### PR DESCRIPTION
## Description

`uds run dev-identity` would fail during local development because `dev-setup` deploys Istio before Pepr. Istio's deployment checks wait for Pepr's ambient admission webhook to become ready, but Pepr has not been deployed yet.

The Prometheus source package also fails to deploy with newer Zarf versions because its component maps `.prometheus-operator-crds.prometheus-operator-crds`, but that mapping is missing from `src/prometheus-stack/zarf-values.yaml`.

This change:

- Adds an optional `deploy_pepr` input to `dev-setup`.
- Deploys Pepr before Istio when requested by `dev-identity`.
- Labels `pepr-system` with `zarf.dev/agent=ignore` so Zarf does not mutate the separately deployed Pepr resources.
- Adds the missing Prometheus Operator CRD values mapping.
- Preserves the existing `dev-setup` behavior by leaving Pepr deployment disabled by default.

## Related Issue

Relates to CORE-684

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- Run `uds run dev-identity --no-progress` and verify Pepr, Istio, Prometheus CRDs, Keycloak, and Authservice deploy successfully.
- Run `uds run dev-setup --dry-run --no-progress` and verify Pepr is not deployed by default.
- Run `uds run dev-identity --dry-run --no-progress` and verify Pepr is deployed before Istio.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed