### PR TITLE
fix: pin unicorn metrics server image

### DIFF
--- a/src/metrics-server/values/unicorn-values.yaml
+++ b/src/metrics-server/values/unicorn-values.yaml
@@ -3,4 +3,4 @@
 
 image:
   repository: cgr.dev/defenseunicorns.com/metrics-server-fips
-  tag: "v0.9.0"
+  tag: "0.8.1"

--- a/src/metrics-server/zarf.yaml
+++ b/src/metrics-server/zarf.yaml
@@ -49,4 +49,5 @@ components:
         valuesFiles:
           - "values/unicorn-values.yaml"
     images:
-      - cgr.dev/defenseunicorns.com/metrics-server-fips:v0.9.0
+      # v0.9.0 regressed Unicorn CI; pin the last CI-confirmed working image.
+      - cgr.dev/defenseunicorns.com/metrics-server-fips@sha256:b0626a33fa03d83098ed1fe3c4df38748d559772d50bc6e7973c41e2a2d52dd4


### PR DESCRIPTION
## Description

Pins the Unicorn Metrics Server Zarf image to the immutable multi-architecture digest for the last CI-confirmed working `0.8.1` image.

## Related Issue

Relates to #2930

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

- Run `uds zarf dev lint packages/metrics-server --flavor unicorn`.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed