### PR TITLE
fix: preserve namespace metadata during startup

### DIFF
--- a/src/pepr/operator/controllers/ca-bundles/ca-bundle.spec.ts
+++ b/src/pepr/operator/controllers/ca-bundles/ca-bundle.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2025-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -492,11 +492,13 @@ describe("CA Bundle ConfigMap", () => {
       });
     });
 
-    it("does not create the Istio namespace when the namespace lookup fails", async () => {
+    it("propagates Istio namespace lookup failures", async () => {
       const error = { status: 500, message: "server error" };
       mockNamespaceGet.mockRejectedValue(error);
 
-      await updateAllCaBundleConfigMaps();
+      await expect(updateAllCaBundleConfigMaps()).rejects.toThrow(
+        /Failed to update CA bundle ConfigMaps for all packages/,
+      );
 
       expect(mockK8sApply).not.toHaveBeenCalledWith({
         metadata: { name: "istio-system" },
@@ -679,7 +681,9 @@ describe("CA Bundle ConfigMap", () => {
         return Promise.resolve({});
       });
 
-      await updateAllCaBundleConfigMaps();
+      await expect(updateAllCaBundleConfigMaps()).rejects.toThrow(
+        /Failed to update CA bundle ConfigMaps for all packages/,
+      );
 
       expect(mockUDSPackageGet).toHaveBeenCalled();
       expect(mockK8sApply).toHaveBeenCalledTimes(4); // Namespace + 2 packages + Istio CM

--- a/src/pepr/operator/controllers/ca-bundles/ca-bundle.spec.ts
+++ b/src/pepr/operator/controllers/ca-bundles/ca-bundle.spec.ts
@@ -17,6 +17,7 @@ import {
 // Mock dependencies
 const mockK8sApply = vi.fn();
 const mockK8sGet = vi.fn();
+const mockNamespaceGet = vi.fn();
 const mockWithLabelGet = vi.fn();
 const mockK8sDelete = vi.fn();
 const mockUDSPackageGet = vi.fn();
@@ -64,6 +65,7 @@ vi.mock("pepr", async importOriginal => {
       } else if (resourceKind === actual.kind.Namespace) {
         return {
           Apply: mockK8sApply,
+          Get: mockNamespaceGet,
         };
       } else if (resourceKind === actual.kind.Secret) {
         // Handle Secret operations
@@ -159,6 +161,7 @@ describe("CA Bundle ConfigMap", () => {
     vi.mocked(getOwnerRef).mockReturnValue(mockOwnerRefs);
     vi.mocked(purgeOrphans).mockResolvedValue();
     mockK8sApply.mockResolvedValue({});
+    mockNamespaceGet.mockRejectedValue({ status: 404, message: "namespace not found" });
     mockUDSPackageGet.mockResolvedValue({ items: [] });
     mockLog.warn.mockClear();
 
@@ -476,6 +479,27 @@ describe("CA Bundle ConfigMap", () => {
     beforeEach(() => {
       mockUDSPackageGet.mockResolvedValue({
         items: mockPackages,
+      });
+    });
+
+    it("does not apply the Istio namespace when it already exists", async () => {
+      mockNamespaceGet.mockResolvedValue({ metadata: { name: "istio-system" } });
+
+      await updateAllCaBundleConfigMaps();
+
+      expect(mockK8sApply).not.toHaveBeenCalledWith({
+        metadata: { name: "istio-system" },
+      });
+    });
+
+    it("does not create the Istio namespace when the namespace lookup fails", async () => {
+      const error = { status: 500, message: "server error" };
+      mockNamespaceGet.mockRejectedValue(error);
+
+      await updateAllCaBundleConfigMaps();
+
+      expect(mockK8sApply).not.toHaveBeenCalledWith({
+        metadata: { name: "istio-system" },
       });
     });
 

--- a/src/pepr/operator/controllers/ca-bundles/ca-bundle.ts
+++ b/src/pepr/operator/controllers/ca-bundles/ca-bundle.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Defense Unicorns
+ * Copyright 2025-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 
@@ -235,9 +235,14 @@ export async function updateAllCaBundleConfigMaps(): Promise<void> {
     const results = await Promise.allSettled([...packageUpdates, updateIstioCAConfigMap()]);
 
     // Check for any failures
-    const failures = results.filter(r => r.status === "rejected");
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
     if (failures.length > 0) {
       log.warn(`Completed CA bundle updates with ${failures.length} failures`);
+      throw new Error(`CA bundle updates failed with ${failures.length} failures`, {
+        cause: failures.map(({ reason }) => reason),
+      });
     } else {
       log.debug("Completed CA bundle ConfigMap updates for all UDS packages");
     }

--- a/src/pepr/operator/controllers/ca-bundles/ca-bundle.ts
+++ b/src/pepr/operator/controllers/ca-bundles/ca-bundle.ts
@@ -115,9 +115,19 @@ export async function updateIstioCAConfigMap(): Promise<void> {
   if (process.env.PEPR_WATCH_MODE === "true" || process.env.PEPR_MODE === "dev") {
     try {
       // Ensure the namespace exists
-      await K8s(kind.Namespace).Apply({
-        metadata: { name: namespace },
-      });
+      try {
+        const existingNamespace = await K8s(kind.Namespace).Get(namespace);
+        log.debug(`Namespace ${existingNamespace.metadata?.name} exists, skipping creation`);
+      } catch (error) {
+        if (error?.status !== 404) {
+          throw error;
+        }
+
+        log.info(`Namespace ${namespace} does not exist, creating it`);
+        await K8s(kind.Namespace).Apply({
+          metadata: { name: namespace },
+        });
+      }
 
       // Build the combined CA bundle content
       const caBundleContent = buildCABundleContent();

--- a/src/pepr/operator/controllers/keycloak/authservice/config.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/config.spec.ts
@@ -95,6 +95,7 @@ vi.mock("pepr", () => ({
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
+      debug: vi.fn(),
       level: "info",
     })),
   },
@@ -106,6 +107,8 @@ vi.mock("pepr", () => ({
 }));
 
 describe("AuthService Config Tests", () => {
+  const namespaceGetMock = vi.fn();
+  const namespaceApplyMock = vi.fn();
   const applyMock = vi
     .fn<(s: kind.Secret) => Promise<kind.Secret>>()
     .mockImplementation((s: kind.Secret) =>
@@ -162,6 +165,11 @@ describe("AuthService Config Tests", () => {
           InNamespace: vi.fn().mockReturnThis(),
           Get: getMock,
         };
+      } else if (kindType === kind.Namespace) {
+        return {
+          Get: namespaceGetMock.mockResolvedValue({ metadata: { name: "authservice" } }),
+          Apply: namespaceApplyMock,
+        };
       } else {
         return {
           Apply: vi.fn(),
@@ -171,8 +179,56 @@ describe("AuthService Config Tests", () => {
 
     await setupAuthserviceSecret();
 
-    expect(applyMock).toHaveBeenCalledTimes(0); // Apply should be called once
+    expect(applyMock).toHaveBeenCalledTimes(0);
+    expect(namespaceApplyMock).not.toHaveBeenCalled();
+    expect(namespaceGetMock).toHaveBeenCalledWith("authservice");
     expect(getMock).toHaveBeenCalledTimes(1); // Get should be called once
+  });
+
+  it("setupAuthserviceSecret should create the namespace when it does not exist", async () => {
+    const getMock = vi.fn<() => Promise<kind.Secret>>().mockResolvedValue({
+      metadata: { name: "authservice-uds" },
+      data: {
+        "config.json": btoa(JSON.stringify(getConfig())),
+      },
+    });
+
+    namespaceGetMock.mockRejectedValue({ status: 404, message: "not found" });
+
+    (K8s as Mock).mockImplementation(kindType => {
+      if (kindType === kind.Secret) {
+        return {
+          Apply: applyMock,
+          InNamespace: vi.fn().mockReturnThis(),
+          Get: getMock,
+        };
+      } else if (kindType === kind.Namespace) {
+        return {
+          Get: namespaceGetMock,
+          Apply: namespaceApplyMock,
+        };
+      } else {
+        return {
+          Apply: vi.fn(),
+        };
+      }
+    });
+
+    await setupAuthserviceSecret();
+
+    expect(namespaceApplyMock).toHaveBeenCalledWith({
+      metadata: { name: "authservice" },
+    });
+    expect(applyMock).not.toHaveBeenCalled();
+  });
+
+  it("should not create the namespace when the namespace lookup fails", async () => {
+    const error = { status: 500, message: "server error" };
+    namespaceGetMock.mockRejectedValue(error);
+
+    await expect(setupAuthserviceSecret()).rejects.toEqual(error);
+
+    expect(namespaceApplyMock).not.toHaveBeenCalled();
   });
 
   it("updateAuthServiceSecret should debounce and update the Kubernetes secret", async () => {

--- a/src/pepr/operator/controllers/keycloak/authservice/config.ts
+++ b/src/pepr/operator/controllers/keycloak/authservice/config.ts
@@ -55,11 +55,21 @@ export async function setupAuthserviceSecret() {
 
     log.info("One-time authservice secret initialization");
     // Ensure the namespace exists in the Kubernetes cluster
-    await K8s(kind.Namespace).Apply({
-      metadata: {
-        name: operatorConfig.namespace,
-      },
-    });
+    try {
+      const namespace = await K8s(kind.Namespace).Get(operatorConfig.namespace);
+      log.debug(`Namespace ${namespace.metadata?.name} exists, skipping creation`);
+    } catch (error) {
+      if (error?.status !== 404) {
+        throw error;
+      }
+
+      log.info(`Namespace ${operatorConfig.namespace} does not exist, creating it`);
+      await K8s(kind.Namespace).Apply({
+        metadata: {
+          name: operatorConfig.namespace,
+        },
+      });
+    }
 
     // Create the secret if it doesn't exist
     try {

--- a/src/pepr/operator/controllers/keycloak/config.spec.ts
+++ b/src/pepr/operator/controllers/keycloak/config.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Defense Unicorns
+ * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+ */
+
+import { K8s, kind } from "pepr";
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import {
+  KEYCLOAK_CLIENTS_SECRET_NAME,
+  KEYCLOAK_CLIENTS_SECRET_NAMESPACE,
+} from "./client-secret-sync";
+import { setupKeycloakClientSecret } from "./config";
+
+const namespaceGetMock = vi.fn();
+const namespaceApplyMock = vi.fn();
+const secretGetMock = vi.fn();
+
+vi.mock("pepr", () => ({
+  K8s: vi.fn(),
+  kind: {
+    Namespace: "Namespace",
+    Secret: "Secret",
+  },
+  Log: {
+    child: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+describe("Keycloak config", () => {
+  beforeEach(() => {
+    process.env.PEPR_WATCH_MODE = "true";
+    namespaceGetMock.mockResolvedValue({ metadata: { name: KEYCLOAK_CLIENTS_SECRET_NAMESPACE } });
+    namespaceApplyMock.mockResolvedValue({});
+    secretGetMock.mockResolvedValue({ metadata: { name: KEYCLOAK_CLIENTS_SECRET_NAME } });
+
+    (K8s as Mock).mockImplementation(resourceKind => {
+      if (resourceKind === kind.Namespace) {
+        return {
+          Get: namespaceGetMock,
+          Apply: namespaceApplyMock,
+        };
+      }
+
+      return {
+        InNamespace: vi.fn().mockReturnValue({ Get: secretGetMock }),
+      };
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.PEPR_WATCH_MODE;
+    delete process.env.PEPR_MODE;
+    vi.clearAllMocks();
+  });
+
+  it("does not apply an existing Keycloak namespace", async () => {
+    await setupKeycloakClientSecret();
+
+    expect(namespaceGetMock).toHaveBeenCalledWith(KEYCLOAK_CLIENTS_SECRET_NAMESPACE);
+    expect(namespaceApplyMock).not.toHaveBeenCalled();
+  });
+
+  it("creates the Keycloak namespace when it does not exist", async () => {
+    namespaceGetMock.mockRejectedValue({ status: 404, message: "not found" });
+
+    await setupKeycloakClientSecret();
+
+    expect(namespaceApplyMock).toHaveBeenCalledWith({
+      metadata: { name: KEYCLOAK_CLIENTS_SECRET_NAMESPACE },
+    });
+  });
+
+  it("does not create the Keycloak namespace when the namespace lookup fails", async () => {
+    const error = { status: 500, message: "server error" };
+    namespaceGetMock.mockRejectedValue(error);
+
+    await expect(setupKeycloakClientSecret()).rejects.toEqual(error);
+
+    expect(namespaceApplyMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/pepr/operator/controllers/keycloak/config.ts
+++ b/src/pepr/operator/controllers/keycloak/config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Defense Unicorns
+ * Copyright 2024-2026 Defense Unicorns
  * SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
  */
 

--- a/src/pepr/operator/controllers/keycloak/config.ts
+++ b/src/pepr/operator/controllers/keycloak/config.ts
@@ -16,11 +16,21 @@ export const log = setupLogger(Component.OPERATOR_KEYCLOAK);
 export async function setupKeycloakClientSecret() {
   if (process.env.PEPR_WATCH_MODE === "true" || process.env.PEPR_MODE === "dev") {
     // Ensure the namespace exists in the Kubernetes cluster
-    await K8s(kind.Namespace).Apply({
-      metadata: {
-        name: KEYCLOAK_CLIENTS_SECRET_NAMESPACE,
-      },
-    });
+    try {
+      const namespace = await K8s(kind.Namespace).Get(KEYCLOAK_CLIENTS_SECRET_NAMESPACE);
+      log.debug(`Namespace ${namespace.metadata?.name} exists, skipping creation`);
+    } catch (error) {
+      if (error?.status !== 404) {
+        throw error;
+      }
+
+      log.info(`Namespace ${KEYCLOAK_CLIENTS_SECRET_NAMESPACE} does not exist, creating it`);
+      await K8s(kind.Namespace).Apply({
+        metadata: {
+          name: KEYCLOAK_CLIENTS_SECRET_NAMESPACE,
+        },
+      });
+    }
 
     // Create the secret if it doesn't exist
     try {

--- a/src/pepr/operator/controllers/uptime/config.spec.ts
+++ b/src/pepr/operator/controllers/uptime/config.spec.ts
@@ -236,7 +236,7 @@ describe("setupUptimeConfig", () => {
 
   it("creates the namespace when it does not exist", async () => {
     process.env.PEPR_WATCH_MODE = "true";
-    namespaceClient.Get.mockRejectedValue(new Error("not found"));
+    namespaceClient.Get.mockRejectedValue({ status: 404, message: "not found" });
     secretClient.Get.mockResolvedValue(makeBlackboxSecret(BLACKBOX_BASE_CONFIG));
 
     await setupUptimeConfig();
@@ -244,6 +244,16 @@ describe("setupUptimeConfig", () => {
     expect(namespaceClient.Apply).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: { name: BLACKBOX_CONFIG_NAMESPACE } }),
     );
+  });
+
+  it("does not create the namespace when the namespace lookup fails", async () => {
+    process.env.PEPR_WATCH_MODE = "true";
+    const error = { status: 500, message: "server error" };
+    namespaceClient.Get.mockRejectedValue(error);
+
+    await expect(setupUptimeConfig()).rejects.toEqual(error);
+
+    expect(namespaceClient.Apply).not.toHaveBeenCalled();
   });
 
   it("skips secret creation when it already exists", async () => {

--- a/src/pepr/operator/controllers/uptime/config.ts
+++ b/src/pepr/operator/controllers/uptime/config.ts
@@ -121,9 +121,14 @@ export async function setupUptimeConfig() {
 
     // Ensure the namespace exists in the Kubernetes cluster
     try {
-      await K8s(kind.Namespace).Get(BLACKBOX_CONFIG_NAMESPACE);
-      log.debug(`Namespace ${BLACKBOX_CONFIG_NAMESPACE} exists, skipping creation`);
-    } catch {
+      const namespace = await K8s(kind.Namespace).Get(BLACKBOX_CONFIG_NAMESPACE);
+      log.debug(`Namespace ${namespace.metadata?.name} exists, skipping creation`);
+    } catch (error) {
+      if (error?.status !== 404) {
+        throw error;
+      }
+
+      log.info(`Namespace ${BLACKBOX_CONFIG_NAMESPACE} does not exist, creating it`);
       await K8s(kind.Namespace).Apply({
         metadata: {
           name: BLACKBOX_CONFIG_NAMESPACE,


### PR DESCRIPTION
## Description

  Updates namespace initialization to use a read-before-create flow. Existing namespaces are no longer subjected to sparse server-side applies that could remove metadata managed by Pepr, Istio, or other controllers.

  The change covers Keycloak, Authservice, CA bundle, and Uptime initialization paths:

  - Read the namespace first.
  - Create it only when the lookup returns `404`.
  - Propagate all other lookup errors.
  - Skip applying to existing namespaces.

  Added and updated tests verify existing namespaces, missing namespaces, and non-`404` errors.

  ## Related Issue

  Relates to INFRA-144

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Other (security config, docs update, etc)

  ## Steps to Validate
  ```bash
    npx --no-install vitest run \
    src/pepr/operator/controllers/keycloak/config.spec.ts \
    src/pepr/operator/controllers/keycloak/authservice/config.spec.ts \
    src/pepr/operator/controllers/ca-bundles/ca-bundle.spec.ts \
    src/pepr/operator/controllers/uptime/config.spec.ts
  ```

  ## Checklist before merging

  - [x] Test, docs, adr added or updated as needed
  - [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed