### PR TITLE
fix(istio): refresh Pepr admission after Ambient enrollment

### DIFF
--- a/src/istio/common/zarf.yaml
+++ b/src/istio/common/zarf.yaml
@@ -149,6 +149,17 @@ components:
                 namespace: pepr-system
                 condition: '{.metadata.annotations.ambient\.istio\.io/redirection}=enabled'
 
+          # Ambient enrollment rewrites networking for the existing Pepr Pods. Roll them
+          # after enrollment so kube-apiserver connects to Pods born into the final data path.
+          - description: "Restart Pepr admission after Ambient enrollment"
+            maxTotalSeconds: 180
+            cmd: |
+              previous_pods="$(./zarf tools kubectl get pods -n pepr-system -l 'app=pepr-uds-core,pepr.dev/controller=admission' --field-selector='status.phase!=Succeeded,status.phase!=Failed' -o name)"
+              ./zarf tools kubectl rollout restart deployment/pepr-uds-core -n pepr-system
+              ./zarf tools kubectl rollout status deployment/pepr-uds-core -n pepr-system --timeout=90s
+              # Wait for the pre-rollout Pods to disappear so their connections are closed before the admission probe.
+              ./zarf tools kubectl wait --for=delete --timeout=60s -n pepr-system $previous_pods
+
           - description: "Verify Pepr admission readiness"
             maxTotalSeconds: 30
             maxRetries: 10


### PR DESCRIPTION
## Description

Istio Ambient enrollment changes the network path of already-running Pods. The existing `ambient.istio.io/redirection=enabled` gate proves that Istio completed enrollment, but it does not prove that kube-apiserver's already-pooled Pepr webhook connections are still usable.

In a three-control-plane k3d cluster, each local API server could call Pepr before enrollment. Immediately after enrollment, two API servers returned `EOF` while both Pepr admission Pods still had the same UIDs and reported `Running`, `Ready=true`, and `ambient.istio.io/redirection=enabled`. In one run, the package's existing admission probe independently failed with `use of closed network connection` before its retained retry recovered.

This change adds a bounded reconciliation step after Ambient enrollment:

- Snapshot active Pepr admission Pods, excluding terminal Pods.
- Rolling-restart only the Pepr admission Deployment.
- Wait for the rollout and for every pre-rollout Pod to be deleted.
- Keep the existing end-to-end admission probe and its retry behavior unchanged.

Istio documents that enrolling an already-running Pod causes `istio-cni` to enter its network namespace and establish new traffic-redirection rules: https://istio.io/latest/docs/ambient/architecture/traffic-redirection/. The stale pooled-connection explanation is an inference from the per-API-server behavior; the failure and the effect of replacing the enrolled Pods were measured directly.

## Related Issue

Follow-up to #2871 (CORE-660) and #2040, which addressed the same intermittent Pepr/Ambient timing and `EOF` symptom.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate

### Environment

- A: current `main` at `acc87064`
- B: this change at `9b1d631e`
- Darwin arm64, UDS CLI v0.34.1, k3d v5.9.0
- `uds-k3d-dev` 0.20.2-airgap / k3s v1.35.6-k3s1
- UDS Core Base 1.12.0 upstream / Istio 1.30.3 / Pepr controller 2.0.0
- Three k3s servers and one agent
- Bundle retries disabled with `--retries 0`; the existing action-level `maxRetries: 10` was intentionally retained

Both revisions were built from clean worktrees with:

```bash
uds run -f tasks/create.yaml single-layer --no-progress \
  --with layer=base \
  --with shim_bundle=false \
  --with create_options=--skip-sbom
```

For each clean install, the harness waited for Istiod to be created but before Pepr was Ambient-enrolled, then sent one server-side dry-run admission request through each k3s server's local API endpoint (`https://127.0.0.1:6443`). It left those connections idle during enrollment and sent ten more requests through each local API server immediately after enrollment (or, for B, after the old Pods had been deleted).

| Revision and run | Before enrollment | After enrollment / rollout | Package admission gate |
| --- | ---: | ---: | --- |
| A / clean run 1 | 3/3 passed | 27/30 passed; 3 `EOF` failures on servers 1 and 2; same Pod UIDs | Failed once with `use of closed network connection`, then retry passed |
| A / clean run 2 | 3/3 passed | 26/30 passed; 4 `EOF` failures on servers 1 and 2; same Pod UIDs | Passed |
| B / clean run 1 | 3/3 passed | 30/30 passed; pre-rollout UIDs gone | Passed on first attempt |
| B / clean run 2 | 3/3 passed | 30/30 passed; pre-rollout UIDs gone | Passed on first attempt |
| B / same-version, same-values redeploy | N/A | 30/30 passed across all three API servers; pre-rollout UIDs gone | Passed on first attempt |

Aggregate post-transition result: **A failed 7/60 admission requests; B failed 0/90.** All deployments completed successfully, demonstrating that the existing retry can hide the baseline race.

<details>
<summary>Representative raw A/B evidence</summary>

Baseline run 1 retained the same Pod identities across enrollment:

```text
before: c8c9ad42... Running Ready=true ambient=<none>
        d567c5fa... Running Ready=true ambient=<none>
after:  c8c9ad42... Running Ready=true ambient=enabled
        d567c5fa... Running Ready=true ambient=enabled

server-1: failed calling webhook "pepr-uds-core.pepr.dev": EOF
server-2: failed calling webhook "pepr-uds-core.pepr.dev": EOF
package probe: failed calling webhook "pepr-uds-core.pepr.dev": use of closed network connection
```

Patched run 1 replaced both enrolled Pods before probing:

```text
before: 82f14d9e... Running Ready=true ambient=<none>
        9a2cca1f... Running Ready=true ambient=<none>
after:  396d6834... Running Ready=true ambient=enabled
        0dce77d0... Running Ready=true ambient=enabled

30/30 post-rollout requests passed; no EOF or closed-network errors occurred.
```

</details>

Additional validation:

- `git diff HEAD^ --check`
- `uds zarf dev lint packages/base --flavor upstream --no-progress`
- `uds zarf dev lint packages/base --flavor registry1 --no-progress`
- `uds zarf dev lint packages/base --flavor unicorn --no-progress`
- Built the upstream `core-base` package successfully
- Two clean HA deployments of A and two clean HA deployments of B
- Two B package redeployments; the final run used identical version and values

## Checklist before merging

- [x] Test, docs, adr added or updated as needed (live A/B and upgrade validation; no user-facing behavior or configuration changed)
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
