### PR TITLE
chore(docs): update stale links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unified Defense Stack - Core (UDS Core)
 
 [![Latest Release](https://img.shields.io/github/v/release/defenseunicorns/uds-core)](https://github.com/defenseunicorns/uds-core/releases)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/defenseunicorns/uds-core/tag-and-release.yaml)](https://github.com/defenseunicorns/uds-core/tag-and-release.yaml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/defenseunicorns/uds-core/tag-and-release.yaml)](https://github.com/defenseunicorns/uds-core/actions/workflows/tag-and-release.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-core/badge)](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-core)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10959/badge)](https://www.bestpractices.dev/projects/10959)
 

--- a/src/pepr/policies/README.md
+++ b/src/pepr/policies/README.md
@@ -1,2 +1,2 @@
 ### Pepr Policies
-See [pepr-policies.md](../../../docs/reference/configuration/pepr-policies.md) for current Pepr Policies
+See the [UDS Policies reference](https://docs.defenseunicorns.com/core/reference/operator--crds/policy-engine/) for current UDS Core policies.


### PR DESCRIPTION
 ## Description

  Update stale documentation links after the UDS Core documentation site migration.

  - Replace the deleted local Pepr policy document link with the current UDS Policies reference.
  - Fix the Build Status badge link to point to the GitHub Actions workflow.

  ## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature
  - [x] Other (security config, docs update, etc)


  ## Checklist before merging

  - [x] Test, docs, adr added or updated as needed
  - [ ] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed