### PR TITLE
chore: bump tested kubernetes version to 1.36

### DIFF
--- a/.github/test-infra/aws/eks/variables.tf
+++ b/.github/test-infra/aws/eks/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 variable "region" {
@@ -82,7 +82,7 @@ variable "databases" {
 variable "kubernetes_version" {
   description = "Kubernetes version to use for the EKS cluster"
   type        = string
-  default     = "1.35"
+  default     = "1.36"
 }
 
 variable "vpc_name" {

--- a/.github/test-infra/aws/rke2/terraform.tfvars
+++ b/.github/test-infra/aws/rke2/terraform.tfvars
@@ -4,4 +4,4 @@ os_distro    = "rhel"
 # Need to allow in from internet for github runner to connect to node
 allowed_in_cidrs = ["0.0.0.0/0"]
 
-rke2_version = "1.35"
+rke2_version = "1.36"

--- a/.github/test-infra/azure/aks/variables.tf
+++ b/.github/test-infra/azure/aks/variables.tf
@@ -67,7 +67,7 @@ variable "sku_tier" {
 
 variable "kubernetes_version" {
   description = "Specifies the AKS Kubernetes version"
-  default     = "1.35"
+  default     = "1.36"
   type        = string
 }
 

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -13,7 +13,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.20.2-airgap
+    ref: 0.20.3-aigrap
     overrides:
       uds-dev-stack:
         minio:

--- a/bundles/k3d-slim-dev/uds-bundle.yaml
+++ b/bundles/k3d-slim-dev/uds-bundle.yaml
@@ -13,7 +13,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.20.3-aigrap
+    ref: 0.20.3-airgap
     overrides:
       uds-dev-stack:
         minio:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.20.2-airgap
+    ref: 0.20.3-aigrap
     overrides:
       uds-dev-stack:
         minio:

--- a/bundles/k3d-standard/uds-bundle.yaml
+++ b/bundles/k3d-standard/uds-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
 packages:
   - name: uds-k3d-dev
     repository: ghcr.io/defenseunicorns/packages/uds-k3d
-    ref: 0.20.3-aigrap
+    ref: 0.20.3-airgap
     overrides:
       uds-dev-stack:
         minio:

--- a/docs/concepts/platform/supported-distributions.mdx
+++ b/docs/concepts/platform/supported-distributions.mdx
@@ -8,14 +8,14 @@ sidebar:
 UDS Core runs on any [CNCF-conformant Kubernetes distribution](https://www.cncf.io/training/certification/software-conformance/) that has not reached [End-of-Life](https://kubernetes.io/releases/#release-history). The following are actively tested in CI:
 
 > [!NOTE]
-> UDS Core currently tests against **Kubernetes 1.35** across all distributions. The target is typically **n-1** (one minor version behind the latest release, latest patch). This version may lag slightly behind new Kubernetes releases.
+> UDS Core currently tests against **Kubernetes 1.36** across all distributions. The target is typically **n-1** (one minor version behind the latest release, latest patch). This version may lag slightly behind new Kubernetes releases.
 
 | Distribution | K8s Version | Status | Testing Schedule |
 |-------------|-------------|--------|-----------------|
-| [K3s](https://k3s.io/) / [k3d](https://k3d.io/) | **1.35** | [![K3d HA Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-k3d-ha.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-k3d-ha.yaml?query=event%3Aschedule+branch%3Amain) | Nightly and before each release |
-| [Amazon EKS](https://aws.amazon.com/eks/) | **1.35** | [![EKS Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-eks.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-eks.yaml?query=event%3Aschedule+branch%3Amain) | Weekly and before each release |
-| [Azure AKS](https://azure.microsoft.com/en-us/products/kubernetes-service) | **1.35** | [![AKS Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-aks.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-aks.yaml?query=event%3Aschedule+branch%3Amain) | Weekly and before each release |
-| [RKE2](https://github.com/rancher/rke2) (on AWS) | **1.35** | [![RKE2 Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-rke2.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-rke2.yaml?query=event%3Aschedule+branch%3Amain) | Weekly and before each release |
+| [K3s](https://k3s.io/) / [k3d](https://k3d.io/) | **1.36** | [![K3d HA Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-k3d-ha.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-k3d-ha.yaml?query=event%3Aschedule+branch%3Amain) | Nightly and before each release |
+| [Amazon EKS](https://aws.amazon.com/eks/) | **1.36** | [![EKS Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-eks.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-eks.yaml?query=event%3Aschedule+branch%3Amain) | Weekly and before each release |
+| [Azure AKS](https://azure.microsoft.com/en-us/products/kubernetes-service) | **1.36** | [![AKS Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-aks.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-aks.yaml?query=event%3Aschedule+branch%3Amain) | Weekly and before each release |
+| [RKE2](https://github.com/rancher/rke2) (on AWS) | **1.36** | [![RKE2 Test](https://github.com/defenseunicorns/uds-core/actions/workflows/test-rke2.yaml/badge.svg?branch=main&event=schedule)](https://github.com/defenseunicorns/uds-core/actions/workflows/test-rke2.yaml?query=event%3Aschedule+branch%3Amain) | Weekly and before each release |
 
 > [!NOTE]
 > Unlisted CNCF-conformant distributions are expected to work but are not validated in CI. Bug reports and contributions for compatibility issues are welcome.

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -6,7 +6,7 @@ tasks:
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/uds-k3d versioning=docker
-        cmd: "./uds zarf package deploy oci://defenseunicorns/uds-k3d:0.20.3-aigrap --confirm"
+        cmd: "./uds zarf package deploy oci://defenseunicorns/uds-k3d:0.20.3-airgap --confirm"
 
   - name: k3d-test-cluster
     actions:

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -6,7 +6,7 @@ tasks:
     actions:
       - description: "Create the K3d cluster"
         # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/uds-k3d versioning=docker
-        cmd: "./uds zarf package deploy oci://defenseunicorns/uds-k3d:0.20.2-airgap --confirm"
+        cmd: "./uds zarf package deploy oci://defenseunicorns/uds-k3d:0.20.3-aigrap --confirm"
 
   - name: k3d-test-cluster
     actions:


### PR DESCRIPTION
## Description

Bumps the tested version and k3d version of kubernetes to 1.36.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Steps to Validate
- If this PR introduces new functionality to UDS Core or addresses a bug, please document the steps to test the changes.

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide](https://github.com/defenseunicorns/uds-core/blob/main/CONTRIBUTING.md) followed
